### PR TITLE
fix: Ensure Quarto extension installation only works within a workspace

### DIFF
--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -9,6 +9,12 @@ interface ExtensionQuickPickItem extends vscode.QuickPickItem {
 
 export async function installQuartoExtensionCommand(context: vscode.ExtensionContext, log: vscode.OutputChannel, recentlyInstalledExtensions: string) {
 	const extensionsListCsv = "https://raw.githubusercontent.com/mcanouil/quarto-extensions/main/extensions/quarto-extensions.csv";
+	if (!vscode.workspace.workspaceFolders) {
+		const message = "Please open a workspace/folder to install Quarto extensions.";
+		log.appendLine(message);
+		vscode.window.showErrorMessage(message);
+		return;
+	}
 
 	const isConnected = await checkInternetConnection();
 	if (!isConnected) {


### PR DESCRIPTION
The extension now checks for an open workspace before allowing the installation of Quarto extensions. If no workspace is detected, an error message prompts the user to open a workspace. Fixes #1