### PR TITLE
feat: add command for new reproducible Quarto documents

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 .vscode-test
 node_modules
 out/test
+out/debug
 out/**/*.map
 src
 .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- feat: add command `Quarto Wizard: New Reproducible Document` to create a new Quarto document.
+
 ## 0.2.1
 
 - docs: update README.md with updated usage instructions.

--- a/assets/templates/julia.qmd
+++ b/assets/templates/julia.qmd
@@ -1,0 +1,25 @@
+---
+title: "Reproducible Quarto Document"
+format: html
+engine: julia
+---
+
+```{julia}
+#| include: false
+using Pkg
+Pkg.add("Plots")
+```
+
+This is a reproducible Quarto document.
+
+
+```{julia}
+using Plots
+plot(sin, x -> sin(2x), 0, 2)
+```
+
+![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+{{< lipsum 1 >}}
+
+The end after @fig-placeholder.

--- a/assets/templates/python.qmd
+++ b/assets/templates/python.qmd
@@ -1,0 +1,23 @@
+---
+title: "Reproducible Quarto Document"
+format: html
+engine: jupyter
+---
+
+This is a reproducible Quarto document.
+
+```{python}
+import matplotlib.pyplot as plt
+
+x = [1, 2, 3, 4, 5]
+y = [1, 4, 9, 16, 25]
+
+plt.plot(x, y)
+plt.show()
+```
+
+![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+{{< lipsum 1 >}}
+
+The end after @fig-placeholder.

--- a/assets/templates/r.qmd
+++ b/assets/templates/r.qmd
@@ -1,0 +1,20 @@
+---
+title: "Reproducible Quarto Document"
+format: html
+engine: knitr
+---
+
+This is a reproducible Quarto document.
+
+```{r}
+x <- c(1, 2, 3, 4, 5)
+y <- c(1, 4, 9, 16, 25)
+
+plot(x, y)
+```
+
+![An image]({{< placeholder 600 400 >}}){#fig-placeholder}
+
+{{< lipsum 1 >}}
+
+The end after @fig-placeholder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quarto-wizard",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quarto-wizard",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.8.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quarto-wizard",
   "displayName": "Quarto Wizard",
   "description": "A Visual Studio Code extension that helps you manage Quarto projects.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "publisher": "mcanouil",
   "author": {
     "name": "Mickaël CANOUIL"
@@ -58,6 +58,10 @@
       {
         "command": "quartoWizard.clearRecentlyInstalled",
         "title": "Quarto Wizard: Clear Recently Installed Extensions"
+      },
+      {
+        "command": "quartoWizard.newQuartoReprex",
+        "title": "Quarto Wizard: New Reproducible Document"
       }
     ]
   },

--- a/src/commands/newQuartoReprex.ts
+++ b/src/commands/newQuartoReprex.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+import { newQuartoReprex } from "../utils/reprex";
+
+export async function newQuartoReprexCommand(context: vscode.ExtensionContext, log: vscode.OutputChannel) {
+	const languages = ["R", "Python", "Julia"];
+	const selectedLanguage = await vscode.window.showQuickPick(languages, {
+		placeHolder: "Select the computing language",
+	});
+
+	if (selectedLanguage) {
+		newQuartoReprex(selectedLanguage, context, log);
+	} else {
+		const message = "No computing language selected. Aborting.";
+		log.appendLine(message);
+		vscode.window.showErrorMessage(message);
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { installQuartoExtensionCommand } from "./commands/installQuartoExtension";
+import { newQuartoReprexCommand } from "./commands/newQuartoReprex";
 
 const RECENTLY_INSTALLED_QUARTO_EXTENSIONS = "recentlyInstalledExtensions";
 const QUARTO_WIZARD_LOG = vscode.window.createOutputChannel("Quarto Wizard");
@@ -22,6 +23,11 @@ export function activate(context: vscode.ExtensionContext) {
 		installQuartoExtensionCommand(context, QUARTO_WIZARD_LOG, RECENTLY_INSTALLED_QUARTO_EXTENSIONS)
 	);
 	context.subscriptions.push(installExtensionDisposable);
+
+	let newQuartoReprexDisposable = vscode.commands.registerCommand("quartoWizard.newQuartoReprex", () =>
+		newQuartoReprexCommand(context, QUARTO_WIZARD_LOG)
+	);
+	context.subscriptions.push(newQuartoReprexDisposable);
 }
 
 export function deactivate() {}

--- a/src/utils/reprex.ts
+++ b/src/utils/reprex.ts
@@ -31,7 +31,7 @@ export async function newQuartoReprex(language: string, context: vscode.Extensio
 			return;
 		}
 
-		const newFile = vscode.Uri.parse("untitled:" + path.join(vscode.workspace.rootPath || "", "Untitled.qmd"));
+		const newFile = vscode.Uri.parse("untitled:" + path.join((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.fsPath) || "", "Untitled.qmd"));
 		vscode.workspace.openTextDocument(newFile).then((document) => {
 			const edit = new vscode.WorkspaceEdit();
 			edit.insert(newFile, new vscode.Position(0, 0), data);

--- a/src/utils/reprex.ts
+++ b/src/utils/reprex.ts
@@ -1,0 +1,49 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+
+export async function newQuartoReprex(language: string, context: vscode.ExtensionContext, log: vscode.OutputChannel) {
+	let templateFile = "";
+
+	switch (language) {
+		case "R":
+			templateFile = "r.qmd";
+			break;
+		case "Julia":
+			templateFile = "julia.qmd";
+			break;
+		case "Python":
+			templateFile = "python.qmd";
+			break;
+		default:
+			const message = `Unsupported language: ${language}`;
+			log.appendLine(message);
+			vscode.window.showErrorMessage(message);
+			return;
+	}
+
+	const filePath = path.join(context.extensionPath, "assets", "templates", templateFile);
+	fs.readFile(filePath, "utf8", (err, data) => {
+		if (err) {
+			const message = `Failed to read the template file: ${err.message}`;
+			log.appendLine(message);
+			vscode.window.showErrorMessage(message);
+			return;
+		}
+
+		const newFile = vscode.Uri.parse("untitled:" + path.join(vscode.workspace.rootPath || "", "Untitled.qmd"));
+		vscode.workspace.openTextDocument(newFile).then((document) => {
+			const edit = new vscode.WorkspaceEdit();
+			edit.insert(newFile, new vscode.Position(0, 0), data);
+			return vscode.workspace.applyEdit(edit).then((success) => {
+				if (success) {
+					vscode.window.showTextDocument(document);
+				} else {
+					const message = "Failed to open the new file!";
+					log.appendLine(message);
+					vscode.window.showErrorMessage(message);
+				}
+			});
+		});
+	});
+}


### PR DESCRIPTION
Introduce a new command to create reproducible Quarto documents with templates for R, Python, and Julia. Update versioning and changelog accordingly.