### PR TITLE
refactor: command titles to use category instead of hardcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Development (unreleased)
 
 - feat: add command `Quarto Wizard: New Reproducible Document` to create a new Quarto document in "new File" menu.
+- refactor: use "category" instead of hardcoding `Quarto Wizard: ` in the command title.
 
 ## 0.4.1 (2025-01-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Development (unreleased)
 
 - feat: add command `Quarto Wizard: New Reproducible Document` to create a new Quarto document in "new File" menu.
-- refactor: use "category" instead of hardcoding `Quarto Wizard: ` in the command title.
+- refactor: use "category" instead of hardcoding `Quarto Wizard:` in the command title.
 
 ## 0.4.1 (2025-01-04)
 

--- a/package.json
+++ b/package.json
@@ -49,19 +49,23 @@
     "commands": [
       {
         "command": "quartoWizard.installExtension",
-        "title": "Quarto Wizard: Install Extension(s)"
+        "title": "Install Extension(s)",
+        "category": "Quarto Wizard"
       },
       {
         "command": "quartoWizard.showOutput",
-        "title": "Quarto Wizard: Show Quarto Wizard Log Output"
+        "title": "Show Quarto Wizard Log Output",
+        "category": "Quarto Wizard"
       },
       {
         "command": "quartoWizard.clearRecentlyInstalled",
-        "title": "Quarto Wizard: Clear Recently Installed Extensions"
+        "title": "Clear Recently Installed Extensions",
+        "category": "Quarto Wizard"
       },
       {
         "command": "quartoWizard.newQuartoReprex",
-        "title": "Quarto Wizard: New Reproducible Document"
+        "title": "New Reproducible Document",
+        "category": "Quarto Wizard"
       }
     ],
     "menus": {


### PR DESCRIPTION
Replace hardcoded command titles with a category for better organisation.