### PR TITLE
fix: `installQuartoExtensionSource` to keep "source" for install/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.5.1 (2025-01-20)
+## 0.5.2 (2025-01-19)
+
+- fix: add source after updating an extension.
+- refactor: add `installQuartoExtensionSource` to contain the logic to install an extension and add the source.
+
+## 0.5.1 (2025-01-19)
 
 - fix(.vscodeignore): remove wrong entry.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quarto-wizard",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quarto-wizard",
-			"version": "0.5.1",
+			"version": "0.5.2",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quarto-wizard",
 	"displayName": "Quarto Wizard",
 	"description": "A Visual Studio Code extension that helps you manage Quarto projects.",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"publisher": "mcanouil",
 	"author": {
 		"name": "Mickaël CANOUIL"

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { findQuartoExtensions } from "../utils/extensions";
 import { ExtensionData, readExtensions } from "../utils/extensions";
-import { installQuartoExtension, removeQuartoExtension } from "../utils/quarto";
+import { removeQuartoExtension, installQuartoExtensionSource } from "../utils/quarto";
 
 class ExtensionTreeItem extends vscode.TreeItem {
 	constructor(
@@ -124,11 +124,9 @@ export class ExtensionsInstalled {
 		);
 		context.subscriptions.push(
 			vscode.commands.registerCommand("quartoWizard.extensionsInstalled.update", (item: ExtensionTreeItem) => {
-				if (item.data?.source) {
-					installQuartoExtension(item.data?.source, log);
-				} else {
-					installQuartoExtension(item.label, log);
-				}
+				installQuartoExtensionSource(item.data?.source ?? item.label, log, workspaceFolder);
+				// Once source is supported in _extension.yml, the above line can be replaced with the following line
+				// installQuartoExtension(item.data?.source ?? item.label, log);
 			})
 		);
 		context.subscriptions.push(


### PR DESCRIPTION
Update the extension installation logic to ensure the source is retained after installation or update. This change introduces a new function to handle the installation process and updates the changelog accordingly.