### PR TITLE
fix: duplication of recently installed extensions in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.3 (unreleased)
 
-- fix: recently installed extensions are no longer duplicated when using search.
+- fix: duplication of recently installed extensions in search results.
 
 ## 0.5.2 (2025-01-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3 (unreleased)
+
+- fix: recently installed extensions are no longer duplicated when using search.
+
 ## 0.5.2 (2025-01-19)
 
 - fix: add source after updating an extension.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quarto-wizard",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quarto-wizard",
-			"version": "0.5.2",
+			"version": "0.5.3",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quarto-wizard",
 	"displayName": "Quarto Wizard",
 	"description": "A Visual Studio Code extension that helps you manage Quarto projects.",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"publisher": "mcanouil",
 	"author": {
 		"name": "Mickaël CANOUIL"

--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -53,7 +53,9 @@ export async function installQuartoExtensionCommand(
 			label: "All Extensions",
 			kind: vscode.QuickPickItemKind.Separator,
 		},
-		...createExtensionItems(extensionsList).sort((a, b) => a.label.localeCompare(b.label)),
+		...createExtensionItems(extensionsList.filter((ext) => !recentlyInstalled.includes(ext))).sort((a, b) =>
+			a.label.localeCompare(b.label)
+		),
 	];
 
 	const quickPick = vscode.window.createQuickPick<ExtensionQuickPickItem>();


### PR DESCRIPTION
Ensure that recently installed extensions do not appear multiple times when using the search functionality.