### PR TITLE
fix: update cache expiration time display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - refactor: use constants for log messages target.
 - fix(src/utils/extensions.ts): caching of the list of available Quarto extensions.
 - fix(src/utils/extensions.ts): update cache expiration time for extensions list and display in log as ISO string.
+- chore: use webpack to bundle the extension.
 
 ## 0.6.0 (2025-01-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - refactor(src/utils/extensions.ts): externalise Quick Pick UI tools.
 - refactor: use constants for log messages target.
 - fix(src/utils/extensions.ts): caching of the list of available Quarto extensions.
+- fix(src/utils/extensions.ts): update cache expiration time for extensions list and display in log as ISO string.
 
 ## 0.6.0 (2025-01-24)
 

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -31,8 +31,8 @@ export async function fetchExtensions(url: string, context: vscode.ExtensionCont
 	const cacheKey = `${"quarto_wizard_extensions_csv_"}${generateHashKey(url)}`;
 	const cachedData = context.globalState.get<{ data: string[]; timestamp: number }>(cacheKey);
 
-	if (cachedData && Date.now() - cachedData.timestamp < 12 * 60 * 60 * 1000) {
-		QUARTO_WIZARD_LOG.appendLine(`Using cached extensions: ${cachedData.timestamp}`);
+	if (cachedData && Date.now() - cachedData.timestamp < 60 * 60 * 1000) {
+		QUARTO_WIZARD_LOG.appendLine(`Using cached extensions: ${new Date(cachedData.timestamp).toISOString()}`);
 		return cachedData.data;
 	} else {
 		QUARTO_WIZARD_LOG.appendLine(`Fetching extensions: ${url}`);


### PR DESCRIPTION
Adjust the cache expiration time from 12 hours to 1 hour and improve the timestamp display format in the log message.