### PR TITLE
feat: add "activationEvents" to `package.json` to avoid unnecessary activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix(src/utils/extensions.ts): caching of the list of available Quarto extensions.
 - fix(src/utils/extensions.ts): update cache expiration time for extensions list and display in log as ISO string.
 - fix: harmonise log and notification messages.
+- fix: add "activationEvents" to `package.json` to avoid unnecessary activation.
 - chore: use webpack to bundle the extension.
 
 ## 0.6.0 (2025-01-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 (unreleased)
+
+- feat: add "activationEvents" to `package.json` to avoid unnecessary activation.
+
 ## 0.7.0 (2025-01-30)
 
 - refactor(src/utils/network.ts): internal logging.
@@ -8,7 +12,6 @@
 - fix(src/utils/extensions.ts): caching of the list of available Quarto extensions.
 - fix(src/utils/extensions.ts): update cache expiration time for extensions list and display in log as ISO string.
 - fix: harmonise log and notification messages.
-- fix: add "activationEvents" to `package.json` to avoid unnecessary activation.
 - chore: use webpack to bundle the extension.
 
 ## 0.6.0 (2025-01-24)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,13 @@
 	"engines": {
 		"vscode": "^1.96.0"
 	},
+	"activationEvents": [
+		"onLanguage:quarto",
+		"workspaceContains:**/*.{qmd,rmd}",
+		"workspaceContains:**/_quarto.{yml,yaml}",
+		"workspaceContains:**/_brand.{yml,yaml}",
+		"workspaceContains:**/_extension.{yml,yaml}"
+	],
 	"contributes": {
 		"commands": [
 			{

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quarto-wizard",
 	"displayName": "Quarto Wizard",
 	"description": "A Visual Studio Code extension that helps you manage Quarto projects.",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"publisher": "mcanouil",
 	"author": {
 		"name": "Mickaël CANOUIL"


### PR DESCRIPTION
Include "activationEvents" in `package.json` to prevent unnecessary activation of the extension.