### PR TITLE
fix: GitHub button functionality in QuickPick UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.8.0 (unreleased)
+## 0.7.1 (unreleased)
 
 - feat: add "activationEvents" to `package.json` to avoid unnecessary activation.
+- fix: GitHub button in QuickPick UI opens again the repository in the default browser.
 
 ## 0.7.0 (2025-01-30)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quarto-wizard",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quarto-wizard",
-			"version": "0.7.0",
+			"version": "0.7.1",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quarto-wizard",
 	"displayName": "Quarto Wizard",
 	"description": "A Visual Studio Code extension that helps you manage Quarto projects.",
-	"version": "0.8.0",
+	"version": "0.7.1",
 	"publisher": "mcanouil",
 	"author": {
 		"name": "Mickaël CANOUIL"

--- a/src/ui/extensionsQuickPick.ts
+++ b/src/ui/extensionsQuickPick.ts
@@ -8,7 +8,7 @@ export interface ExtensionQuickPickItem extends vscode.QuickPickItem {
 export function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
 	return extensions.map((ext) => ({
 		label: formatExtensionLabel(ext),
-		description: ext,
+		description: getGitHubLink(ext),
 		buttons: [
 			{
 				iconPath: new vscode.ThemeIcon("github"),
@@ -43,6 +43,12 @@ export async function showExtensionQuickPick(
 	quickPick.placeholder = "Select Quarto extensions to install";
 	quickPick.canSelectMany = true;
 	quickPick.matchOnDescription = true;
+	quickPick.onDidTriggerItemButton((e) => {
+		const url = e.item.url;
+		if (url) {
+			vscode.env.openExternal(vscode.Uri.parse(url));
+		}
+	});
 
 	return new Promise((resolve) => {
 		quickPick.onDidAccept(() => {


### PR DESCRIPTION
Correct the behavior of the GitHub button in the QuickPick UI to open the repository in the default browser. Update version numbers accordingly.