### PR TITLE
fix: broken extensions install by updating description handling

### DIFF
--- a/src/ui/extensionsQuickPick.ts
+++ b/src/ui/extensionsQuickPick.ts
@@ -8,7 +8,7 @@ export interface ExtensionQuickPickItem extends vscode.QuickPickItem {
 export function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
 	return extensions.map((ext) => ({
 		label: formatExtensionLabel(ext),
-		description: getGitHubLink(ext),
+		description: ext,
 		buttons: [
 			{
 				iconPath: new vscode.ThemeIcon("github"),


### PR DESCRIPTION
The change modifies the extension description to use the extension name instead of a GitHub link, addressing the issue with the extensions installation process. Fixes #44