### PR TITLE
ci: upload built VSIX to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,4 +56,10 @@ jobs:
 
       - name: Build extension
         shell: bash
-        run: vsce package --pre-release
+        run: vsce package --pre-release --out quarto-wizard.vsix
+
+      - name: Upload VSIX as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: quarto-wizard-${{ github.sha }}
+          path: quarto-wizard.vsix


### PR DESCRIPTION
Add a step to the CI workflow to upload the built VSIX file as an artifact after packaging.