### PR TITLE
ci: limit VSIX retention to 10 days in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,4 @@ jobs:
         with:
           name: quarto-wizard-${{ github.sha }}
           path: quarto-wizard.vsix
+          retention-days: 10


### PR DESCRIPTION
Update the CI workflow to set the retention period for the VSIX file to 10 days.