### PR TITLE
fix: activate `quarto-wizard-explorer` view only in a workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 dist
 node_modules
 *.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.3 (unreleased)
 
-- fix: activate view in activity bar only in a workspace.
+- fix: activate `quarto-wizard-explorer` view only in a workspace.
 - chore(CITATION.cff): add citation file.
 - chore: update TypeScript configuration settings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 (unreleased)
 
+- fix: activate view in activity bar only in a workspace.
 - chore(CITATION.cff): add citation file.
 - chore: update TypeScript configuration settings.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@vscode/vsce": "^3.2.2",
 				"ts-loader": "^9.5.2",
 				"typescript": "^5.7.3",
-				"webpack": "^5.97.1",
+				"webpack": "^5.98.0",
 				"webpack-cli": "^6.0.1"
 			},
 			"engines": {
@@ -670,16 +670,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -704,38 +704,17 @@
 				}
 			}
 		},
-		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+		"node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
+				"fast-deep-equal": "^3.1.3"
 			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ajv-keywords": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"license": "MIT",
 			"peerDependencies": {
-				"ajv": "^6.9.1"
+				"ajv": "^8.8.2"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -1579,13 +1558,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/fast-uri": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -2184,9 +2156,9 @@
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2895,16 +2867,6 @@
 				"once": "^1.3.1"
 			}
 		},
-		"node_modules/punycode": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/punycode.js": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -3090,15 +3052,16 @@
 			"license": "ISC"
 		},
 		"node_modules/schema-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -3585,63 +3548,6 @@
 				}
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3"
-			},
-			"peerDependencies": {
-				"ajv": "^8.8.2"
-			}
-		},
-		"node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"ajv": "^8.9.0",
-				"ajv-formats": "^2.1.1",
-				"ajv-keywords": "^5.1.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
 		"node_modules/terser/node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3896,16 +3802,6 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
-		"node_modules/uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"punycode": "^2.1.0"
-			}
-		},
 		"node_modules/url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -3946,9 +3842,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.97.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
-			"integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
+			"version": "5.98.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+			"integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3970,9 +3866,9 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.2.0",
+				"schema-utils": "^4.3.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.10",
+				"terser-webpack-plugin": "^5.3.11",
 				"watchpack": "^2.4.1",
 				"webpack-sources": "^3.2.3"
 			},

--- a/package.json
+++ b/package.json
@@ -207,7 +207,8 @@
 					"id": "quarto-wizard-explorer",
 					"title": "Quarto Wizard",
 					"icon": "assets/logo/logo.svg",
-					"contextualTitle": "Quarto Wizard"
+					"contextualTitle": "Quarto Wizard",
+					"when": "workspaceFolderCount >= 1"
 				}
 			]
 		},
@@ -218,7 +219,8 @@
 					"name": "Extensions Installed",
 					"icon": "assets/logo/logo.svg",
 					"contextualTitle": "Quarto Wizard Extensions Installed",
-					"visibility": "visible"
+					"visibility": "visible",
+					"when": "workspaceFolderCount >= 1"
 				}
 			]
 		},
@@ -272,7 +274,7 @@
 		"@vscode/vsce": "^3.2.2",
 		"ts-loader": "^9.5.2",
 		"typescript": "^5.7.3",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-cli": "^6.0.1"
 	},
 	"dependencies": {


### PR DESCRIPTION
Restrict the activation of the `quarto-wizard-explorer` view  to when at least one workspace folder is present. 