### PR TITLE
fix: properly ignore bundled modules in .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,5 +13,7 @@ webpack.config.js
 src
 dist/**/*.map
 **/*.vsix
+node_modules
 
 assets/logo/logo-social.png
+CITATION.cff


### PR DESCRIPTION
Update the .vscodeignore file to ensure that bundled modules and additional files are properly ignored during packaging.