### PR TITLE
refactor: use logMessage function and output chanel as log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - feat: retrieve and display extensions details from GitHub API.
 - feat: add more details in QuickPick UI for extensions.
+- feat: set `log` to `true` for output channel, allowing colouring.
 - fix: activate `quarto-wizard-explorer` view only in a workspace.
 - refactor: use constants variables for cache name and expiration time.
+- refactor: use `logMessage` function to log messages.
 - docs: add GitHub account authentication as a requirement.
 - chore(CITATION.cff): add citation file.
 - chore: update TypeScript configuration settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/rest": "^21.1.0",
+				"chalk": "^5.4.1",
 				"js-yaml": "^4.1.0",
 				"typescript": "^5.7.3"
 			},
@@ -579,6 +580,21 @@
 				"darwin"
 			]
 		},
+		"node_modules/@vscode/vsce/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -1137,18 +1153,15 @@
 			"license": "CC-BY-4.0"
 		},
 		"node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+			"integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
 			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
 			"engines": {
-				"node": ">=4"
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/cheerio": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"commands": [
 			{
 				"command": "quartoWizard.getExtensionsDetails",
-				"title": "Get Extensions Information",
+				"title": "Get Extensions Details",
 				"category": "Quarto Wizard"
 			},
 			{

--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
-import { QW_LOG, QW_RECENTLY_INSTALLED } from "../constants";
-import { showLogsCommand } from "../utils/log";
+import { QW_RECENTLY_INSTALLED } from "../constants";
+import { showLogsCommand, logMessage } from "../utils/log";
 import { checkInternetConnection } from "../utils/network";
 import { getQuartoPath, checkQuartoPath, installQuartoExtension, installQuartoExtensionSource } from "../utils/quarto";
 import { askTrustAuthors, askConfirmInstall } from "../utils/ask";
@@ -26,7 +26,7 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
 		async (progress, token) => {
 			token.onCancellationRequested(() => {
 				const message = "Operation cancelled by the user.";
-				QW_LOG.appendLine(message);
+				logMessage(message);
 				vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
 			});
 
@@ -61,16 +61,16 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
 			});
 
 			if (installedExtensions.length > 0) {
-				QW_LOG.appendLine(`\n\nSuccessfully installed extension${installedExtensions.length > 1 ? "s" : ""}:`);
+				logMessage(`Successfully installed extension${installedExtensions.length > 1 ? "s" : ""}:`);
 				installedExtensions.forEach((ext) => {
-					QW_LOG.appendLine(` - ${ext}`);
+					logMessage(` - ${ext}`);
 				});
 			}
 
 			if (failedExtensions.length > 0) {
-				QW_LOG.appendLine(`\n\nFailed to install extension${failedExtensions.length > 1 ? "s" : ""}:`);
+				logMessage(`Failed to install extension${failedExtensions.length > 1 ? "s" : ""}:`);
 				failedExtensions.forEach((ext) => {
-					QW_LOG.appendLine(` - ${ext}`);
+					logMessage(` - ${ext}`);
 				});
 				const message = [
 					"The following extension",
@@ -84,7 +84,7 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
 				const message = [installedCount, " extension", installedCount > 1 ? "s" : "", " installed successfully."].join(
 					""
 				);
-				QW_LOG.appendLine(message);
+				logMessage(message);
 				vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
 			}
 		}
@@ -94,7 +94,7 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
 export async function installQuartoExtensionCommand(context: vscode.ExtensionContext) {
 	if (!vscode.workspace.workspaceFolders) {
 		const message = `Please open a workspace/folder to install Quarto extensions.`;
-		QW_LOG.appendLine(message);
+		logMessage(message);
 		vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
 		return;
 	}

--- a/src/commands/newQuartoReprex.ts
+++ b/src/commands/newQuartoReprex.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
-import { QW_LOG } from "../constants";
-import { showLogsCommand } from "../utils/log";
+import { showLogsCommand, logMessage } from "../utils/log";
 import { newQuartoReprex } from "../utils/reprex";
 
 export async function newQuartoReprexCommand(context: vscode.ExtensionContext) {
@@ -13,7 +12,7 @@ export async function newQuartoReprexCommand(context: vscode.ExtensionContext) {
 		newQuartoReprex(selectedLanguage, context);
 	} else {
 		const message = `No computing language selected. Aborting.`;
-		QW_LOG.appendLine(message);
+		logMessage(message);
 		vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-export const QW_LOG = vscode.window.createOutputChannel("Quarto Wizard");
+export const QW_LOG = vscode.window.createOutputChannel("Quarto Wizard", { log: true });
 
 export const QW_RECENTLY_INSTALLED = "recentlyInstalledExtensions";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { QW_LOG, QW_RECENTLY_INSTALLED } from "./constants";
-import { showLogsCommand } from "./utils/log";
+import { showLogsCommand, logMessage } from "./utils/log";
 import { installQuartoExtensionCommand } from "./commands/installQuartoExtension";
 import { newQuartoReprexCommand } from "./commands/newQuartoReprex";
 import { ExtensionsInstalled } from "./ui/extensionsInstalled";
@@ -13,7 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("quartoWizard.clearRecentlyInstalled", () => {
 			context.globalState.update(QW_RECENTLY_INSTALLED, []);
 			const message = "Recently installed Quarto extensions have been cleared.";
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
 		})
 	);

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -22,6 +22,7 @@ class ExtensionTreeItem extends vscode.TreeItem {
 		}
 	}
 }
+
 class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<ExtensionTreeItem> {
 	private _onDidChangeTreeData: vscode.EventEmitter<ExtensionTreeItem | undefined | void> = new vscode.EventEmitter<
 		ExtensionTreeItem | undefined | void
@@ -45,7 +46,7 @@ class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<Extensi
 		if (!element) {
 			if (Object.keys(this.extensionsData).length === 0) {
 				return Promise.resolve([
-					new ExtensionTreeItem("No extensions installed", vscode.TreeItemCollapsibleState.None, undefined, "info"),
+					new ExtensionTreeItem("No extensions installed", vscode.TreeItemCollapsibleState.None, undefined),
 				]);
 			}
 			return Promise.resolve(this.getExtensionItems());

--- a/src/utils/ask.ts
+++ b/src/utils/ask.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
-import { QW_LOG } from "../constants";
-import { showLogsCommand } from "../utils/log";
+import { showLogsCommand, logMessage } from "../utils/log";
 
 export async function askTrustAuthors(): Promise<number> {
 	const config = vscode.workspace.getConfiguration("quartoWizard.ask", null);
@@ -22,7 +21,7 @@ export async function askTrustAuthors(): Promise<number> {
 			return 0;
 		} else if (trustAuthors?.label !== "Yes") {
 			const message = "Operation cancelled because the authors are not trusted.";
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
 			return 1;
 		}
@@ -50,7 +49,7 @@ export async function askConfirmInstall(): Promise<number> {
 			return 0;
 		} else if (installWorkspace?.label !== "Yes") {
 			const message = "Operation cancelled by the user.";
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
 			return 1;
 		}
@@ -78,7 +77,7 @@ export async function askConfirmRemove(): Promise<number> {
 			return 0;
 		} else if (removeWorkspace?.label !== "Yes") {
 			const message = "Operation cancelled by the user.";
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
 			return 1;
 		}

--- a/src/utils/extensionDetails.ts
+++ b/src/utils/extensionDetails.ts
@@ -1,14 +1,13 @@
 import * as vscode from "vscode";
 import { Octokit } from "@octokit/rest";
 import {
-	QW_LOG,
 	QW_EXTENSIONS,
 	QW_EXTENSIONS_CACHE,
 	QW_EXTENSIONS_CACHE_TIME,
 	QW_EXTENSION_DETAILS_CACHE,
 	QW_EXTENSION_DETAILS_CACHE_TIME,
 } from "../constants";
-import { showLogsCommand } from "./log";
+import { showLogsCommand, logMessage } from "./log";
 import { Credentials } from "./githubAuth";
 import { generateHashKey } from "./hash";
 
@@ -34,11 +33,11 @@ async function fetchExtensions(context: vscode.ExtensionContext): Promise<string
 	const cachedData = context.globalState.get<{ data: string[]; timestamp: number }>(cacheKey);
 
 	if (cachedData && Date.now() - cachedData.timestamp < QW_EXTENSIONS_CACHE_TIME) {
-		QW_LOG.appendLine(`Using cached extensions: ${new Date(cachedData.timestamp).toISOString()}`);
+		logMessage(`Using cached extensions: ${new Date(cachedData.timestamp).toISOString()}`);
 		return cachedData.data;
 	}
 
-	QW_LOG.appendLine(`Fetching extensions: ${url}`);
+	logMessage(`Fetching extensions: ${url}`);
 	let message = `Error fetching list of extensions from ${url}.`;
 	try {
 		const response: Response = await fetch(url);
@@ -51,7 +50,7 @@ async function fetchExtensions(context: vscode.ExtensionContext): Promise<string
 		await context.globalState.update(cacheKey, { data: extensionsList, timestamp: Date.now() });
 		return extensionsList;
 	} catch (error) {
-		QW_LOG.appendLine(`${message} ${error}`);
+		logMessage(`${message} ${error}`);
 		vscode.window.showErrorMessage(`${message}. ${showLogsCommand()}`);
 		return [];
 	}
@@ -91,12 +90,12 @@ async function getExtensionDetails(
 	}>(cacheKey);
 
 	if (cachedExtensionDetails && Date.now() - cachedExtensionDetails.timestamp < QW_EXTENSION_DETAILS_CACHE_TIME) {
-		QW_LOG.appendLine(`Using cached information: ${ext} ${new Date(cachedExtensionDetails.timestamp).toISOString()}`);
+		logMessage(`Using cached details: ${ext} ${new Date(cachedExtensionDetails.timestamp).toISOString()}`);
 		return cachedExtensionDetails.ExtensionDetails;
 	}
 
-	QW_LOG.appendLine(`Fetching information: ${ext}`);
-	let message = `Error fetching information for ${ext}.`;
+	logMessage(`Fetching details: ${ext}`);
+	let message = `Error fetching details for ${ext}.`;
 	let ExtensionDetails: ExtensionDetails;
 	try {
 		const [owner, name] = ext.split("/");
@@ -127,7 +126,7 @@ async function getExtensionDetails(
 		await context.globalState.update(cacheKey, { ExtensionDetails: ExtensionDetails, timestamp: Date.now() });
 		return ExtensionDetails;
 	} catch (error) {
-		QW_LOG.appendLine(`${message} ${error}`);
+		logMessage(`${message} ${error}`);
 		vscode.window.showErrorMessage(`${message}. ${showLogsCommand()}`);
 		return undefined;
 	}

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,3 +1,9 @@
+import { QW_LOG } from "../constants";
+
 export function showLogsCommand(): string {
 	return "[Show logs](command:quartoWizard.showOutput)";
+}
+
+export function logMessage(message: string): void {
+	QW_LOG.appendLine(message);
 }

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
-import { QW_LOG } from "../constants";
-import { showLogsCommand } from "./log";
+import { showLogsCommand, logMessage } from "./log";
 
 export async function checkInternetConnection(url: string = "https://github.com/"): Promise<boolean> {
 	try {
@@ -9,13 +8,13 @@ export async function checkInternetConnection(url: string = "https://github.com/
 			return true;
 		} else {
 			const message = `No internet connection. Please check your network settings.`;
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
 			return false;
 		}
 	} catch (error) {
 		const message = `No internet connection. Please check your network settings.`;
-		QW_LOG.appendLine(message);
+		logMessage(message);
 		vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
 		return false;
 	}

--- a/src/utils/quarto.ts
+++ b/src/utils/quarto.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { exec } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
-import { QW_LOG } from "../constants";
+import { logMessage } from "./log";
 import { findModifiedExtensions, getMtimeExtensions } from "./extensions";
 
 let cachedQuartoPath: string | undefined;
@@ -58,7 +58,7 @@ export async function checkQuartoVersion(quartoPath: string | undefined): Promis
 }
 
 export async function installQuartoExtension(extension: string): Promise<boolean> {
-	QW_LOG.appendLine(`\n\nInstalling ${extension} ...`);
+	logMessage(`Installing ${extension} ...`);
 	return new Promise((resolve) => {
 		if (vscode.workspace.workspaceFolders === undefined) {
 			return;
@@ -70,7 +70,7 @@ export async function installQuartoExtension(extension: string): Promise<boolean
 
 		exec(command, { cwd: workspaceFolder }, (error, stdout, stderr) => {
 			if (stderr) {
-				QW_LOG.appendLine(`${stderr}`);
+				logMessage(`${stderr}`);
 				const isInstalled = stderr.includes("Extension installation complete");
 				if (isInstalled) {
 					resolve(true);
@@ -112,7 +112,7 @@ export async function installQuartoExtensionSource(extension: string, workspaceF
 }
 
 export async function removeQuartoExtension(extension: string): Promise<boolean> {
-	QW_LOG.appendLine(`\n\nRemoving ${extension} ...`);
+	logMessage(`Removing ${extension} ...`);
 
 	return new Promise((resolve) => {
 		if (vscode.workspace.workspaceFolders === undefined) {
@@ -125,7 +125,7 @@ export async function removeQuartoExtension(extension: string): Promise<boolean>
 
 		exec(command, { cwd: workspaceFolder }, (error, stdout, stderr) => {
 			if (stderr) {
-				QW_LOG.appendLine(`${stderr}`);
+				logMessage(`${stderr}`);
 				const isRemoved = stderr.includes("Extension removed");
 				if (isRemoved) {
 					resolve(true);

--- a/src/utils/reprex.ts
+++ b/src/utils/reprex.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
-import { QW_LOG } from "../constants";
-import { showLogsCommand } from "./log";
+import { showLogsCommand, logMessage } from "./log";
 
 export async function newQuartoReprex(language: string, context: vscode.ExtensionContext) {
 	let templateFile = "";
@@ -19,7 +18,7 @@ export async function newQuartoReprex(language: string, context: vscode.Extensio
 			break;
 		default:
 			const message = `Unsupported language: ${language}.`;
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
 			return;
 	}
@@ -28,7 +27,7 @@ export async function newQuartoReprex(language: string, context: vscode.Extensio
 	fs.readFile(filePath, "utf8", (err, data) => {
 		if (err) {
 			const message = `Failed to read the template file: ${err.message}.`;
-			QW_LOG.appendLine(message);
+			logMessage(message);
 			vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
 			return;
 		}


### PR DESCRIPTION
Replace direct logging calls with a centralised logMessage function for consistency and improved maintainability. Update output channel creation to enable logging.