### PR TITLE
fix: prevent error notification when extension details cannot be retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: prevent error notification when extension details cannot be retrieved.
+
 ## 0.8.0 (2025-02-18)
 
 - feat: retrieve and display extensions details from GitHub API.

--- a/src/utils/extensionDetails.ts
+++ b/src/utils/extensionDetails.ts
@@ -7,7 +7,7 @@ import {
 	QW_EXTENSION_DETAILS_CACHE,
 	QW_EXTENSION_DETAILS_CACHE_TIME,
 } from "../constants";
-import { showLogsCommand, logMessage } from "./log";
+import { logMessage } from "./log";
 import { Credentials } from "./githubAuth";
 import { generateHashKey } from "./hash";
 
@@ -59,7 +59,6 @@ async function fetchExtensions(context: vscode.ExtensionContext): Promise<string
 		return extensionsList;
 	} catch (error) {
 		logMessage(`${message} ${error}`, "error");
-		vscode.window.showErrorMessage(`${message}. ${showLogsCommand()}`);
 		return [];
 	}
 }
@@ -150,7 +149,6 @@ async function getExtensionDetails(
 		return ExtensionDetails;
 	} catch (error) {
 		logMessage(`${message} ${error}`, "error");
-		vscode.window.showErrorMessage(`${message}. ${showLogsCommand()}`);
 		return undefined;
 	}
 }


### PR DESCRIPTION
Eliminate unnecessary error notifications when extension details cannot be fetched, enhancing the overall user experience.