### PR TITLE
refactor: use a pre-fetched list of Quarto extensions for the QuickPick UI

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,3 +19,6 @@ node_modules
 assets/logo/logo-social.png
 assets/videos/**
 CITATION.cff
+
+# Ignore scripts not needed in the final package
+src/utils/githubAuth.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- refactor: use a pre-fetched list of Quarto extensions for the QuickPick UI.
+- refactor: drop GitHub authentication requirement for the extension details.
+
 ## 0.8.1 (2025-02-20)
 
 - fix: prevent error notification when extension details cannot be retrieved.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This extension provides a user-friendly interface to browse, select, and install
 
 - **Check Internet Connection**: Ensure you have an active internet connection before installing extensions.
 - **Check Quarto Installation**: Verify that Quarto is installed and available in your system's PATH.
-- **Allow GitHub Access**: Enable GitHub authentication for the extension to display the list of available Quarto extensions (_i.e._, read-only access to public information).
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
 		"webpack-cli": "^6.0.1"
 	},
 	"dependencies": {
-		"@octokit/rest": "^21.1.0",
 		"@types/lodash": "^4.17.15",
 		"js-yaml": "^4.1.0",
 		"lodash": "^4.17.21",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,37 +14,14 @@ export const QW_RECENTLY_INSTALLED = "recentlyInstalledExtensions";
  * URL to the Quarto extensions CSV file.
  */
 export const QW_EXTENSIONS =
-	"https://raw.githubusercontent.com/mcanouil/quarto-extensions/main/extensions/quarto-extensions.csv";
+	"https://raw.githubusercontent.com/mcanouil/quarto-extensions/refs/heads/quarto-wizard/quarto-extensions.json";
 
 /**
- * Key for caching the Quarto extensions CSV.
+ * Key for caching the Quarto extensions JSON.
  */
-export const QW_EXTENSIONS_CACHE = "quarto_wizard_extensions_csv";
+export const QW_EXTENSIONS_CACHE = "quarto_wizard_extensions";
 
 /**
- * Cache duration for the Quarto extensions CSV (default to 1 hour).
+ * Cache duration for the Quarto extensions JSON (default to 1 hour).
  */
-export const QW_EXTENSIONS_CACHE_TIME = 60 * 60 * 1000;
-
-/**
- * Key for caching Quarto extension details retrieved from the GitHub API.
- */
-export const QW_EXTENSION_DETAILS_CACHE = "quarto_wizard_extensions_details";
-
-/**
- * Cache duration for Quarto extension details (default to 24 hours).
- */
-export const QW_EXTENSION_DETAILS_CACHE_TIME = 24 * 60 * 60 * 1000;
-
-/**
- * GitHub authentication provider ID.
- */
-export const QW_AUTH_PROVIDER_ID = "github";
-
-/**
- * Scopes for the GitHub authentication provider.
- * "no scope" = Grants read-only access to public information.
- * The GitHub Authentication Provider accepts the scopes described here:
- * https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
- */
-export const QW_AUTH_PROVIDER_SCOPES: string[] = [];
+export const QW_EXTENSIONS_CACHE_TIME = 0 * 60 * 60 * 1000;

--- a/src/utils/githubAuth.ts
+++ b/src/utils/githubAuth.ts
@@ -1,6 +1,19 @@
 import * as vscode from "vscode";
 import * as Octokit from "@octokit/rest";
-import { QW_AUTH_PROVIDER_ID, QW_AUTH_PROVIDER_SCOPES } from "../constants";
+// import { QW_AUTH_PROVIDER_ID, QW_AUTH_PROVIDER_SCOPES } from "../constants";
+
+/**
+ * GitHub authentication provider ID.
+ */
+export const QW_AUTH_PROVIDER_ID = "github";
+
+/**
+ * Scopes for the GitHub authentication provider.
+ * "no scope" = Grants read-only access to public information.
+ * The GitHub Authentication Provider accepts the scopes described here:
+ * https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
+ */
+export const QW_AUTH_PROVIDER_SCOPES: string[] = [];
 
 /**
  * Manages GitHub authentication and provides an authenticated Octokit instance.


### PR DESCRIPTION
Refactor the QuickPick UI to utilise a pre-fetched list of Quarto extensions including repository details, eliminating the need for GitHub authentication to retrieve extension details via Rest API.