### PR TITLE
refactor: remove dependency on `quarto remove` for uninstalling extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- refactor: no longer use `quarto remove` to uninstall an extension.
+
 ## 0.9.0 (2025-02-20)
 
 - refactor: use a pre-fetched list of Quarto extensions for the QuickPick UI.


### PR DESCRIPTION
Remove dependency on `quarto remove` for uninstalling extensions by implementing a direct file system approach, enhancing performance and reliability.