### PR TITLE
feat: add URI handler for installing Quarto extensions from the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- feat: add URI handler for installing Quarto extensions from the browser.  
+  `vscode://mcanouil.quarto-wizard/install?repo=mcanouil/quarto-iconify`
+
 ## 0.13.0 (2025-02-22)
 
 - feat: allow to disable the automatic markdown linting via `markdownlint` with a "never" option.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
 		"workspaceContains:**/*.{qmd,rmd}",
 		"workspaceContains:**/_quarto.{yml,yaml}",
 		"workspaceContains:**/_brand.{yml,yaml}",
-		"workspaceContains:**/_extension.{yml,yaml}"
+		"workspaceContains:**/_extension.{yml,yaml}",
+		"onUri"
 	],
 	"main": "./dist/extension",
 	"scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { newQuartoReprexCommand } from "./commands/newQuartoReprex";
 import { ExtensionsInstalled } from "./ui/extensionsInstalled";
 import { getExtensionsDetails } from "./utils/extensionDetails";
 import { lint } from "./utils/lint";
+import { handleUri } from "./utils/handleUri";
 
 /**
  * This method is called when the extension is activated.
@@ -41,6 +42,8 @@ export function activate(context: vscode.ExtensionContext) {
 	new ExtensionsInstalled(context);
 
 	lint(context);
+
+	vscode.window.registerUriHandler({ handleUri });
 }
 
 /**

--- a/src/utils/handleUri.ts
+++ b/src/utils/handleUri.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { showLogsCommand, logMessage } from "../utils/log";
 import { installQuartoExtensionSource } from "./quarto";
 
 /**
@@ -8,13 +9,26 @@ import { installQuartoExtensionSource } from "./quarto";
  *
  * vscode://mcanouil.quarto-wizard/install?repo=<owner>/<repository>
  */
-export function handleUri(uri: vscode.Uri) {
+export async function handleUri(uri: vscode.Uri) {
 	if (uri.path === "/install") {
 		const repo = new URLSearchParams(uri.query).get("repo");
 		if (!repo || !vscode.workspace.workspaceFolders) {
 			return;
 		}
 		const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+		const installWorkspace = await vscode.window.showInformationMessage(
+			`Do you confirm the installation of "${repo}" extension?`,
+			{ modal: true },
+			"Yes",
+			"No"
+		);
+
+		if (installWorkspace === "No") {
+			const message = "Operation cancelled by the user.";
+			logMessage(message, "info");
+			vscode.window.showInformationMessage(`${message} ${showLogsCommand()}.`);
+			return;
+		}
 		installQuartoExtensionSource(repo, workspaceFolder);
 	}
 }

--- a/src/utils/handleUri.ts
+++ b/src/utils/handleUri.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode";
+import { installQuartoExtensionSource } from "./quarto";
+
+/**
+ * Handle the URI passed to the extension.
+ *
+ * @param uri - The URI passed to the extension.
+ *
+ * vscode://mcanouil.quarto-wizard/install?repo=<owner>/<repository>
+ */
+export function handleUri(uri: vscode.Uri) {
+	if (uri.path === "/install") {
+		const repo = new URLSearchParams(uri.query).get("repo");
+		if (!repo || !vscode.workspace.workspaceFolders) {
+			return;
+		}
+		const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+		installQuartoExtensionSource(repo, workspaceFolder);
+	}
+}


### PR DESCRIPTION
Introduce a URI handler that allows users to install Quarto extensions directly from the browser, enhancing the extension's functionality.