### PR TITLE
feat:  add custom "markdownlint" rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: add custome "markdownlint" rules: "blanks-around-fenced-divs".
+- feat: add custom "markdownlint" rules: "blanks-around-fenced-divs".
 - fix: set "markdownlint" linting to "on type" by default.
 - chore: remove a `console.log()` statement.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: add custome "markdownlint" rules: "blanks-around-fenced-divs".
+- fix: set "markdownlint" linting to "on type" by default.
 - chore: remove a `console.log()` statement.
 
 ## 0.14.1 (2025-02-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- feat: add custome "markdownlint" rules: "blanks-around-fenced-divs".
+- chore: remove a `console.log()` statement.
+
 ## 0.14.1 (2025-02-23)
 
 - feat: improve the SVG icon.

--- a/markdownlint-rules/001-blanks-around-fenced-divs.js
+++ b/markdownlint-rules/001-blanks-around-fenced-divs.js
@@ -1,0 +1,25 @@
+/** @type {import("markdownlint").Rule} */
+module.exports = {
+  "names": ["QMD001", "blanks-around-fenced-divs"],
+  "description": "Fenced Divs markers should be surrounded by blank lines",
+  "tags": ["fenced_divs", "blank_lines"],
+  "parser": "none",
+  "function": function QMD001(params, onError) {
+    const lines = params.lines;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+
+      if (line.match(/^:{3,}/)) {
+        const isMissingTopBlank = i === 0 || lines[i - 1].trim().length > 0;
+        const isMissingBottomBlank = i === lines.length - 1 || lines[i + 1].trim().length > 0;
+        if (isMissingTopBlank || isMissingBottomBlank) {
+          onError({
+            lineNumber: i + 1,
+            detail: `Before: ${isMissingTopBlank ? "missing" : "present"}, After: ${isMissingBottomBlank ? "missing" : "present"}`,
+          });
+        }
+      }
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
 						"type",
 						"never"
 					],
-					"default": "save",
+					"default": "type",
 					"markdownDescription": "Run the markdown linter on save (`save`), on type (`type`), or never (`never`)."
 				},
 				"quartoWizard.log.level": {

--- a/package.json
+++ b/package.json
@@ -323,6 +323,11 @@
 					"markdownDescription": "The level of logging to use. `error` to only log errors, `warn` to log warnings and errors, `info` to log info, warnings, and errors, `debug` to log everything."
 				}
 			}
+		},
+		"configurationDefaults": {
+			"markdownlint.customRules": [
+				"{mcanouil.quarto-wizard}/markdownlint-rules/001-blanks-around-fenced-divs.js"
+			]
 		}
 	}
 }

--- a/src/utils/activate.ts
+++ b/src/utils/activate.ts
@@ -54,10 +54,9 @@ export async function activateExtensions(extensions: string[], context: vscode.E
 		const extension = await vscode.extensions.getExtension(extensionId);
 		if (extension) {
 			if (!extension.isActive) {
-				console.log(`Activating ${extensionId}...`);
 				await extension.activate();
+				QW_LOG.appendLine(`${extensionId} activated.`);
 			}
-			QW_LOG.appendLine(`${extensionId} activated.`);
 		} else {
 			QW_LOG.appendLine(`Failed to activate ${extensionId}.`);
 			await promptInstallExtension(extensionId, context);


### PR DESCRIPTION
Introduce custom markdownlint rules for fenced divs, set linting to "on type" by default, and enhance logging by removing unnecessary console statements. Update the changelog to reflect these changes.