### PR TITLE
feat: Implement workspace folder selection utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@types/js-yaml": "^4.0.9",
 				"@types/node": "^22.13.9",
 				"@types/semver": "^7.5.8",
-				"@types/vscode": "^1.98.0",
+				"@types/vscode": "^1.96.0",
 				"@vscode/vsce": "^3.2.2",
 				"eslint": "^9.21.0",
 				"eslint-plugin-tsdoc": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@types/js-yaml": "^4.0.9",
 		"@types/node": "^22.13.9",
 		"@types/semver": "^7.5.8",
-		"@types/vscode": "^1.98.0",
+		"@types/vscode": "^1.96.0",
 		"@vscode/vsce": "^3.2.2",
 		"eslint": "^9.21.0",
 		"eslint-plugin-tsdoc": "^0.4.0",

--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -6,6 +6,7 @@ import { getQuartoPath, checkQuartoPath, installQuartoExtensionSource } from "..
 import { askTrustAuthors, askConfirmInstall } from "../utils/ask";
 import { getExtensionsDetails } from "../utils/extensionDetails";
 import { ExtensionQuickPickItem, showExtensionQuickPick } from "../ui/extensionsQuickPick";
+import { selectWorkspaceFolder } from "../utils/workspace";
 
 /**
  * Installs the selected Quarto extensions.
@@ -13,10 +14,10 @@ import { ExtensionQuickPickItem, showExtensionQuickPick } from "../ui/extensions
  * @param selectedExtensions - The extensions selected by the user for installation.
  */
 async function installQuartoExtensions(selectedExtensions: readonly ExtensionQuickPickItem[]) {
-	if (!vscode.workspace.workspaceFolders) {
+	const workspaceFolder = await selectWorkspaceFolder();
+	if (!workspaceFolder) {
 		return;
 	}
-	const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 	const mutableSelectedExtensions: ExtensionQuickPickItem[] = [...selectedExtensions];
 
 	if ((await askTrustAuthors()) !== 0) return;

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -7,6 +7,7 @@ import { logMessage, showLogsCommand } from "../utils/log";
 import { ExtensionData, findQuartoExtensions, readExtensions } from "../utils/extensions";
 import { removeQuartoExtension, installQuartoExtensionSource } from "../utils/quarto";
 import { getExtensionsDetails } from "../utils/extensionDetails";
+import { selectWorkspaceFolder } from "../utils/workspace";
 
 /**
  * Represents a tree item for a Quarto extension.
@@ -183,11 +184,11 @@ export class ExtensionsInstalled {
 	private treeDataProvider!: QuartoExtensionTreeDataProvider;
 
 	private async initialise(context: vscode.ExtensionContext) {
-		if (!vscode.workspace.workspaceFolders) {
+		const workspaceFolder = await selectWorkspaceFolder();
+		if (!workspaceFolder) {
 			return;
 		}
 
-		const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 		this.treeDataProvider = new QuartoExtensionTreeDataProvider(workspaceFolder);
 		const view = vscode.window.createTreeView("quartoWizard.extensionsInstalled", {
 			treeDataProvider: this.treeDataProvider,

--- a/src/utils/handleUri.ts
+++ b/src/utils/handleUri.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
-import { showLogsCommand, logMessage } from "../utils/log";
 import { installQuartoExtensionSource } from "./quarto";
+import { showLogsCommand, logMessage } from "../utils/log";
+import { selectWorkspaceFolder } from "../utils/workspace";
 
 /**
  * Handle the URI passed to the extension.
@@ -12,10 +13,10 @@ import { installQuartoExtensionSource } from "./quarto";
 export async function handleUri(uri: vscode.Uri) {
 	if (uri.path === "/install") {
 		const repo = new URLSearchParams(uri.query).get("repo");
-		if (!repo || !vscode.workspace.workspaceFolders) {
+		const workspaceFolder = await selectWorkspaceFolder();
+		if (!repo || !workspaceFolder) {
 			return;
 		}
-		const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 		const installWorkspace = await vscode.window.showInformationMessage(
 			`Do you confirm the installation of "${repo}" extension?`,
 			{ modal: true },

--- a/src/utils/quarto.ts
+++ b/src/utils/quarto.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { logMessage } from "./log";
 import { findModifiedExtensions, getMtimeExtensions, removeExtension } from "./extensions";
+import { selectWorkspaceFolder } from "./workspace";
 
 let cachedQuartoPath: string | undefined;
 
@@ -82,11 +83,11 @@ export async function checkQuartoVersion(quartoPath: string | undefined): Promis
  */
 export async function installQuartoExtension(extension: string): Promise<boolean> {
 	logMessage(`Installing ${extension} ...`, "info");
+	const workspaceFolder = await selectWorkspaceFolder();
 	return new Promise((resolve) => {
-		if (!vscode.workspace.workspaceFolders) {
+		if (!workspaceFolder) {
 			return;
 		}
-		const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 		const quartoPath = getQuartoPath();
 		checkQuartoPath(quartoPath);
 		const command = `${quartoPath} add ${extension} --no-prompt`;
@@ -149,10 +150,10 @@ export async function installQuartoExtensionSource(extension: string, workspaceF
  */
 export async function removeQuartoExtension(extension: string): Promise<boolean> {
 	logMessage(`Removing ${extension} ...`, "info");
-	if (!vscode.workspace.workspaceFolders) {
+	const workspaceFolder = await selectWorkspaceFolder();
+	if (!workspaceFolder) {
 		return false;
 	}
-	const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
 	const status = await removeExtension(extension, path.join(workspaceFolder, "_extensions"));
 	return status;
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,0 +1,26 @@
+import * as vscode from "vscode";
+
+/**
+ * Prompts the user to select a workspace folder if multiple workspace folders are detected.
+ *
+ * @returns {Promise<string | undefined>} - The selected workspace folder path or undefined if no selection is made.
+ */
+export async function selectWorkspaceFolder(): Promise<string | undefined> {
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		return undefined;
+	}
+
+	if (workspaceFolders.length === 1) {
+		return workspaceFolders[0].uri.fsPath;
+	}
+
+	const selectedFolder = await vscode.window.showQuickPick(
+		workspaceFolders.map((folder) => folder.name),
+		{
+			placeHolder: "Select a workspace folder",
+		}
+	);
+
+	return selectedFolder ? workspaceFolders.find((folder) => folder.name === selectedFolder)?.uri.fsPath : undefined;
+}


### PR DESCRIPTION
Add a utility function to prompt users for workspace folder selection when multiple folders are detected. This enhancement improves user experience by ensuring the correct workspace folder is selected for operations involving Quarto extensions.

First step towards #88