### PR TITLE
feat: add support for multi-root workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- feat: Implement workspace folder selection utility ([#100](https://github.com/mcanouil/quarto-wizard/issues/100)).
+- feat: add support for multi-root workspaces ([#101](https://github.com/mcanouil/quarto-wizard/issues/101)).
+- feat: implement workspace folder selection utility ([#100](https://github.com/mcanouil/quarto-wizard/issues/100)).
 
 ## 0.14.2 (2025-03-06)
 

--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -13,11 +13,7 @@ import { selectWorkspaceFolder } from "../utils/workspace";
  *
  * @param selectedExtensions - The extensions selected by the user for installation.
  */
-async function installQuartoExtensions(selectedExtensions: readonly ExtensionQuickPickItem[]) {
-	const workspaceFolder = await selectWorkspaceFolder();
-	if (!workspaceFolder) {
-		return;
-	}
+async function installQuartoExtensions(selectedExtensions: readonly ExtensionQuickPickItem[], workspaceFolder: string) {
 	const mutableSelectedExtensions: ExtensionQuickPickItem[] = [...selectedExtensions];
 
 	if ((await askTrustAuthors()) !== 0) return;
@@ -104,10 +100,8 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
  * @param context - The extension context.
  */
 export async function installQuartoExtensionCommand(context: vscode.ExtensionContext) {
-	if (!vscode.workspace.workspaceFolders) {
-		const message = `Please open a workspace/folder to install Quarto extensions.`;
-		logMessage(message, "error");
-		vscode.window.showErrorMessage(`${message} ${showLogsCommand()}.`);
+	const workspaceFolder = await selectWorkspaceFolder();
+	if (!workspaceFolder) {
 		return;
 	}
 
@@ -122,7 +116,7 @@ export async function installQuartoExtensionCommand(context: vscode.ExtensionCon
 	const selectedExtensions = await showExtensionQuickPick(extensionsList, recentlyInstalled);
 
 	if (selectedExtensions.length > 0) {
-		await installQuartoExtensions(selectedExtensions);
+		await installQuartoExtensions(selectedExtensions, workspaceFolder);
 		const selectedIDs = selectedExtensions.map((ext) => ext.id);
 		const updatedRecentlyInstalled = [...selectedIDs, ...recentlyInstalled.filter((ext) => !selectedIDs.includes(ext))];
 		await context.globalState.update(QW_RECENTLY_INSTALLED, updatedRecentlyInstalled.slice(0, 5));


### PR DESCRIPTION
Add support for multi-root workspaces to enhance user experience. Update the installation command to accept a workspace folder as a parameter, ensuring proper functionality in multi-root scenarios. Include a changelog entry for the new feature.

Fixes #88