### PR TITLE
ci: set explicit permissions in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,12 @@ on:
       - "package.json"
       - "package-lock.json"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.action }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set explicit permissions and concurrency settings in the CI workflow to enhance control and efficiency during builds.