### PR TITLE
fix: activate `markdownlint` extension earlier to avoid linting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: activate `markdownlint` extension earlier to avoid linting issues.
+- fix: tweak `markdownlint` extension activation and trigger to avoid linting issues.
 
 ## 0.15.0 (2025-03-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: activate `markdownlint` extension earlier to avoid linting issues.
+
 ## 0.15.0 (2025-03-09)
 
 - feat: add support for multi-root workspaces ([#102](https://github.com/mcanouil/quarto-wizard/issues/102)).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,8 @@ export const QW_EXTENSIONS_CACHE = "quarto_wizard_extensions";
  * Cache duration for the Quarto extensions JSON (default to 1 hour).
  */
 export const QW_EXTENSIONS_CACHE_TIME = 1 * 60 * 60 * 1000;
+
+/**
+ * Markdown Lint extension identifier.
+ */
+export const kMarkDownLintExtension = "DavidAnson.vscode-markdownlint";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { QW_LOG, QW_RECENTLY_INSTALLED, kMarkDownLintExtension } from "./constants";
+import { QW_LOG, QW_RECENTLY_INSTALLED } from "./constants";
 import { showLogsCommand, logMessage } from "./utils/log";
 import { installQuartoExtensionCommand } from "./commands/installQuartoExtension";
 import { newQuartoReprexCommand } from "./commands/newQuartoReprex";
@@ -7,7 +7,6 @@ import { ExtensionsInstalled } from "./ui/extensionsInstalled";
 import { getExtensionsDetails } from "./utils/extensionDetails";
 import { lint } from "./utils/lint";
 import { handleUri } from "./utils/handleUri";
-import { activateExtensions } from "./utils/activate";
 
 /**
  * This method is called when the extension is activated.
@@ -19,9 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand("quartoWizard.showOutput", () => QW_LOG.show()));
 	QW_LOG.appendLine("Quarto Wizard, your magical assistant, is now active!");
 
-	activateExtensions([kMarkDownLintExtension], context);
-
-	lint();
+	lint(context);
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("quartoWizard.clearRecentlyInstalled", () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { QW_LOG, QW_RECENTLY_INSTALLED } from "./constants";
+import { QW_LOG, QW_RECENTLY_INSTALLED, kMarkDownLintExtension } from "./constants";
 import { showLogsCommand, logMessage } from "./utils/log";
 import { installQuartoExtensionCommand } from "./commands/installQuartoExtension";
 import { newQuartoReprexCommand } from "./commands/newQuartoReprex";
@@ -7,6 +7,7 @@ import { ExtensionsInstalled } from "./ui/extensionsInstalled";
 import { getExtensionsDetails } from "./utils/extensionDetails";
 import { lint } from "./utils/lint";
 import { handleUri } from "./utils/handleUri";
+import { activateExtensions } from "./utils/activate";
 
 /**
  * This method is called when the extension is activated.
@@ -17,6 +18,10 @@ import { handleUri } from "./utils/handleUri";
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand("quartoWizard.showOutput", () => QW_LOG.show()));
 	QW_LOG.appendLine("Quarto Wizard, your magical assistant, is now active!");
+
+	activateExtensions([kMarkDownLintExtension], context);
+
+	lint();
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("quartoWizard.clearRecentlyInstalled", () => {
@@ -40,8 +45,6 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	new ExtensionsInstalled(context);
-
-	lint(context);
 
 	vscode.window.registerUriHandler({ handleUri });
 }

--- a/src/utils/lint.ts
+++ b/src/utils/lint.ts
@@ -1,8 +1,5 @@
 import * as vscode from "vscode";
-import { QW_LOG } from "../constants";
-import { activateExtensions } from "./activate";
-
-const kMarkDownLintExtension = "DavidAnson.vscode-markdownlint";
+import { QW_LOG, kMarkDownLintExtension } from "../constants";
 
 /**
  * Lints the currently active text editor if the document language is "quarto".
@@ -77,11 +74,10 @@ function lintOnEvent(lintOn: string) {
  *
  * @param context - The extension context provided by VS Code.
  */
-export function lint(context: vscode.ExtensionContext) {
+export function lint() {
 	const config = vscode.workspace.getConfiguration("quartoWizard.lint", null);
 	const lintOn = config.get<string>("trigger") || "never";
 	if (vscode.window.activeTextEditor?.document.languageId === "quarto" && lintOn !== "never") {
-		activateExtensions([kMarkDownLintExtension], context);
 		lintOnEvent(lintOn);
 	}
 }

--- a/src/utils/lint.ts
+++ b/src/utils/lint.ts
@@ -1,5 +1,14 @@
 import * as vscode from "vscode";
 import { QW_LOG, kMarkDownLintExtension } from "../constants";
+import { activateExtensions } from "./activate";
+
+/**
+ * Toggle markdown linting for the currently active text editor.
+ */
+export function toggleLinting() {
+	vscode.commands.executeCommand("markdownlint.toggleLinting");
+	vscode.commands.executeCommand("markdownlint.toggleLinting"); // Toggle twice to ensure linting is enabled
+}
 
 /**
  * Lints the currently active text editor if the document language is "quarto".
@@ -20,10 +29,7 @@ function triggerLint() {
 	if (editor && editor.document.languageId === "quarto") {
 		vscode.languages
 			.setTextDocumentLanguage(editor.document, "markdown")
-			.then(() => {
-				vscode.commands.executeCommand("markdownlint.toggleLinting");
-				vscode.commands.executeCommand("markdownlint.toggleLinting"); // Toggle twice to ensure linting is enabled
-			})
+			.then(toggleLinting)
 			.then(() => {
 				vscode.languages.setTextDocumentLanguage(editor.document, "quarto");
 			});
@@ -74,10 +80,12 @@ function lintOnEvent(lintOn: string) {
  *
  * @param context - The extension context provided by VS Code.
  */
-export function lint() {
+export function lint(context: vscode.ExtensionContext) {
 	const config = vscode.workspace.getConfiguration("quartoWizard.lint", null);
 	const lintOn = config.get<string>("trigger") || "never";
 	if (vscode.window.activeTextEditor?.document.languageId === "quarto" && lintOn !== "never") {
+		activateExtensions([kMarkDownLintExtension], context);
+		toggleLinting();
 		lintOnEvent(lintOn);
 	}
 }


### PR DESCRIPTION
Activate the `markdownlint` extension during the extension's activation phase to prevent linting issues in Quarto documents. This change ensures that linting occurs seamlessly without delays or errors.