### PR TITLE
refactor: disable "blanks-around-fenced-divs" rule by default and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: disable "blanks-around-fenced-divs" rule by default.
+- docs: add a note about the "blanks-around-fenced-divs" rule in the README.
+
 ## 0.15.1 (2025-03-10)
 
 - fix: tweak `markdownlint` extension activation and trigger to avoid linting issues.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ In the context of Quarto, it's recommended to disable the following rule in your
 
 See the [`markdownlint` README](https://github.com/DavidAnson/vscode-markdownlint?tab=readme-ov-file) for more information.
 
+#### Custom Markdown Linting Rules
+
+- `QMD001` / `blanks-around-fenced-divs`: Ensure there are no blank lines around [fenced divs](https://pandoc.org/MANUAL.html#extension-fenced_divs) delimiters.
+
+  ```json
+  {
+    "markdownlint.config": {
+      "blanks-around-fenced-divs": true
+    }
+  }
+  ```
+
 ## Development
 
 1. Clone the repository:

--- a/package.json
+++ b/package.json
@@ -325,6 +325,9 @@
 			}
 		},
 		"configurationDefaults": {
+			"markdownlint.config": {
+				"blanks-around-fenced-divs": false
+			},
 			"markdownlint.customRules": [
 				"{mcanouil.quarto-wizard}/markdownlint-rules/001-blanks-around-fenced-divs.js"
 			]


### PR DESCRIPTION
Disable the "blanks-around-fenced-divs" rule by default in the configuration to improve user experience. Update the README to include a note about this rule and provide guidance on its usage. Reflect these changes in the changelog.