### PR TITLE
refactor(src/utils/workspace.ts): use `vscode.WorkspaceFolderPickOptions()` for workspace folder selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: disable "blanks-around-fenced-divs" rule by default.
+- refactor(src/utils/workspace.ts): use `vscode.WorkspaceFolderPickOptions()` for workspace folder selection.
 - docs: add a note about the "blanks-around-fenced-divs" rule in the README.
 
 ## 0.15.1 (2025-03-10)

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -15,12 +15,12 @@ export async function selectWorkspaceFolder(): Promise<string | undefined> {
 		return workspaceFolders[0].uri.fsPath;
 	}
 
-	const selectedFolder = await vscode.window.showQuickPick(
-		workspaceFolders.map((folder) => folder.name),
-		{
-			placeHolder: "Select a workspace folder",
-		}
-	);
+	const options: vscode.WorkspaceFolderPickOptions = {
+		placeHolder: "Select a workspace folder",
+		ignoreFocusOut: true,
+	};
 
-	return selectedFolder ? workspaceFolders.find((folder) => folder.name === selectedFolder)?.uri.fsPath : undefined;
+	const selectedFolder = await vscode.window.showWorkspaceFolderPick(options);
+
+	return selectedFolder?.uri.fsPath;
 }


### PR DESCRIPTION
Enhance the workspace folder selection process by implementing the native VSCode API `vscode.WorkspaceFolderPickOptions()`.