### PR TITLE
feat: add a welcome view in the Quarto Wizard Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: add a welcome view in the Quarto Wizard Explorer.
 - fix: disable "blanks-around-fenced-divs" rule by default.
 - refactor(src/utils/workspace.ts): use `vscode.WorkspaceFolderPickOptions()` for workspace folder selection.
 - docs: add a note about the "blanks-around-fenced-divs" rule in the README.

--- a/package.json
+++ b/package.json
@@ -252,6 +252,12 @@
 				}
 			]
 		},
+		"viewsWelcome": [
+			{
+				"view": "quartoWizard.extensionsInstalled",
+				"contents": "No Quarto extensions installed ([browse extensions](https://m.canouil.dev/quarto-extensions/)).\n[Install Extension(s)](command:quartoWizard.installExtension)\nTo learn more about Quarto and Quarto extensions [read the documentation](https://quarto.org/)."
+			}
+		],
 		"views": {
 			"quarto-wizard-explorer": [
 				{

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -100,20 +100,25 @@ class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<Workspa
 	}
 
 	private getWorkspaceFolderItems(): WorkspaceFolderTreeItem[] {
-		return this.workspaceFolders.map((folder) => new WorkspaceFolderTreeItem(folder.name, folder.uri.fsPath));
+		return this.workspaceFolders
+			.filter((folder) => {
+				const folderData = this.extensionsDataByFolder[folder.uri.fsPath] || {};
+				return Object.keys(folderData).length > 0;
+			})
+			.map((folder) => new WorkspaceFolderTreeItem(folder.name, folder.uri.fsPath));
 	}
 
 	private getExtensionItems(workspacePath: string): ExtensionTreeItem[] {
 		const folderData = this.extensionsDataByFolder[workspacePath] || {};
 		if (Object.keys(folderData).length === 0) {
 			return [
-				new ExtensionTreeItem(
-					"No extensions installed.",
-					vscode.TreeItemCollapsibleState.None,
-					workspacePath,
-					undefined,
-					"info"
-				),
+				// new ExtensionTreeItem(
+				// 	"No extensions installed.",
+				// 	vscode.TreeItemCollapsibleState.None,
+				// 	workspacePath,
+				// 	undefined,
+				// 	"info"
+				// ),
 			];
 		}
 


### PR DESCRIPTION
Introduce a welcome view in the Quarto Wizard Explorer to inform users about the absence of installed Quarto extensions and provide links for installation and documentation. This enhancement improves user experience by guiding new users effectively.