### PR TITLE
feat: handle empty workspace(s) in the explorer view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: add a welcome view in the Quarto Wizard Explorer.
+- feat: handle empty workspace(s) in the explorer view.
 - fix: disable "blanks-around-fenced-divs" rule by default.
 - refactor(src/utils/workspace.ts): use `vscode.WorkspaceFolderPickOptions()` for workspace folder selection.
 - docs: add a note about the "blanks-around-fenced-divs" rule in the README.

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -100,6 +100,11 @@ class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<Workspa
 	}
 
 	private getWorkspaceFolderItems(): WorkspaceFolderTreeItem[] {
+		if (this.workspaceFolders.length > 1) {
+			return this.workspaceFolders.map((folder) => {
+				return new WorkspaceFolderTreeItem(folder.name, folder.uri.fsPath);
+			});
+		}
 		return this.workspaceFolders
 			.filter((folder) => {
 				const folderData = this.extensionsDataByFolder[folder.uri.fsPath] || {};
@@ -112,13 +117,13 @@ class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<Workspa
 		const folderData = this.extensionsDataByFolder[workspacePath] || {};
 		if (Object.keys(folderData).length === 0) {
 			return [
-				// new ExtensionTreeItem(
-				// 	"No extensions installed.",
-				// 	vscode.TreeItemCollapsibleState.None,
-				// 	workspacePath,
-				// 	undefined,
-				// 	"info"
-				// ),
+				new ExtensionTreeItem(
+					"No extensions installed.",
+					vscode.TreeItemCollapsibleState.None,
+					workspacePath,
+					undefined,
+					"info"
+				),
 			];
 		}
 


### PR DESCRIPTION
Enhance the explorer view to properly manage and display empty workspaces, improving user experience when no extensions are installed.