### PR TITLE
fix: GitHub icon / "open source" visibility for tree elements without source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: don't show "Open Source" button for tree element with no "source".
+- fix: GitHub icon / "open source" visibility for tree elements without source.
 
 ## 0.16.0 (2025-03-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: don't show "Open Source" button for tree element with no "source".
+
 ## 0.16.0 (2025-03-15)
 
 ## 0.15.2 (2025-03-12)

--- a/package.json
+++ b/package.json
@@ -221,12 +221,12 @@
 				},
 				{
 					"command": "quartoWizard.extensionsInstalled.remove",
-					"when": "view == quartoWizard.extensionsInstalled && (viewItem == quartoExtensionItem || viewItem == quartoExtensionItemOutdated)",
+					"when": "view == quartoWizard.extensionsInstalled && (viewItem == quartoExtensionItem || viewItem == quartoExtensionItemOutdated || viewItem == quartoExtensionItemNoSource)",
 					"group": "inline@3"
 				},
 				{
 					"command": "quartoWizard.extensionsInstalled.openSource",
-					"when": "view == quartoWizard.extensionsInstalled && (viewItem == quartoExtensionItem || viewItem == quartoExtensionItemOutdated)",
+					"when": "view == quartoWizard.extensionsInstalled && (viewItem == quartoExtensionItem || viewItem == quartoExtensionItemOutdated) && viewItem != quartoExtensionItemNoSource",
 					"group": "inline@4"
 				}
 			],

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -39,14 +39,18 @@ class ExtensionTreeItem extends vscode.TreeItem {
 		icon?: string,
 		latestVersion?: string
 	) {
+		super(label, collapsibleState);
 		const needsUpdate = latestVersion !== undefined;
 		let contextValue = "quartoExtensionItemValues";
 		if (needsUpdate) {
 			contextValue = "quartoExtensionItemOutdated";
 		} else if (data) {
-			contextValue = "quartoExtensionItem";
+			if (!this.data?.source) {
+				contextValue = "quartoExtensionItemNoSource";
+			} else {
+				contextValue = "quartoExtensionItem";
+			}
 		}
-		super(label, collapsibleState);
 		this.tooltip = `${this.label}`;
 		this.description = this.data ? `${this.data.version}${needsUpdate ? ` (latest: ${latestVersion})` : ""}` : "";
 		this.contextValue = contextValue;


### PR DESCRIPTION
Remove the display of the GitHub icon for tree elements that do not have a source. This change prevents confusion for users when the icon is not functional, as it indicates a lack of installation via Quarto Wizard.

Fixes #114