### PR TITLE
fix: correct typo in short title of the installExtension command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: correct typo in short title of the `quartoWizard.installExtension` command.
+
 ## 0.16.2 (2025-03-22)
 
 - refactor: update to reflect changes in <https://github.com/mcanouil/quarto-extensions>.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 			{
 				"command": "quartoWizard.installExtension",
 				"title": "Install Extension(s)",
-				"shortTitle": "Refresh",
+				"shortTitle": "Install",
 				"icon": "$(add)",
 				"category": "Quarto Wizard"
 			},


### PR DESCRIPTION
Update the short title from "Refresh" to "Install" for improved clarity and accuracy in the Quarto Wizard interface. Document the change in the changelog.