### PR TITLE
feat: Support extension tags in default Quarto installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat: enhance URI handling for Quarto extensions.
 - feat: enhance Quarto extension installation and template handling.
 - feat: documentation for Quarto commands.
+- feat: support extension tags in default Quarto installation.
 
 ## 0.17.0 (2025-03-31)
 

--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -47,7 +47,12 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
 					increment: (1 / (totalExtensions + 1)) * 100,
 				});
 
-				const success = await installQuartoExtensionSource(selectedExtension.id, workspaceFolder);
+				let extensionSource = selectedExtension.id;
+				if (selectedExtension.tag) {
+					extensionSource = `${selectedExtension.id}@${selectedExtension.tag}`;
+				}
+
+				const success = await installQuartoExtensionSource(extensionSource, workspaceFolder);
 				// Once source is supported in _extension.yml, the above line can be replaced with the following line
 				// const success = await installQuartoExtension(extension);
 				if (success) {

--- a/src/ui/extensionsQuickPick.ts
+++ b/src/ui/extensionsQuickPick.ts
@@ -7,6 +7,7 @@ import { ExtensionDetails } from "../utils/extensionDetails";
 export interface ExtensionQuickPickItem extends vscode.QuickPickItem {
 	url?: string;
 	id?: string;
+	tag?: string;
 	template?: boolean;
 	templateContent?: string;
 }
@@ -29,6 +30,7 @@ export function createExtensionItems(extensions: ExtensionDetails[]): ExtensionQ
 		],
 		url: ext.html_url,
 		id: ext.id,
+		tag: ext.tag,
 		template: ext.template,
 		templateContent: ext.templateContent,
 	}));


### PR DESCRIPTION
Enable the default installation of Quarto extensions to use specified tags when available. This enhancement improves the installation process by ensuring that the latest tagged version of an extension is used, aligning with user expectations and enhancing functionality.

Fixes #120