### PR TITLE
fix: strip tag from source URL in `/use?repo=<repository>` handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: strip tag from source URL in `/use?repo=<repository>` handler
+
 ## 0.18.0 (2025-04-03)
 
 - feat: add `/use?repo=<repository>` URI handler for installing Quarto extensions templates from the browser.

--- a/src/utils/handleUri.ts
+++ b/src/utils/handleUri.ts
@@ -72,13 +72,10 @@ export async function handleUriInstall(uri: vscode.Uri) {
  * The function installs the specified extension and then opens its template for immediate use.
  */
 export async function handleUriUse(uri: vscode.Uri, context: vscode.ExtensionContext) {
-	const repo = new URLSearchParams(uri.query).get("repo");
-	const workspaceFolder = await selectWorkspaceFolder();
-	if (!repo || !workspaceFolder) {
-		return;
-	}
 	await handleUriInstall(uri);
 	const extensionsList = await getExtensionsDetails(context);
+	const repoSource = new URLSearchParams(uri.query).get("repo");
+	const repo = repoSource?.replace(/@.*$/, "");
 	const matchingExtension = extensionsList.find((ext: ExtensionDetails) => ext.id === repo);
 	if (!matchingExtension) {
 		const message = `Extension "${repo}" not found.`;


### PR DESCRIPTION
Improve the user authentication process by addressing edge cases that caused failures.