### PR TITLE
fix: handle undefined source in repository field for extension tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: handle undefined source in repository field for extension tree
+
 ## 0.18.3 (2025-04-12)
 
 - chore: no usrer-facing changes.

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -100,7 +100,7 @@ function readYamlFile(filePath: string): ExtensionData | null {
 		version: data.version,
 		contributes: Object.keys(data.contributes).join(", "),
 		source: data.source,
-		repository: data.source.replace(/@.*$/, ""),
+		repository: data.source ? data.source.replace(/@.*$/, "") : undefined,
 	};
 }
 


### PR DESCRIPTION
Ensure the repository field is set to undefined when the source is not provided. This change prevents potential errors in extensions processing.

Fixes #139