### PR TITLE
feat: use error code from Quarto CLI >= 1.7.23 when installing an extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: use error code from Quarto CLI >= 1.7.23 when installing an extension.
+
 ## 0.18.4 (2025-04-17)
 
 - fix: handle undefined source in repository field for extension tree

--- a/src/utils/quarto.ts
+++ b/src/utils/quarto.ts
@@ -92,18 +92,27 @@ export async function installQuartoExtension(extension: string, workspaceFolder:
 		const command = `${quartoPath} add ${extension} --no-prompt`;
 
 		exec(command, { cwd: workspaceFolder }, (error, stdout, stderr) => {
-			if (stderr) {
-				logMessage(`${stderr}`, "error");
-				const isInstalled = stderr.includes("Extension installation complete");
-				if (isInstalled) {
-					resolve(true);
-				} else {
-					resolve(false);
-					return;
+			let isInstalled = false;
+			if (error) {
+				logMessage(`Error installing extension: ${error}`, "error");
+				if (stderr) {
+					logMessage(`${stderr}`, "error");
 				}
+			} else if (stderr) {
+				isInstalled = stderr.includes("Extension installation complete");
+				if (!isInstalled) {
+					logMessage(`${stderr}`, "error");
+				}
+			} else {
+				isInstalled = true;
 			}
-			vscode.commands.executeCommand("quartoWizard.extensionsInstalled.refresh");
-			resolve(true);
+
+			if (isInstalled) {
+				vscode.commands.executeCommand("quartoWizard.extensionsInstalled.refresh");
+				resolve(true);
+			} else {
+				resolve(false);
+			}
 		});
 	});
 }


### PR DESCRIPTION
Update the error handling in the Quarto extension installation process to align with the error codes introduced in Quarto 1.7.

Fixes #135