### PR TITLE
fix: ensure update check occurs after installing, updating, or removing an extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: ensure update check occurs after installing, updating, or removing an extension.
+
 ## 0.18.5 (2025-04-25)
 
 - feat: use error code from Quarto CLI >= 1.7.23 when installing an extension.

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -347,6 +347,7 @@ export class ExtensionsInstalled {
 				// const success = await installQuartoExtension(item.data?.repository ?? item.label);
 				if (success) {
 					vscode.window.showInformationMessage(`Extension "${item.label}" updated successfully.`);
+					this.treeDataProvider.checkUpdate(context, view);
 					this.treeDataProvider.forceRefresh();
 				} else {
 					if (!item.data?.repository) {
@@ -371,6 +372,7 @@ export class ExtensionsInstalled {
 				const success = await removeQuartoExtension(item.label, item.workspaceFolder);
 				if (success) {
 					vscode.window.showInformationMessage(`Extension "${item.label}" removed successfully.`);
+					this.treeDataProvider.checkUpdate(context, view);
 					this.treeDataProvider.forceRefresh();
 				} else {
 					vscode.window.showErrorMessage(`Failed to remove extension "${item.label}". ${showLogsCommand()}.`);


### PR DESCRIPTION
Ensure a check for updates and refresh are triggered after installing, updating, or removing an extension to ensure the UI is updated to avoid showing outdated information.