### PR TITLE
refactor: convert remaining forEach to functional array methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix: enable extensions caching with 30-minute TTL for improved performance and reduced network requests.
 - fix: migrate from `child_process.exec()` to `child_process.spawn()` for enhanced security and elimination of command injection risks.
 - fix: resolve promise properly when workspace folder is empty in `installQuartoExtension()` function.
+- refactor: Convert remaining forEach to functional array methods.
 - chore: polish code, comments, and documentation.
 - chore: update dependencies to latest versions.
 - chore: optimise `README.md` images.

--- a/src/commands/installQuartoExtension.ts
+++ b/src/commands/installQuartoExtension.ts
@@ -77,16 +77,12 @@ async function installQuartoExtensions(selectedExtensions: readonly ExtensionQui
 
 			if (installedExtensions.length > 0) {
 				logMessage(`Successfully installed extension${installedExtensions.length > 1 ? "s" : ""}:`, "info");
-				installedExtensions.forEach((ext) => {
-					logMessage(` - ${ext}`, "info");
-				});
+				installedExtensions.map((ext) => logMessage(` - ${ext}`, "info"));
 			}
 
 			if (failedExtensions.length > 0) {
 				logMessage(`Failed to install extension${failedExtensions.length > 1 ? "s" : ""}:`, "error");
-				failedExtensions.forEach((ext) => {
-					logMessage(` - ${ext}`, "error");
-				});
+				failedExtensions.map((ext) => logMessage(` - ${ext}`, "error"));
 				const message = [
 					"The following extension",
 					failedExtensions.length > 1 ? "s were" : " was",

--- a/src/utils/activate.ts
+++ b/src/utils/activate.ts
@@ -55,15 +55,19 @@ async function promptInstallExtension(extensionId: string, context: vscode.Exten
  */
 export async function activateExtensions(extensions: string[], context: vscode.ExtensionContext): Promise<void> {
 	await Promise.all(extensions.map(async (extensionId) => {
-		const extension = await vscode.extensions.getExtension(extensionId);
-		if (extension) {
-			if (!extension.isActive) {
-				await extension.activate();
-				QW_LOG.appendLine(`${extensionId} activated.`);
+		try {
+			const extension = vscode.extensions.getExtension(extensionId);
+			if (extension) {
+				if (!extension.isActive) {
+					await extension.activate();
+					QW_LOG.appendLine(`${extensionId} activated.`);
+				}
+			} else {
+				QW_LOG.appendLine(`Failed to activate ${extensionId}.`);
+				await promptInstallExtension(extensionId, context);
 			}
-		} else {
-			QW_LOG.appendLine(`Failed to activate ${extensionId}.`);
-			await promptInstallExtension(extensionId, context);
+		} catch (error) {
+			QW_LOG.appendLine(`Failed to activate ${extensionId}: ${error instanceof Error ? error.message : String(error)}`);
 		}
 	}));
 }

--- a/src/utils/activate.ts
+++ b/src/utils/activate.ts
@@ -54,7 +54,7 @@ async function promptInstallExtension(extensionId: string, context: vscode.Exten
  * @returns A promise that resolves when all extensions have been processed.
  */
 export async function activateExtensions(extensions: string[], context: vscode.ExtensionContext): Promise<void> {
-	extensions.forEach(async (extensionId) => {
+	await Promise.all(extensions.map(async (extensionId) => {
 		const extension = await vscode.extensions.getExtension(extensionId);
 		if (extension) {
 			if (!extension.isActive) {
@@ -65,5 +65,5 @@ export async function activateExtensions(extensions: string[], context: vscode.E
 			QW_LOG.appendLine(`Failed to activate ${extensionId}.`);
 			await promptInstallExtension(extensionId, context);
 		}
-	});
+	}));
 }


### PR DESCRIPTION
Convert remaining `forEach` loops to functional array methods for improved readability and performance.