### PR TITLE
test: Increase timeout for checkInternetConnection tests

### DIFF
--- a/src/test/suite/timeout.test.ts
+++ b/src/test/suite/timeout.test.ts
@@ -29,29 +29,29 @@ suite("Timeout Handling Test Suite", () => {
 	});
 
 	test("checkInternetConnection should succeed with valid URL and sufficient timeout", async function () {
-		this.timeout(10000);
+		this.timeout(15000);
 
-		// Test with a reliable URL and reasonable timeout
-		const result = await checkInternetConnection("https://httpbin.org/status/200", 5000);
+		// Test with GitHub (reliable URL used by the extension) with generous timeout
+		const result = await checkInternetConnection("https://github.com", 10000);
 
 		// Should return true for a valid, reachable URL
-		assert.strictEqual(result, true);
+		assert.strictEqual(result, true, "Expected github.com to be reachable");
 	});
 
 	test("timeout parameters should be properly passed", async function () {
 		this.timeout(5000);
 
-		// Test that timeout parameters are handled correctly
-		const shortTimeout = 100; // Very short timeout
+		// Test that timeout parameters are handled correctly with non-routable IP
+		const shortTimeout = 500; // Short but reliable timeout
 		const start = Date.now();
 
-		// Use a URL that should timeout with a very short timeout
-		const result = await checkInternetConnection("https://httpbin.org/delay/1", shortTimeout);
+		// Use a non-routable IP that will definitely timeout
+		const result = await checkInternetConnection("http://10.255.255.1", shortTimeout);
 		const elapsed = Date.now() - start;
 
 		// Should return false and respect the timeout
 		assert.strictEqual(result, false);
-		assert.ok(elapsed >= shortTimeout && elapsed < shortTimeout * 3,
+		assert.ok(elapsed >= shortTimeout && elapsed < shortTimeout * 2,
 			`Expected timeout around ${shortTimeout}ms, got ${elapsed}ms`);
 	});
 });


### PR DESCRIPTION
Adjust the timeout settings in the checkInternetConnection tests to ensure reliable execution, particularly when testing with external URLs and non-routable IPs. This change enhances the robustness of the tests by accommodating varying network conditions.