### PR TITLE
feat: add schema types, loading, and cache to core library

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -131,6 +131,23 @@ export class ManifestError extends QuartoWizardError {
 }
 
 /**
+ * Error when parsing a schema file fails.
+ */
+export class SchemaError extends QuartoWizardError {
+	/** Path to the schema file. */
+	readonly schemaPath?: string;
+
+	constructor(message: string, options?: { schemaPath?: string; cause?: unknown }) {
+		super(message, "SCHEMA_ERROR", {
+			suggestion: options?.schemaPath ? `Check the schema file at: ${options.schemaPath}` : undefined,
+			cause: options?.cause,
+		});
+		this.name = "SchemaError";
+		this.schemaPath = options?.schemaPath;
+	}
+}
+
+/**
  * Error when a version cannot be resolved.
  */
 export class VersionError extends QuartoWizardError {

--- a/packages/core/src/filesystem/index.ts
+++ b/packages/core/src/filesystem/index.ts
@@ -26,3 +26,14 @@ export {
 } from "./discovery.js";
 
 export { type WalkEntry, type WalkCallback, walkDirectory, collectFiles, copyDirectory, pathExists } from "./walk.js";
+
+export {
+	SCHEMA_FILENAMES,
+	type SchemaReadResult,
+	findSchemaFile,
+	parseSchemaFile,
+	parseSchemaContent,
+	readSchema,
+} from "./schema.js";
+
+export { SchemaCache } from "./schema-cache.js";

--- a/packages/core/src/filesystem/schema-cache.ts
+++ b/packages/core/src/filesystem/schema-cache.ts
@@ -1,0 +1,68 @@
+/**
+ * @title Schema Cache Module
+ * @description In-memory cache for parsed extension schemas.
+ *
+ * Provides lazy-loading schema caching without file watchers.
+ * File watching belongs in the VSCode extension layer.
+ *
+ * @module filesystem
+ */
+
+import type { ExtensionSchema } from "../types/schema.js";
+import { readSchema } from "./schema.js";
+
+/**
+ * Cache for parsed extension schemas.
+ * Schemas are loaded lazily on first access.
+ */
+export class SchemaCache {
+	private cache: Map<string, ExtensionSchema> = new Map();
+
+	/**
+	 * Get the schema for an extension directory.
+	 * Loads and caches the schema on first access.
+	 *
+	 * @param extensionDir - Path to the extension directory
+	 * @returns Parsed schema or null if no schema file exists
+	 */
+	get(extensionDir: string): ExtensionSchema | null {
+		if (this.cache.has(extensionDir)) {
+			return this.cache.get(extensionDir)!;
+		}
+
+		const result = readSchema(extensionDir);
+
+		if (!result) {
+			return null;
+		}
+
+		this.cache.set(extensionDir, result.schema);
+		return result.schema;
+	}
+
+	/**
+	 * Check whether a schema is cached for the given directory.
+	 *
+	 * @param extensionDir - Path to the extension directory
+	 * @returns True if a schema is cached
+	 */
+	has(extensionDir: string): boolean {
+		return this.cache.has(extensionDir);
+	}
+
+	/**
+	 * Invalidate the cached schema for a specific extension directory.
+	 *
+	 * @param extensionDir - Path to the extension directory
+	 */
+	invalidate(extensionDir: string): void {
+		this.cache.delete(extensionDir);
+	}
+
+	/**
+	 * Invalidate all cached schemas.
+	 */
+	invalidateAll(): void {
+		this.cache.clear();
+	}
+}

--- a/packages/core/src/filesystem/schema.ts
+++ b/packages/core/src/filesystem/schema.ts
@@ -1,0 +1,119 @@
+/**
+ * @title Schema Parsing Module
+ * @description Schema parsing for _schema.yml files.
+ *
+ * Provides functions to find, parse, and read Quarto extension schemas.
+ *
+ * @module filesystem
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+import type { ExtensionSchema, RawSchema } from "../types/schema.js";
+import { normaliseSchema } from "../types/schema.js";
+import { SchemaError } from "../errors.js";
+
+/** Supported schema file names. */
+export const SCHEMA_FILENAMES = ["_schema.yml", "_schema.yaml"] as const;
+
+/**
+ * Result of reading a schema file.
+ */
+export interface SchemaReadResult {
+	/** Parsed schema data. */
+	schema: ExtensionSchema;
+	/** Full path to the schema file. */
+	schemaPath: string;
+	/** Filename used (e.g., "_schema.yml"). */
+	filename: string;
+}
+
+/**
+ * Find the schema file in a directory.
+ *
+ * @param directory - Directory to search
+ * @returns Path to schema file or null if not found
+ */
+export function findSchemaFile(directory: string): string | null {
+	for (const filename of SCHEMA_FILENAMES) {
+		const schemaPath = path.join(directory, filename);
+		if (fs.existsSync(schemaPath)) {
+			return schemaPath;
+		}
+	}
+	return null;
+}
+
+/**
+ * Parse a schema file from a path.
+ *
+ * @param schemaPath - Full path to the schema file
+ * @returns Parsed schema
+ * @throws SchemaError if parsing fails
+ */
+export function parseSchemaFile(schemaPath: string): ExtensionSchema {
+	try {
+		const content = fs.readFileSync(schemaPath, "utf-8");
+		return parseSchemaContent(content, schemaPath);
+	} catch (error) {
+		if (error instanceof SchemaError) {
+			throw error;
+		}
+		throw new SchemaError(`Failed to read schema file: ${error instanceof Error ? error.message : String(error)}`, {
+			schemaPath,
+			cause: error,
+		});
+	}
+}
+
+/**
+ * Parse schema content from a YAML string.
+ *
+ * @param content - YAML content
+ * @param sourcePath - Source path for error messages (optional)
+ * @returns Parsed schema
+ * @throws SchemaError if parsing fails
+ */
+export function parseSchemaContent(content: string, sourcePath?: string): ExtensionSchema {
+	try {
+		const raw = yaml.load(content) as RawSchema;
+
+		if (!raw || typeof raw !== "object") {
+			throw new SchemaError("Schema file is empty or invalid", { schemaPath: sourcePath });
+		}
+
+		return normaliseSchema(raw);
+	} catch (error) {
+		if (error instanceof SchemaError) {
+			throw error;
+		}
+		throw new SchemaError(`Failed to parse schema: ${error instanceof Error ? error.message : String(error)}`, {
+			schemaPath: sourcePath,
+			cause: error,
+		});
+	}
+}
+
+/**
+ * Read a schema from a directory.
+ *
+ * @param directory - Directory containing the schema
+ * @returns SchemaReadResult or null if no schema found
+ */
+export function readSchema(directory: string): SchemaReadResult | null {
+	const schemaPath = findSchemaFile(directory);
+
+	if (!schemaPath) {
+		return null;
+	}
+
+	const schema = parseSchemaFile(schemaPath);
+	const filename = path.basename(schemaPath);
+
+	return {
+		schema,
+		schemaPath,
+		filename,
+	};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
 	NetworkError,
 	SecurityError,
 	ManifestError,
+	SchemaError,
 	VersionError,
 	CancellationError,
 	isQuartoWizardError,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -31,3 +31,15 @@ export {
 } from "./registry.js";
 
 export { type HttpHeader, type AuthConfig, type AuthConfigOptions, createAuthConfig, getAuthHeaders } from "./auth.js";
+
+export {
+	type CompletionSpec,
+	type FieldDescriptor,
+	type ShortcodeSchema,
+	type ExtensionSchema,
+	type RawSchema,
+	normaliseFieldDescriptor,
+	normaliseFieldDescriptorMap,
+	normaliseShortcodeSchema,
+	normaliseSchema,
+} from "./schema.js";

--- a/packages/core/src/types/schema.ts
+++ b/packages/core/src/types/schema.ts
@@ -1,0 +1,238 @@
+/**
+ * @title Schema Types Module
+ * @description Extension schema types for parsing _schema.yml files.
+ *
+ * Defines types for field descriptors, completion specs, shortcode schemas,
+ * and the overall extension schema structure.
+ *
+ * @module types
+ */
+
+/**
+ * Completion specification for a field.
+ * Describes how a field's value should be completed in an editor.
+ */
+export interface CompletionSpec {
+	/** Type of completion (e.g., "file", "value"). */
+	type?: string;
+	/** File extensions to filter (for file completions). */
+	extensions?: string[];
+	/** Placeholder text shown in the editor. */
+	placeholder?: string;
+	/** Static list of allowed values. */
+	values?: string[];
+	/** Whether completion values are dynamically resolved. */
+	dynamic?: boolean;
+	/** Source for dynamic completion values. */
+	source?: string;
+}
+
+/**
+ * Descriptor for a single field in an extension schema.
+ * Describes the type, constraints, and metadata for a configuration option.
+ */
+export interface FieldDescriptor {
+	/** Data type of the field (e.g., "string", "number", "boolean", "object", "array"). */
+	type?: string;
+	/** Whether the field is required. */
+	required?: boolean;
+	/** Default value for the field. */
+	default?: unknown;
+	/** Human-readable description of the field. */
+	description?: string;
+	/** Allowed values for the field. */
+	enum?: unknown[];
+	/** Whether enum matching is case-insensitive. */
+	enumCaseInsensitive?: boolean;
+	/** Regular expression pattern the value must match. */
+	pattern?: string;
+	/** Whether the pattern must match the entire value. */
+	patternExact?: boolean;
+	/** Minimum numeric value. */
+	min?: number;
+	/** Maximum numeric value. */
+	max?: number;
+	/** Minimum string length. */
+	minLength?: number;
+	/** Maximum string length. */
+	maxLength?: number;
+	/** Alternative names for the field. */
+	aliases?: string[];
+	/** Whether the field is deprecated. */
+	deprecated?: boolean | string;
+	/** Completion specification for the field. */
+	completion?: CompletionSpec;
+	/** Schema for array items when type is "array". */
+	items?: FieldDescriptor;
+	/** Schema for object properties when type is "object". */
+	properties?: Record<string, FieldDescriptor>;
+}
+
+/**
+ * Schema for a shortcode, including its arguments and attributes.
+ */
+export interface ShortcodeSchema {
+	/** Human-readable description of the shortcode. */
+	description?: string;
+	/** Positional arguments accepted by the shortcode. */
+	arguments?: Array<FieldDescriptor & { name: string }>;
+	/** Named attributes accepted by the shortcode. */
+	attributes?: Record<string, FieldDescriptor>;
+}
+
+/**
+ * Complete extension schema parsed from a _schema.yml file.
+ * All sections are optional and default to empty objects or arrays.
+ */
+export interface ExtensionSchema {
+	/** Options (top-level YAML keys) the extension accepts. */
+	options?: Record<string, FieldDescriptor>;
+	/** Shortcodes the extension provides. */
+	shortcodes?: Record<string, ShortcodeSchema>;
+	/** Format-specific options the extension supports. */
+	formats?: Record<string, Record<string, FieldDescriptor>>;
+	/** Project-level options the extension supports. */
+	projects?: Record<string, FieldDescriptor>;
+	/** Element-level attributes the extension supports. */
+	elementAttributes?: Record<string, FieldDescriptor>;
+}
+
+/**
+ * Raw schema data as parsed from YAML.
+ * Uses kebab-case keys matching the _schema.yml structure.
+ */
+export interface RawSchema {
+	options?: Record<string, unknown>;
+	shortcodes?: Record<string, unknown>;
+	formats?: Record<string, unknown>;
+	projects?: Record<string, unknown>;
+	"element-attributes"?: Record<string, unknown>;
+}
+
+/**
+ * Mapping of kebab-case YAML field descriptor keys to camelCase TypeScript keys.
+ */
+const KEBAB_TO_CAMEL: Record<string, string> = {
+	"enum-case-insensitive": "enumCaseInsensitive",
+	"pattern-exact": "patternExact",
+	"min-length": "minLength",
+	"max-length": "maxLength",
+};
+
+/**
+ * Normalise a raw field descriptor from YAML, converting kebab-case keys to camelCase.
+ *
+ * @param raw - Raw field descriptor object from YAML
+ * @returns Normalised FieldDescriptor
+ */
+export function normaliseFieldDescriptor(raw: Record<string, unknown>): FieldDescriptor {
+	const result: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(raw)) {
+		const camelKey = KEBAB_TO_CAMEL[key] ?? key;
+
+		if (camelKey === "items" && value && typeof value === "object" && !Array.isArray(value)) {
+			result[camelKey] = normaliseFieldDescriptor(value as Record<string, unknown>);
+		} else if (camelKey === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+			result[camelKey] = normaliseFieldDescriptorMap(value as Record<string, unknown>);
+		} else {
+			result[camelKey] = value;
+		}
+	}
+
+	return result as FieldDescriptor;
+}
+
+/**
+ * Normalise a map of field descriptors from YAML.
+ *
+ * @param raw - Raw object mapping field names to descriptors
+ * @returns Normalised map of FieldDescriptor objects
+ */
+export function normaliseFieldDescriptorMap(raw: Record<string, unknown>): Record<string, FieldDescriptor> {
+	const result: Record<string, FieldDescriptor> = {};
+
+	for (const [key, value] of Object.entries(raw)) {
+		if (value && typeof value === "object" && !Array.isArray(value)) {
+			result[key] = normaliseFieldDescriptor(value as Record<string, unknown>);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Normalise a raw shortcode schema from YAML.
+ *
+ * @param raw - Raw shortcode schema object from YAML
+ * @returns Normalised ShortcodeSchema
+ */
+export function normaliseShortcodeSchema(raw: Record<string, unknown>): ShortcodeSchema {
+	const result: ShortcodeSchema = {};
+
+	if (typeof raw["description"] === "string") {
+		result.description = raw["description"];
+	}
+
+	if (Array.isArray(raw["arguments"])) {
+		result.arguments = raw["arguments"].map((arg: unknown) => {
+			if (arg && typeof arg === "object" && !Array.isArray(arg)) {
+				const rawArg = arg as Record<string, unknown>;
+				const normalised = normaliseFieldDescriptor(rawArg);
+				return { ...normalised, name: String(rawArg["name"] ?? "") };
+			}
+			return { name: "" };
+		});
+	}
+
+	if (raw["attributes"] && typeof raw["attributes"] === "object" && !Array.isArray(raw["attributes"])) {
+		result.attributes = normaliseFieldDescriptorMap(raw["attributes"] as Record<string, unknown>);
+	}
+
+	return result;
+}
+
+/**
+ * Normalise a raw schema from YAML to an ExtensionSchema.
+ *
+ * @param raw - Raw schema data from YAML parsing
+ * @returns Normalised ExtensionSchema
+ */
+export function normaliseSchema(raw: RawSchema): ExtensionSchema {
+	const result: ExtensionSchema = {};
+
+	if (raw.options && typeof raw.options === "object") {
+		result.options = normaliseFieldDescriptorMap(raw.options);
+	}
+
+	if (raw.shortcodes && typeof raw.shortcodes === "object") {
+		const shortcodes: Record<string, ShortcodeSchema> = {};
+		for (const [key, value] of Object.entries(raw.shortcodes)) {
+			if (value && typeof value === "object" && !Array.isArray(value)) {
+				shortcodes[key] = normaliseShortcodeSchema(value as Record<string, unknown>);
+			}
+		}
+		result.shortcodes = shortcodes;
+	}
+
+	if (raw.formats && typeof raw.formats === "object") {
+		const formats: Record<string, Record<string, FieldDescriptor>> = {};
+		for (const [formatName, formatValue] of Object.entries(raw.formats)) {
+			if (formatValue && typeof formatValue === "object" && !Array.isArray(formatValue)) {
+				formats[formatName] = normaliseFieldDescriptorMap(formatValue as Record<string, unknown>);
+			}
+		}
+		result.formats = formats;
+	}
+
+	if (raw.projects && typeof raw.projects === "object") {
+		result.projects = normaliseFieldDescriptorMap(raw.projects);
+	}
+
+	const elementAttributes = raw["element-attributes"];
+	if (elementAttributes && typeof elementAttributes === "object") {
+		result.elementAttributes = normaliseFieldDescriptorMap(elementAttributes as Record<string, unknown>);
+	}
+
+	return result;
+}

--- a/packages/core/tests/filesystem/schema.test.ts
+++ b/packages/core/tests/filesystem/schema.test.ts
@@ -1,0 +1,610 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+	normaliseFieldDescriptor,
+	normaliseFieldDescriptorMap,
+	normaliseShortcodeSchema,
+	normaliseSchema,
+} from "../../src/types/schema.js";
+import {
+	findSchemaFile,
+	parseSchemaContent,
+	parseSchemaFile,
+	readSchema,
+} from "../../src/filesystem/schema.js";
+import { SchemaCache } from "../../src/filesystem/schema-cache.js";
+import { SchemaError } from "../../src/errors.js";
+
+describe("normaliseFieldDescriptor", () => {
+	it("passes through camelCase keys unchanged", () => {
+		const result = normaliseFieldDescriptor({
+			type: "string",
+			required: true,
+			description: "A test field",
+		});
+
+		expect(result.type).toBe("string");
+		expect(result.required).toBe(true);
+		expect(result.description).toBe("A test field");
+	});
+
+	it("converts kebab-case keys to camelCase", () => {
+		const result = normaliseFieldDescriptor({
+			"enum-case-insensitive": true,
+			"pattern-exact": true,
+			"min-length": 3,
+			"max-length": 50,
+		});
+
+		expect(result.enumCaseInsensitive).toBe(true);
+		expect(result.patternExact).toBe(true);
+		expect(result.minLength).toBe(3);
+		expect(result.maxLength).toBe(50);
+	});
+
+	it("normalises nested items descriptor", () => {
+		const result = normaliseFieldDescriptor({
+			type: "array",
+			items: {
+				type: "string",
+				"min-length": 1,
+			},
+		});
+
+		expect(result.items).toBeDefined();
+		expect(result.items!.type).toBe("string");
+		expect(result.items!.minLength).toBe(1);
+	});
+
+	it("normalises nested properties descriptors", () => {
+		const result = normaliseFieldDescriptor({
+			type: "object",
+			properties: {
+				name: { type: "string", "max-length": 100 },
+				count: { type: "number", min: 0 },
+			},
+		});
+
+		expect(result.properties).toBeDefined();
+		expect(result.properties!["name"].type).toBe("string");
+		expect(result.properties!["name"].maxLength).toBe(100);
+		expect(result.properties!["count"].type).toBe("number");
+		expect(result.properties!["count"].min).toBe(0);
+	});
+
+	it("handles enum and default values", () => {
+		const result = normaliseFieldDescriptor({
+			type: "string",
+			enum: ["left", "right", "center"],
+			default: "left",
+		});
+
+		expect(result.enum).toEqual(["left", "right", "center"]);
+		expect(result.default).toBe("left");
+	});
+
+	it("handles aliases and deprecated fields", () => {
+		const result = normaliseFieldDescriptor({
+			type: "string",
+			aliases: ["old-name"],
+			deprecated: "Use new-field instead",
+		});
+
+		expect(result.aliases).toEqual(["old-name"]);
+		expect(result.deprecated).toBe("Use new-field instead");
+	});
+
+	it("handles completion spec", () => {
+		const result = normaliseFieldDescriptor({
+			type: "string",
+			completion: {
+				type: "file",
+				extensions: [".lua"],
+			},
+		});
+
+		expect(result.completion).toBeDefined();
+		expect(result.completion!.type).toBe("file");
+		expect(result.completion!.extensions).toEqual([".lua"]);
+	});
+});
+
+describe("normaliseFieldDescriptorMap", () => {
+	it("normalises a map of field descriptors", () => {
+		const result = normaliseFieldDescriptorMap({
+			theme: { type: "string", "enum-case-insensitive": true },
+			count: { type: "number", min: 1, max: 100 },
+		});
+
+		expect(result["theme"].type).toBe("string");
+		expect(result["theme"].enumCaseInsensitive).toBe(true);
+		expect(result["count"].min).toBe(1);
+		expect(result["count"].max).toBe(100);
+	});
+
+	it("skips non-object entries", () => {
+		const result = normaliseFieldDescriptorMap({
+			valid: { type: "string" },
+			invalid: "not an object" as unknown as Record<string, unknown>,
+		});
+
+		expect(result["valid"]).toBeDefined();
+		expect(result["invalid"]).toBeUndefined();
+	});
+});
+
+describe("normaliseShortcodeSchema", () => {
+	it("normalises a shortcode with arguments and attributes", () => {
+		const result = normaliseShortcodeSchema({
+			description: "A test shortcode",
+			arguments: [
+				{ name: "src", type: "string", required: true },
+				{ name: "alt", type: "string" },
+			],
+			attributes: {
+				width: { type: "number", min: 0 },
+				caption: { type: "string", "max-length": 200 },
+			},
+		});
+
+		expect(result.description).toBe("A test shortcode");
+		expect(result.arguments).toHaveLength(2);
+		expect(result.arguments![0].name).toBe("src");
+		expect(result.arguments![0].required).toBe(true);
+		expect(result.attributes!["width"].min).toBe(0);
+		expect(result.attributes!["caption"].maxLength).toBe(200);
+	});
+
+	it("handles missing optional fields", () => {
+		const result = normaliseShortcodeSchema({});
+
+		expect(result.description).toBeUndefined();
+		expect(result.arguments).toBeUndefined();
+		expect(result.attributes).toBeUndefined();
+	});
+});
+
+describe("normaliseSchema", () => {
+	it("normalises all five sections", () => {
+		const result = normaliseSchema({
+			options: {
+				theme: { type: "string" },
+			},
+			shortcodes: {
+				img: { description: "Image shortcode" },
+			},
+			formats: {
+				html: {
+					toc: { type: "boolean", default: true },
+				},
+			},
+			projects: {
+				output: { type: "string" },
+			},
+			"element-attributes": {
+				width: { type: "number" },
+			},
+		});
+
+		expect(result.options).toBeDefined();
+		expect(result.options!["theme"].type).toBe("string");
+		expect(result.shortcodes).toBeDefined();
+		expect(result.shortcodes!["img"].description).toBe("Image shortcode");
+		expect(result.formats).toBeDefined();
+		expect(result.formats!["html"]["toc"].type).toBe("boolean");
+		expect(result.projects).toBeDefined();
+		expect(result.projects!["output"].type).toBe("string");
+		expect(result.elementAttributes).toBeDefined();
+		expect(result.elementAttributes!["width"].type).toBe("number");
+	});
+
+	it("returns empty object for empty schema", () => {
+		const result = normaliseSchema({});
+
+		expect(result.options).toBeUndefined();
+		expect(result.shortcodes).toBeUndefined();
+		expect(result.formats).toBeUndefined();
+		expect(result.projects).toBeUndefined();
+		expect(result.elementAttributes).toBeUndefined();
+	});
+});
+
+describe("parseSchemaContent", () => {
+	it("parses valid YAML with options", () => {
+		const yamlContent = `
+options:
+  theme:
+    type: string
+    enum:
+      - light
+      - dark
+    default: light
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.options).toBeDefined();
+		expect(schema.options!["theme"].type).toBe("string");
+		expect(schema.options!["theme"].enum).toEqual(["light", "dark"]);
+		expect(schema.options!["theme"].default).toBe("light");
+	});
+
+	it("parses valid YAML with shortcodes", () => {
+		const yamlContent = `
+shortcodes:
+  placeholder:
+    description: Generates placeholder images
+    arguments:
+      - name: width
+        type: number
+        required: true
+    attributes:
+      format:
+        type: string
+        enum:
+          - png
+          - jpg
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.shortcodes).toBeDefined();
+		expect(schema.shortcodes!["placeholder"].description).toBe("Generates placeholder images");
+		expect(schema.shortcodes!["placeholder"].arguments).toHaveLength(1);
+		expect(schema.shortcodes!["placeholder"].arguments![0].name).toBe("width");
+		expect(schema.shortcodes!["placeholder"].attributes!["format"].enum).toEqual(["png", "jpg"]);
+	});
+
+	it("parses kebab-case keys and normalises to camelCase", () => {
+		const yamlContent = `
+options:
+  name:
+    type: string
+    min-length: 1
+    max-length: 100
+    enum-case-insensitive: true
+    pattern-exact: false
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.options!["name"].minLength).toBe(1);
+		expect(schema.options!["name"].maxLength).toBe(100);
+		expect(schema.options!["name"].enumCaseInsensitive).toBe(true);
+		expect(schema.options!["name"].patternExact).toBe(false);
+	});
+
+	it("parses element-attributes section", () => {
+		const yamlContent = `
+element-attributes:
+  width:
+    type: number
+    min: 0
+  height:
+    type: number
+    min: 0
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.elementAttributes).toBeDefined();
+		expect(schema.elementAttributes!["width"].type).toBe("number");
+		expect(schema.elementAttributes!["height"].min).toBe(0);
+	});
+
+	it("parses formats section with nested format options", () => {
+		const yamlContent = `
+formats:
+  html:
+    toc:
+      type: boolean
+      default: true
+  pdf:
+    margin:
+      type: string
+      default: 1in
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.formats).toBeDefined();
+		expect(schema.formats!["html"]["toc"].type).toBe("boolean");
+		expect(schema.formats!["pdf"]["margin"].default).toBe("1in");
+	});
+
+	it("throws SchemaError on empty content", () => {
+		expect(() => parseSchemaContent("")).toThrow(SchemaError);
+	});
+
+	it("throws SchemaError on invalid YAML", () => {
+		expect(() => parseSchemaContent("title: [invalid")).toThrow(SchemaError);
+	});
+
+	it("includes source path in error for empty content", () => {
+		expect(() => parseSchemaContent("", "/path/to/schema.yml")).toThrow(/schema/i);
+	});
+
+	it("handles minimal schema with only one section", () => {
+		const yamlContent = `
+options:
+  enabled:
+    type: boolean
+    default: true
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.options).toBeDefined();
+		expect(schema.shortcodes).toBeUndefined();
+		expect(schema.formats).toBeUndefined();
+		expect(schema.projects).toBeUndefined();
+		expect(schema.elementAttributes).toBeUndefined();
+	});
+
+	it("parses nested field descriptors with items and properties", () => {
+		const yamlContent = `
+options:
+  tags:
+    type: array
+    items:
+      type: string
+      min-length: 1
+  config:
+    type: object
+    properties:
+      name:
+        type: string
+        required: true
+      nested:
+        type: object
+        properties:
+          level:
+            type: number
+`;
+
+		const schema = parseSchemaContent(yamlContent);
+
+		expect(schema.options!["tags"].items).toBeDefined();
+		expect(schema.options!["tags"].items!.type).toBe("string");
+		expect(schema.options!["tags"].items!.minLength).toBe(1);
+		expect(schema.options!["config"].properties).toBeDefined();
+		expect(schema.options!["config"].properties!["name"].required).toBe(true);
+		expect(schema.options!["config"].properties!["nested"].properties!["level"].type).toBe("number");
+	});
+});
+
+describe("filesystem schema functions", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "schema-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	describe("findSchemaFile", () => {
+		it("finds _schema.yml", () => {
+			const schemaPath = path.join(tempDir, "_schema.yml");
+			fs.writeFileSync(schemaPath, "options:\n  test:\n    type: string\n");
+
+			const result = findSchemaFile(tempDir);
+
+			expect(result).toBe(schemaPath);
+		});
+
+		it("finds _schema.yaml", () => {
+			const schemaPath = path.join(tempDir, "_schema.yaml");
+			fs.writeFileSync(schemaPath, "options:\n  test:\n    type: string\n");
+
+			const result = findSchemaFile(tempDir);
+
+			expect(result).toBe(schemaPath);
+		});
+
+		it("prefers .yml over .yaml", () => {
+			fs.writeFileSync(path.join(tempDir, "_schema.yml"), "options:\n  a:\n    type: string\n");
+			fs.writeFileSync(path.join(tempDir, "_schema.yaml"), "options:\n  b:\n    type: string\n");
+
+			const result = findSchemaFile(tempDir);
+
+			expect(result).toBe(path.join(tempDir, "_schema.yml"));
+		});
+
+		it("returns null when no schema exists", () => {
+			const result = findSchemaFile(tempDir);
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("parseSchemaFile", () => {
+		it("parses a schema file", () => {
+			const schemaPath = path.join(tempDir, "_schema.yml");
+			fs.writeFileSync(
+				schemaPath,
+				"options:\n  enabled:\n    type: boolean\n    default: true\n",
+			);
+
+			const schema = parseSchemaFile(schemaPath);
+
+			expect(schema.options).toBeDefined();
+			expect(schema.options!["enabled"].type).toBe("boolean");
+			expect(schema.options!["enabled"].default).toBe(true);
+		});
+
+		it("throws SchemaError for non-existent file", () => {
+			const schemaPath = path.join(tempDir, "nonexistent.yml");
+
+			expect(() => parseSchemaFile(schemaPath)).toThrow(SchemaError);
+		});
+
+		it("re-throws SchemaError from parsing", () => {
+			const schemaPath = path.join(tempDir, "_schema.yml");
+			fs.writeFileSync(schemaPath, "");
+
+			expect(() => parseSchemaFile(schemaPath)).toThrow(SchemaError);
+		});
+	});
+
+	describe("readSchema", () => {
+		it("reads schema from directory", () => {
+			fs.writeFileSync(
+				path.join(tempDir, "_schema.yml"),
+				"options:\n  theme:\n    type: string\n",
+			);
+
+			const result = readSchema(tempDir);
+
+			expect(result).not.toBeNull();
+			expect(result!.schema.options!["theme"].type).toBe("string");
+			expect(result!.filename).toBe("_schema.yml");
+		});
+
+		it("returns null when no schema in directory", () => {
+			const result = readSchema(tempDir);
+
+			expect(result).toBeNull();
+		});
+	});
+});
+
+describe("SchemaError", () => {
+	it("has the correct error code", () => {
+		const error = new SchemaError("test error");
+
+		expect(error.code).toBe("SCHEMA_ERROR");
+		expect(error.name).toBe("SchemaError");
+	});
+
+	it("includes schema path", () => {
+		const error = new SchemaError("test error", { schemaPath: "/path/to/schema.yml" });
+
+		expect(error.schemaPath).toBe("/path/to/schema.yml");
+		expect(error.suggestion).toContain("/path/to/schema.yml");
+	});
+
+	it("preserves the cause chain", () => {
+		const cause = new Error("original error");
+		const error = new SchemaError("wrapped", { cause });
+
+		expect(error.cause).toBe(cause);
+	});
+});
+
+describe("SchemaCache", () => {
+	let tempDir: string;
+	let cache: SchemaCache;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "schema-cache-test-"));
+		cache = new SchemaCache();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns null for directory without schema", () => {
+		const result = cache.get(tempDir);
+
+		expect(result).toBeNull();
+	});
+
+	it("loads and caches schema on first access", () => {
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  theme:\n    type: string\n",
+		);
+
+		const result = cache.get(tempDir);
+
+		expect(result).not.toBeNull();
+		expect(result!.options!["theme"].type).toBe("string");
+		expect(cache.has(tempDir)).toBe(true);
+	});
+
+	it("returns cached schema on subsequent access", () => {
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  theme:\n    type: string\n",
+		);
+
+		const first = cache.get(tempDir);
+		const second = cache.get(tempDir);
+
+		expect(first).toBe(second);
+	});
+
+	it("invalidates a specific entry", () => {
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  theme:\n    type: string\n",
+		);
+
+		cache.get(tempDir);
+		expect(cache.has(tempDir)).toBe(true);
+
+		cache.invalidate(tempDir);
+		expect(cache.has(tempDir)).toBe(false);
+	});
+
+	it("invalidates all entries", () => {
+		const tempDir2 = fs.mkdtempSync(path.join(os.tmpdir(), "schema-cache-test2-"));
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  a:\n    type: string\n",
+		);
+		fs.writeFileSync(
+			path.join(tempDir2, "_schema.yml"),
+			"options:\n  b:\n    type: string\n",
+		);
+
+		cache.get(tempDir);
+		cache.get(tempDir2);
+		expect(cache.has(tempDir)).toBe(true);
+		expect(cache.has(tempDir2)).toBe(true);
+
+		cache.invalidateAll();
+		expect(cache.has(tempDir)).toBe(false);
+		expect(cache.has(tempDir2)).toBe(false);
+
+		fs.rmSync(tempDir2, { recursive: true, force: true });
+	});
+
+	it("reloads schema after invalidation", () => {
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  theme:\n    type: string\n",
+		);
+
+		const first = cache.get(tempDir);
+		cache.invalidate(tempDir);
+
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  colour:\n    type: string\n",
+		);
+
+		const second = cache.get(tempDir);
+
+		expect(first!.options!["theme"]).toBeDefined();
+		expect(second!.options!["colour"]).toBeDefined();
+		expect(second!.options!["theme"]).toBeUndefined();
+	});
+
+	it("reports has as false before first access", () => {
+		fs.writeFileSync(
+			path.join(tempDir, "_schema.yml"),
+			"options:\n  test:\n    type: string\n",
+		);
+
+		expect(cache.has(tempDir)).toBe(false);
+
+		cache.get(tempDir);
+		expect(cache.has(tempDir)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- Add `ExtensionSchema`, `FieldDescriptor`, `CompletionSpec`, and `ShortcodeSchema` type definitions for `_schema.yml` files, with kebab-case YAML keys normalised to camelCase TypeScript properties.
- Add `findSchemaFile`, `parseSchemaFile`, `parseSchemaContent`, and `readSchema` functions mirroring the existing manifest loading pattern.
- Add `SchemaCache` class for lazy-loading and caching parsed schemas.
- Add `SchemaError` class following the existing error hierarchy.
- Add 42 tests covering type normalisation, file discovery, parsing, cache behaviour, and error handling.

## Test plan

- [x] All 42 new schema tests pass (`npx vitest run tests/filesystem/schema.test.ts`).
- [x] Full test suite passes (411 tests, 0 failures).
- [x] TypeScript type checking passes (`tsc --noEmit`).