### PR TITLE
fix: correct element-attributes type and harden schema cache

### DIFF
--- a/packages/core/src/filesystem/schema-cache.ts
+++ b/packages/core/src/filesystem/schema-cache.ts
@@ -30,14 +30,18 @@ export class SchemaCache {
 			return this.cache.get(extensionDir)!;
 		}
 
-		const result = readSchema(extensionDir);
+		try {
+			const result = readSchema(extensionDir);
 
-		if (!result) {
+			if (!result) {
+				return null;
+			}
+
+			this.cache.set(extensionDir, result.schema);
+			return result.schema;
+		} catch {
 			return null;
 		}
-
-		this.cache.set(extensionDir, result.schema);
-		return result.schema;
 	}
 
 	/**

--- a/packages/core/src/filesystem/schema.ts
+++ b/packages/core/src/filesystem/schema.ts
@@ -79,7 +79,7 @@ export function parseSchemaContent(content: string, sourcePath?: string): Extens
 	try {
 		const raw = yaml.load(content) as RawSchema;
 
-		if (!raw || typeof raw !== "object") {
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
 			throw new SchemaError("Schema file is empty or invalid", { schemaPath: sourcePath });
 		}
 

--- a/packages/core/src/types/schema.ts
+++ b/packages/core/src/types/schema.ts
@@ -93,8 +93,8 @@ export interface ExtensionSchema {
 	formats?: Record<string, Record<string, FieldDescriptor>>;
 	/** Project-level options the extension supports. */
 	projects?: Record<string, FieldDescriptor>;
-	/** Element-level attributes the extension supports. */
-	elementAttributes?: Record<string, FieldDescriptor>;
+	/** Element-level attributes grouped by CSS class or element type (e.g., "_any", "panel", "card"). */
+	elementAttributes?: Record<string, Record<string, FieldDescriptor>>;
 }
 
 /**
@@ -201,7 +201,7 @@ export function normaliseShortcodeSchema(raw: Record<string, unknown>): Shortcod
 export function normaliseSchema(raw: RawSchema): ExtensionSchema {
 	const result: ExtensionSchema = {};
 
-	if (raw.options && typeof raw.options === "object") {
+	if (raw.options && typeof raw.options === "object" && !Array.isArray(raw.options)) {
 		result.options = normaliseFieldDescriptorMap(raw.options);
 	}
 
@@ -225,13 +225,19 @@ export function normaliseSchema(raw: RawSchema): ExtensionSchema {
 		result.formats = formats;
 	}
 
-	if (raw.projects && typeof raw.projects === "object") {
+	if (raw.projects && typeof raw.projects === "object" && !Array.isArray(raw.projects)) {
 		result.projects = normaliseFieldDescriptorMap(raw.projects);
 	}
 
 	const elementAttributes = raw["element-attributes"];
-	if (elementAttributes && typeof elementAttributes === "object") {
-		result.elementAttributes = normaliseFieldDescriptorMap(elementAttributes as Record<string, unknown>);
+	if (elementAttributes && typeof elementAttributes === "object" && !Array.isArray(elementAttributes)) {
+		const groups: Record<string, Record<string, FieldDescriptor>> = {};
+		for (const [groupKey, groupValue] of Object.entries(elementAttributes as Record<string, unknown>)) {
+			if (groupValue && typeof groupValue === "object" && !Array.isArray(groupValue)) {
+				groups[groupKey] = normaliseFieldDescriptorMap(groupValue as Record<string, unknown>);
+			}
+		}
+		result.elementAttributes = groups;
 	}
 
 	return result;


### PR DESCRIPTION
## Summary

- Fix `elementAttributes` type from flat `Record<string, FieldDescriptor>` to grouped `Record<string, Record<string, FieldDescriptor>>` matching the actual `_schema.yml` structure where attributes are nested under CSS class or element type keys (e.g., `_any`, `panel`, `card`).
- Make `SchemaCache.get()` exception-safe by catching errors from malformed schema files and returning `null`, preventing one broken `_schema.yml` from crashing the tree view, completions, or diagnostics.
- Add `Array.isArray` guard in `parseSchemaContent` to reject YAML arrays at root level.
- Standardise `Array.isArray` guards across all `normaliseSchema` sections for consistency.

## Test plan

- [x] All 415 core tests pass.
- [x] TypeScript compilation clean (`tsc --noEmit`).
- [x] New tests: YAML array rejection, YAML scalar rejection, cache returns null for malformed schema, cache returns null for invalid YAML syntax.
- [x] Updated tests: element-attributes now use two-level nesting structure.