### PR TITLE
fix: share single SchemaCache instance and harden providers

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { ExtensionsInstalled } from "./ui/extensionsInstalled";
 import { getExtensionsDetails, clearExtensionsCache } from "./utils/extensionDetails";
 import { handleUri } from "./utils/handleUri";
 import { setManualToken, clearManualToken } from "./utils/auth";
+import { SchemaCache } from "@quarto-wizard/core";
 import { registerYamlProviders } from "./providers/registerYamlProviders";
 import { registerShortcodeCompletionProvider } from "./providers/shortcodeCompletionProvider";
 
@@ -121,14 +122,17 @@ export function activate(context: vscode.ExtensionContext) {
 		),
 	);
 
+	// Shared schema cache for all providers and tree view
+	const schemaCache = new SchemaCache();
+
 	// Initialise the Extensions Installed tree view provider
-	new ExtensionsInstalled(context);
+	new ExtensionsInstalled(context, schemaCache);
 
 	// Register YAML completion and diagnostics providers for extension schemas
-	registerYamlProviders(context);
+	registerYamlProviders(context, schemaCache);
 
 	// Register shortcode completion provider for Quarto documents
-	registerShortcodeCompletionProvider(context);
+	registerShortcodeCompletionProvider(context, schemaCache);
 
 	// Register URI handler for browser-based extension installation (e.g., vscode://mcanouil.quarto-wizard/install?repo=owner/repo)
 	context.subscriptions.push(

--- a/src/providers/registerYamlProviders.ts
+++ b/src/providers/registerYamlProviders.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
-import { SchemaCache } from "@quarto-wizard/core";
+import * as path from "node:path";
+import type { SchemaCache } from "@quarto-wizard/core";
 import { YamlCompletionProvider, YAML_DOCUMENT_SELECTOR } from "./yamlCompletionProvider";
 import { YamlDiagnosticsProvider } from "./yamlDiagnosticsProvider";
 import { logMessage } from "../utils/log";
@@ -10,10 +11,9 @@ import { logMessage } from "../utils/log";
  * schema cache when _schema.yml files change.
  *
  * @param context - The VS Code extension context.
+ * @param schemaCache - Shared schema cache instance.
  */
-export function registerYamlProviders(context: vscode.ExtensionContext): void {
-	const schemaCache = new SchemaCache();
-
+export function registerYamlProviders(context: vscode.ExtensionContext, schemaCache: SchemaCache): void {
 	// Register completion provider.
 	const completionProvider = new YamlCompletionProvider(schemaCache);
 	context.subscriptions.push(
@@ -27,7 +27,7 @@ export function registerYamlProviders(context: vscode.ExtensionContext): void {
 	// Watch for _schema.yml changes to invalidate the cache and revalidate.
 	const schemaWatcher = vscode.workspace.createFileSystemWatcher("**/_schema.{yml,yaml}");
 	const invalidateAndRevalidate = (uri: vscode.Uri) => {
-		const dir = vscode.Uri.joinPath(uri, "..").fsPath;
+		const dir = path.normalize(vscode.Uri.joinPath(uri, "..").fsPath);
 		schemaCache.invalidate(dir);
 		diagnosticsProvider.revalidateAll();
 		logMessage(`Schema cache invalidated for ${dir}.`, "debug");

--- a/src/ui/extensionTreeDataProvider.ts
+++ b/src/ui/extensionTreeDataProvider.ts
@@ -222,7 +222,7 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 			case "projects":
 				return this.fieldItems(schema.projects ?? {});
 			case "elementAttributes":
-				return this.fieldItems(schema.elementAttributes ?? {});
+				return this.formatItems(schema.elementAttributes ?? {});
 		}
 	}
 

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { normaliseVersion, SchemaCache } from "@quarto-wizard/core";
+import { normaliseVersion } from "@quarto-wizard/core";
+import type { SchemaCache } from "@quarto-wizard/core";
 import { logMessage, getShowLogsLink } from "../utils/log";
 import { removeQuartoExtension, removeQuartoExtensions, installQuartoExtension } from "../utils/quarto";
 import { withProgressNotification } from "../utils/withProgressNotification";
@@ -21,14 +22,13 @@ export class ExtensionsInstalled {
 	 *
 	 * @param context - The extension context.
 	 */
-	private initialise(context: vscode.ExtensionContext) {
+	private initialise(context: vscode.ExtensionContext, schemaCache: SchemaCache) {
 		const workspaceFolders = vscode.workspace.workspaceFolders || [];
 		if (workspaceFolders.length === 0) {
 			logMessage("No workspace folders open. Extensions view not initialised.", "debug");
 			return;
 		}
 
-		const schemaCache = new SchemaCache();
 		this.treeDataProvider = new QuartoExtensionTreeDataProvider(workspaceFolders, schemaCache);
 		context.subscriptions.push(this.treeDataProvider);
 		const view = vscode.window.createTreeView("quartoWizard.extensionsInstalled", {
@@ -345,7 +345,7 @@ export class ExtensionsInstalled {
 		);
 	}
 
-	constructor(context: vscode.ExtensionContext) {
-		this.initialise(context);
+	constructor(context: vscode.ExtensionContext, schemaCache: SchemaCache) {
+		this.initialise(context, schemaCache);
 	}
 }


### PR DESCRIPTION
## Summary

- Use a single `SchemaCache` created in `extension.ts` and passed to all consumers (tree view, YAML providers, shortcode completion) instead of each creating its own instance.
- Fix `elementAttributes` tree rendering to use `formatItems` (two-level nesting) instead of `fieldItems`.
- Add top-level try-catch in YAML and shortcode completion providers to prevent unhandled exceptions from crashing the completion pipeline.
- Normalise URI path when invalidating schema cache to ensure consistent cache key matching.
- Cancel debounced validation when a document is closed to prevent stale diagnostics.
- Guard against unknown type names in schema validation to avoid false positives.
- Cap regex pattern length at 1024 characters to mitigate ReDoS risk from malicious schemas.
- Use `import type` for `SchemaCache` in consumer modules that only reference it as a type.

## Test plan

- [ ] Verify all 415 existing tests still pass.
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`).
- [ ] Verify ESLint passes with zero warnings.
- [ ] Verify Prettier formatting is correct.
- [ ] Open a workspace with Quarto extensions and confirm schema completions and diagnostics still work.
- [ ] Confirm tree view correctly renders `elementAttributes` as nested groups.