### PR TITLE
fix: use SnippetString for YAML completion indentation and re-trigger on backspace

### DIFF
--- a/src/providers/yamlCompletionProvider.ts
+++ b/src/providers/yamlCompletionProvider.ts
@@ -121,10 +121,10 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 			const isObject = item.kind === vscode.CompletionItemKind.Module;
 
 			if (isObject) {
-				item.insertText = `\n${childIndent}${label}:\n${childIndent}  `;
+				item.insertText = new vscode.SnippetString(`\n${childIndent}${label}:\n${childIndent}  $0`);
 				item.command = { command: "editor.action.triggerSuggest", title: "Trigger Suggest" };
 			} else {
-				item.insertText = `\n${childIndent}${label}: `;
+				item.insertText = new vscode.SnippetString(`\n${childIndent}${label}: $0`);
 			}
 			item.filterText = label;
 			item.range = replaceRange;


### PR DESCRIPTION
## Summary

- Use `SnippetString` instead of plain strings in `adjustForValuePosition` to prevent VS Code's `increaseIndentPattern` from adding extra indentation when completing keys after a colon.
- Add a debounced `onDidChangeTextDocument` listener to re-trigger the suggest widget on backspace, since backspace cannot be a trigger character.

## Test plan

- [ ] In `_quarto.yml`, type `extensions:\n  modal:`, place cursor after `modal:`, trigger completion, accept an option key. The key should appear at 4 spaces of indentation (not 6).
- [ ] In `_quarto.yml`, start typing an option key under an extension, press backspace. The suggest widget should re-appear.
- [ ] Verify `npx tsc --noEmit`, `npx eslint src/`, and `npx prettier --check "src/**/*.ts"` all pass.