### PR TITLE
feat: trigger element attribute completions on `{` and support link/image attributes

### DIFF
--- a/src/providers/elementAttributeCompletionProvider.ts
+++ b/src/providers/elementAttributeCompletionProvider.ts
@@ -415,7 +415,13 @@ export function registerElementAttributeProviders(context: vscode.ExtensionConte
 	const selector: vscode.DocumentSelector = { language: "quarto" };
 
 	const completionProvider = new ElementAttributeCompletionProvider(schemaCache);
-	const completionDisposable = vscode.languages.registerCompletionItemProvider(selector, completionProvider, " ", "=");
+	const completionDisposable = vscode.languages.registerCompletionItemProvider(
+		selector,
+		completionProvider,
+		" ",
+		"=",
+		"{",
+	);
 	context.subscriptions.push(completionDisposable);
 
 	const hoverProvider = new ElementAttributeHoverProvider(schemaCache);

--- a/src/test/suite/elementAttributeParser.test.ts
+++ b/src/test/suite/elementAttributeParser.test.ts
@@ -95,6 +95,24 @@ suite("Element Attribute Parser", () => {
 			assert.strictEqual(bounds.start, 5);
 			assert.strictEqual(bounds.elementType, "Div");
 		});
+
+		test("should return bounds for an image link attribute block", () => {
+			const text = "![alt](url){.class}";
+			const bounds = getAttributeBounds(text, 14);
+			assert.ok(bounds);
+			assert.strictEqual(bounds.start, 11);
+			assert.strictEqual(bounds.end, 19);
+			assert.strictEqual(bounds.elementType, "Span");
+		});
+
+		test("should return bounds for a link attribute block", () => {
+			const text = "[text](url){.class}";
+			const bounds = getAttributeBounds(text, 14);
+			assert.ok(bounds);
+			assert.strictEqual(bounds.start, 11);
+			assert.strictEqual(bounds.end, 19);
+			assert.strictEqual(bounds.elementType, "Span");
+		});
 	});
 
 	suite("parseAttributeAtPosition", () => {
@@ -245,6 +263,24 @@ suite("Element Attribute Parser", () => {
 			assert.strictEqual(result.cursorContext, "attributeKey");
 			assert.deepStrictEqual(result.classes, []);
 			assert.deepStrictEqual(result.attributes, {});
+		});
+
+		test("should parse attributes for image link syntax", () => {
+			const text = "![alt](url){.class }";
+			const result = parseAttributeAtPosition(text, 19);
+			assert.ok(result);
+			assert.strictEqual(result.elementType, "Span");
+			assert.deepStrictEqual(result.classes, ["class"]);
+			assert.strictEqual(result.cursorContext, "attributeKey");
+		});
+
+		test("should parse attributes for link syntax", () => {
+			const text = "[text](url){.class }";
+			const result = parseAttributeAtPosition(text, 19);
+			assert.ok(result);
+			assert.strictEqual(result.elementType, "Span");
+			assert.deepStrictEqual(result.classes, ["class"]);
+			assert.strictEqual(result.cursorContext, "attributeKey");
 		});
 	});
 });

--- a/src/utils/elementAttributeParser.ts
+++ b/src/utils/elementAttributeParser.ts
@@ -1,6 +1,8 @@
 /**
  * Lightweight parser for Pandoc element attribute syntax:
  * - Spans:      [text]{.class attr=value}
+ * - Links:      [text](url){.class attr=value}
+ * - Images:     ![alt](url){.class attr=value}
  * - Divs:       ::: {.class attr=value}
  * - Code spans: `code`{.class attr=value}
  *
@@ -54,8 +56,9 @@ export interface AttributeBounds {
 /**
  * Find the bounds of a Pandoc attribute block surrounding the given offset.
  *
- * Validates that the `{` is preceded by `]` (span), `:::` with optional spaces (div),
- * or `` ` `` (code span), confirming a Pandoc attribute context rather than YAML.
+ * Validates that the `{` is preceded by `]` (span), `)` (link/image),
+ * `:::` with optional spaces (div), or `` ` `` (code span), confirming a
+ * Pandoc attribute context rather than YAML.
  *
  * @param text - The full document text.
  * @param offset - The cursor offset within the text.
@@ -123,6 +126,7 @@ export function getAttributeBounds(text: string, offset: number): AttributeBound
  *
  * Valid contexts:
  * - `]` immediately before `{` (Span)
+ * - `)` immediately before `{` (Span) — link/image: `[text](url){` or `![alt](url){`
  * - `` ` `` immediately before `{` (Code)
  * - `:::` with optional spaces before `{` (Div)
  * - `# Heading text ` before `{` at line start (Header)
@@ -138,6 +142,11 @@ function isPandocAttributeContext(text: string, bracePos: number): PandocElement
 
 	// Span: ]{...}
 	if (charBefore === "]") {
+		return "Span";
+	}
+
+	// Link / Image: [text](url){...} or ![alt](url){...}
+	if (charBefore === ")") {
 		return "Span";
 	}
 


### PR DESCRIPTION
## Summary

- Add `{` as a trigger character for the element attribute completion provider, so completions appear automatically when opening a Pandoc attribute block (e.g. `::: {`, `]{`, `` ` ``{`).
- Recognise `)` before `{` in `isPandocAttributeContext` to detect link (`[text](url){`) and image (`![alt](url){`) attribute contexts, mapped to `"Span"`.
- Add four tests covering `getAttributeBounds` and `parseAttributeAtPosition` for link/image syntax.

## Test plan

- [ ] `npx tsc --noEmit` passes.
- [ ] `npx eslint src/` passes.
- [ ] `npx prettier --check "src/**/*.ts"` passes.
- [ ] `npm test` passes (332 passing; 10 pre-existing failures in `activate.test.js`).
- [ ] Manual: type `::: {` in a `.qmd` file and verify completions appear automatically.
- [ ] Manual: type `[text]{` and verify completions appear automatically.
- [ ] Manual: type `` `code`{ `` and verify completions appear automatically.
- [ ] Manual: type `![alt](url){` and verify completions appear automatically.
- [ ] Manual: type `{` in plain text (not after a Pandoc element) and verify no completions appear.