### PR TITLE
feat: support union types in FieldDescriptor.type

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -43,4 +43,6 @@ export {
 	normaliseFieldDescriptorMap,
 	normaliseShortcodeSchema,
 	normaliseSchema,
+	typeIncludes,
+	formatType,
 } from "./schema.js";

--- a/packages/core/src/types/schema.ts
+++ b/packages/core/src/types/schema.ts
@@ -45,8 +45,8 @@ export interface DeprecatedSpec {
  * Describes the type, constraints, and metadata for a configuration option.
  */
 export interface FieldDescriptor {
-	/** Data type of the field (e.g., "string", "number", "boolean", "object", "array", "content"). */
-	type?: string;
+	/** Data type of the field. A single type name or an array of type names for union types. */
+	type?: string | string[];
 	/** Whether the field is required. */
 	required?: boolean;
 	/** Default value for the field. */
@@ -272,4 +272,31 @@ export function normaliseSchema(raw: RawSchema): ExtensionSchema {
 	}
 
 	return result;
+}
+
+/**
+ * Check whether a type spec includes a given type name.
+ *
+ * @param typeSpec - Type spec (string, string array, or undefined).
+ * @param name - Type name to look for.
+ * @returns True if the type spec includes the given name.
+ */
+export function typeIncludes(typeSpec: string | string[] | undefined, name: string): boolean {
+	if (Array.isArray(typeSpec)) {
+		return typeSpec.includes(name);
+	}
+	return typeSpec === name;
+}
+
+/**
+ * Format a type spec for display (e.g., "number | boolean").
+ *
+ * @param typeSpec - Type spec (string, string array, or undefined).
+ * @returns Human-readable type string.
+ */
+export function formatType(typeSpec: string | string[] | undefined): string {
+	if (Array.isArray(typeSpec)) {
+		return typeSpec.join(" | ");
+	}
+	return typeSpec ?? "";
 }

--- a/src/providers/elementAttributeCompletionProvider.ts
+++ b/src/providers/elementAttributeCompletionProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import type { FieldDescriptor, SchemaCache, ExtensionSchema } from "@quarto-wizard/core";
-import { discoverInstalledExtensions } from "@quarto-wizard/core";
+import { discoverInstalledExtensions, typeIncludes } from "@quarto-wizard/core";
 import { parseAttributeAtPosition, type PandocElementType } from "../utils/elementAttributeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
@@ -353,7 +353,7 @@ export class ElementAttributeCompletionProvider implements vscode.CompletionItem
 			}
 		}
 
-		if (descriptor.type === "boolean" && items.length === 0) {
+		if (typeIncludes(descriptor.type, "boolean") && items.length === 0) {
 			for (const label of ["true", "false"]) {
 				const item = new vscode.CompletionItem(label, vscode.CompletionItemKind.Value);
 				item.detail = source;

--- a/src/providers/shortcodeCompletionProvider.ts
+++ b/src/providers/shortcodeCompletionProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import type { ShortcodeSchema, FieldDescriptor, SchemaCache } from "@quarto-wizard/core";
-import { discoverInstalledExtensions } from "@quarto-wizard/core";
+import { discoverInstalledExtensions, typeIncludes } from "@quarto-wizard/core";
 import { parseShortcodeAtPosition } from "../utils/shortcodeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
@@ -323,7 +323,7 @@ export class ShortcodeCompletionProvider implements vscode.CompletionItemProvide
 			items.push(...fileItems);
 		}
 
-		if (descriptor.type === "boolean" && items.length === 0) {
+		if (typeIncludes(descriptor.type, "boolean") && items.length === 0) {
 			const trueItem = new vscode.CompletionItem("true", vscode.CompletionItemKind.Value);
 			trueItem.sortText = "!1_true";
 			items.push(trueItem);

--- a/src/providers/yamlCompletionProvider.ts
+++ b/src/providers/yamlCompletionProvider.ts
@@ -1,5 +1,11 @@
 import * as vscode from "vscode";
-import { discoverInstalledExtensions, formatExtensionId, getExtensionTypes } from "@quarto-wizard/core";
+import {
+	discoverInstalledExtensions,
+	formatExtensionId,
+	getExtensionTypes,
+	typeIncludes,
+	formatType,
+} from "@quarto-wizard/core";
 import type { SchemaCache, ExtensionSchema, FieldDescriptor, InstalledExtension } from "@quarto-wizard/core";
 import { getYamlKeyPath, getYamlIndentLevel, isInYamlRegion, getExistingKeysAtPath } from "../utils/yamlPosition";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
@@ -315,7 +321,7 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 			}
 		}
 
-		if (descriptor.type === "boolean") {
+		if (typeIncludes(descriptor.type, "boolean")) {
 			for (const label of ["true", "false"]) {
 				const item = new vscode.CompletionItem(label, vscode.CompletionItemKind.Value);
 				item.insertText = ` ${label}`;
@@ -337,7 +343,7 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 	}
 
 	private fieldToCompletionItem(key: string, descriptor: FieldDescriptor): vscode.CompletionItem {
-		const isObject = descriptor.type === "object" || descriptor.properties !== undefined;
+		const isObject = typeIncludes(descriptor.type, "object") || descriptor.properties !== undefined;
 		const kind = isObject ? vscode.CompletionItemKind.Module : vscode.CompletionItemKind.Property;
 		const item = new vscode.CompletionItem(key, kind);
 
@@ -349,7 +355,7 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 
 		const meta: string[] = [];
 		if (descriptor.type) {
-			meta.push(`**Type:** \`${descriptor.type}\``);
+			meta.push(`**Type:** \`${formatType(descriptor.type)}\``);
 		}
 		if (descriptor.required) {
 			meta.push("**Required**");

--- a/src/providers/yamlHoverProvider.ts
+++ b/src/providers/yamlHoverProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { discoverInstalledExtensions, formatExtensionId, getExtensionTypes } from "@quarto-wizard/core";
+import { discoverInstalledExtensions, formatExtensionId, getExtensionTypes, formatType } from "@quarto-wizard/core";
 import type {
 	SchemaCache,
 	ExtensionSchema,
@@ -259,7 +259,7 @@ export class YamlHoverProvider implements vscode.HoverProvider {
 
 		const details: string[] = [];
 		if (descriptor.type) {
-			details.push(`**Type:** \`${descriptor.type}\``);
+			details.push(`**Type:** \`${formatType(descriptor.type)}\``);
 		}
 		if (descriptor.required) {
 			details.push("**Required:** yes");

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -382,5 +382,72 @@ suite("Inline Attribute Diagnostics", () => {
 			assert.strictEqual(findings.length, 1);
 			assert.strictEqual(findings[0].code, "schema-type-mismatch");
 		});
+
+		test("union type [number, boolean]: accepts valid number", () => {
+			const descriptor: FieldDescriptor = { type: ["number", "boolean"] };
+			const findings = validateInlineValue("val", "42", descriptor);
+			assert.strictEqual(findings.length, 0);
+		});
+
+		test("union type [number, boolean]: accepts valid boolean", () => {
+			const descriptor: FieldDescriptor = { type: ["number", "boolean"] };
+			const findings = validateInlineValue("val", "true", descriptor);
+			assert.strictEqual(findings.length, 0);
+		});
+
+		test("union type [number, boolean]: rejects invalid value", () => {
+			const descriptor: FieldDescriptor = { type: ["number", "boolean"] };
+			const findings = validateInlineValue("val", "hello", descriptor);
+			assert.strictEqual(findings.length, 1);
+			assert.strictEqual(findings[0].code, "schema-type-mismatch");
+		});
+
+		test("union type [number, array]: validates number component", () => {
+			const descriptor: FieldDescriptor = { type: ["number", "array"] };
+			const findings = validateInlineValue("val", "42", descriptor);
+			assert.strictEqual(findings.length, 0);
+		});
+
+		test("union type [number, array]: rejects non-number string", () => {
+			const descriptor: FieldDescriptor = { type: ["number", "array"] };
+			const findings = validateInlineValue("val", "hello", descriptor);
+			assert.strictEqual(findings.length, 1);
+			assert.strictEqual(findings[0].code, "schema-type-mismatch");
+		});
+
+		test("union type [string, array]: accepts any string", () => {
+			const descriptor: FieldDescriptor = { type: ["string", "array"] };
+			const findings = validateInlineValue("val", "anything", descriptor);
+			assert.strictEqual(findings.length, 0);
+		});
+
+		test("union type [boolean, array]: accepts valid boolean", () => {
+			const descriptor: FieldDescriptor = { type: ["boolean", "array"] };
+			const findings = validateInlineValue("val", "false", descriptor);
+			assert.strictEqual(findings.length, 0);
+		});
+
+		test("union type [boolean, array]: rejects non-boolean string", () => {
+			const descriptor: FieldDescriptor = { type: ["boolean", "array"] };
+			const findings = validateInlineValue("val", "hello", descriptor);
+			assert.strictEqual(findings.length, 1);
+			assert.strictEqual(findings[0].code, "schema-type-mismatch");
+		});
+
+		test("pure non-inline union [array, object]: skipped", () => {
+			const descriptor: FieldDescriptor = { type: ["array", "object"] };
+			const findings = validateInlineValue("val", "anything", descriptor);
+			assert.strictEqual(findings.length, 0);
+		});
+
+		test("deprecated field with pure non-inline union still warns", () => {
+			const descriptor: FieldDescriptor = {
+				type: ["array", "object"],
+				deprecated: { message: "Use 'items' instead." },
+			};
+			const findings = validateInlineValue("old", "val", descriptor);
+			assert.strictEqual(findings.length, 1);
+			assert.strictEqual(findings[0].code, "schema-deprecated");
+		});
 	});
 });

--- a/src/ui/extensionTreeItems.ts
+++ b/src/ui/extensionTreeItems.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import type { ExtensionSchema, FieldDescriptor, ShortcodeSchema } from "@quarto-wizard/core";
+import { formatType } from "@quarto-wizard/core";
 import { getExtensionRepository, type InstalledExtension } from "../utils/extensions";
 
 /**
@@ -145,7 +146,7 @@ export class SchemaFieldTreeItem extends vscode.TreeItem {
 
 		const parts: string[] = [];
 		if (field.type) {
-			parts.push(field.type);
+			parts.push(formatType(field.type));
 		}
 		if (field.required) {
 			parts.push("required");

--- a/src/utils/schemaDocumentation.ts
+++ b/src/utils/schemaDocumentation.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import type { FieldDescriptor, DeprecatedSpec } from "@quarto-wizard/core";
+import { typeIncludes, formatType } from "@quarto-wizard/core";
 
 /**
  * Extract the word at a given offset in the text.
@@ -25,7 +26,7 @@ export function getWordAtOffset(text: string, offset: number): string | null {
 export function hasCompletableValues(descriptor: FieldDescriptor): boolean {
 	return !!(
 		descriptor.enum ||
-		descriptor.type === "boolean" ||
+		typeIncludes(descriptor.type, "boolean") ||
 		descriptor.completion?.values ||
 		descriptor.completion?.type === "file"
 	);
@@ -50,7 +51,7 @@ export function buildAttributeDoc(descriptor: FieldDescriptor, source?: string):
 
 	const meta: string[] = [];
 	if (descriptor.type) {
-		meta.push(`Type: \`${descriptor.type}\``);
+		meta.push(`Type: \`${formatType(descriptor.type)}\``);
 	}
 	if (descriptor.required) {
 		meta.push("Required");


### PR DESCRIPTION
## Summary

- Widen `FieldDescriptor.type` from `string` to `string | string[]` to support union types (e.g. `type: [number, boolean]`).
- Add `typeIncludes` and `formatType` utility functions exported from `@quarto-wizard/core`.
- Update all providers (completion, diagnostics, hover, tree items) to use the new utilities instead of direct `=== "boolean"` / `=== "object"` comparisons.
- Fix inline attribute diagnostics: only skip validation when the union has no inline-representable members, not when it contains any non-inline type.

## Test plan

- [ ] Verify core tests pass (430 tests).
- [ ] Verify extension tests pass (342 passing, 10 pre-existing failures in `activate.test.ts`).
- [ ] Open a Quarto document with a `_schema.yml` that uses `type: [number, boolean]` and verify completions, hover, and diagnostics work correctly.
- [ ] Verify inline attribute diagnostics correctly validate union types (e.g. `{val=42}` accepted for `[number, array]`, `{val=hello}` rejected).