### PR TITLE
feat(docs): add dev site rendering to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,10 @@ jobs:
         shell: bash
         run: npm run docs:api
 
+      - name: Build dev VSIX
+        shell: bash
+        run: npx vsce package --pre-release --out docs/quarto-wizard-dev.vsix
+
       - name: Render dev site
         shell: bash
         working-directory: ./docs

--- a/docs/_quarto-dev.yml
+++ b/docs/_quarto-dev.yml
@@ -1,5 +1,7 @@
 project:
   output-dir: _site/dev
+  resources:
+    - quarto-wizard-dev.vsix
 
 website:
   title: "Quarto Wizard (Development)"
@@ -7,6 +9,6 @@ website:
   announcement:
     icon: exclamation-circle
     dismissable: false
-    content: "**Development** - This documentation is for the development version of Quarto Wizard. For the stable version, please visit [the main documentation](https://m.canouil.dev/quarto-wizard)."
+    content: "**Development** - This documentation is for the [development version of Quarto Wizard](quarto-wizard-dev.vsix). For the stable version, please visit [the main documentation](https://m.canouil.dev/quarto-wizard)."
     type: warning
     position: above-navbar


### PR DESCRIPTION
## Summary

- Render a release site from the latest semver tag at `_site/` and a dev site from the default branch HEAD at `_site/dev/`.
- Add `docs/_quarto-dev.yml` Quarto profile that sets `output-dir: _site/dev` and displays a development warning banner.
- Use step-level `env` blocks instead of inline `${{ }}` interpolation in `run` commands to prevent script injection.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` and verify both the release and dev sites render.
- [ ] Confirm the release site is accessible at the root GitHub Pages URL.
- [ ] Confirm the dev site is accessible at `/dev/` and displays the development warning banner.