### PR TITLE
ci: add schema package to build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,18 @@ jobs:
         shell: bash
         run: npm ci
 
+      - name: Lint schema package
+        id: lint-schema
+        shell: bash
+        working-directory: packages/schema
+        run: npm run lint
+
+      - name: Test schema package
+        id: test-schema
+        shell: bash
+        working-directory: packages/schema
+        run: npm test
+
       - name: Lint core package
         id: lint-core
         shell: bash
@@ -145,9 +157,9 @@ jobs:
           fi
 
           # Use steps context to determine overall job status
-          if [[ "${{ steps.lint-core.outcome }}" == "failure" || "${{ steps.test-core.outcome }}" == "failure" || "${{ steps.webpack.outcome }}" == "failure" || "${{ steps.lint.outcome }}" == "failure" || "${{ steps.format.outcome }}" == "failure" || "${{ steps.test-compile.outcome }}" == "failure" || "$test_outcome" == "failure" || "${{ steps.build-extension.outcome }}" == "failure" ]]; then
+          if [[ "${{ steps.lint-schema.outcome }}" == "failure" || "${{ steps.test-schema.outcome }}" == "failure" || "${{ steps.lint-core.outcome }}" == "failure" || "${{ steps.test-core.outcome }}" == "failure" || "${{ steps.webpack.outcome }}" == "failure" || "${{ steps.lint.outcome }}" == "failure" || "${{ steps.format.outcome }}" == "failure" || "${{ steps.test-compile.outcome }}" == "failure" || "$test_outcome" == "failure" || "${{ steps.build-extension.outcome }}" == "failure" ]]; then
             echo "Status: failure" >> job-summary.txt
-          elif [[ "${{ steps.lint-core.outcome }}" == "cancelled" || "${{ steps.test-core.outcome }}" == "cancelled" || "${{ steps.webpack.outcome }}" == "cancelled" || "${{ steps.lint.outcome }}" == "cancelled" || "${{ steps.format.outcome }}" == "cancelled" || "${{ steps.test-compile.outcome }}" == "cancelled" || "$test_outcome" == "cancelled" || "${{ steps.build-extension.outcome }}" == "cancelled" ]]; then
+          elif [[ "${{ steps.lint-schema.outcome }}" == "cancelled" || "${{ steps.test-schema.outcome }}" == "cancelled" || "${{ steps.lint-core.outcome }}" == "cancelled" || "${{ steps.test-core.outcome }}" == "cancelled" || "${{ steps.webpack.outcome }}" == "cancelled" || "${{ steps.lint.outcome }}" == "cancelled" || "${{ steps.format.outcome }}" == "cancelled" || "${{ steps.test-compile.outcome }}" == "cancelled" || "$test_outcome" == "cancelled" || "${{ steps.build-extension.outcome }}" == "cancelled" ]]; then
             echo "Status: cancelled" >> job-summary.txt
           else
             echo "Status: success" >> job-summary.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,12 +282,20 @@ jobs:
           npm pack
           mv quarto-wizard-core-*.tgz "${GITHUB_WORKSPACE}/"
 
+      - name: Package schema library
+        shell: bash
+        run: |
+          cd packages/schema
+          npm pack
+          mv quarto-wizard-schema-*.tgz "${GITHUB_WORKSPACE}/"
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: |
             ${{ github.workspace }}/quarto-wizard-${{ env.VERSION }}.vsix
             ${{ github.workspace }}/quarto-wizard-core-${{ env.VERSION }}.tgz
+            ${{ github.workspace }}/quarto-wizard-schema-${{ env.VERSION }}.tgz
 
       - name: Release extension on GitHub
         env:
@@ -301,6 +309,7 @@ jobs:
             gh release create ${VERSION} \
               "./quarto-wizard-${VERSION}.vsix#Quarto Wizard (vsix)" \
               "./quarto-wizard-core-${VERSION}.tgz#Quarto Wizard Core (tgz)" \
+              "./quarto-wizard-schema-${VERSION}.tgz#Quarto Wizard Schema (tgz)" \
               --prerelease \
               --title ${VERSION} \
               --notes-file ${CHANGELOG} \
@@ -309,6 +318,7 @@ jobs:
             gh release create ${VERSION} \
               "./quarto-wizard-${VERSION}.vsix#Quarto Wizard (vsix)" \
               "./quarto-wizard-core-${VERSION}.tgz#Quarto Wizard Core (tgz)" \
+              "./quarto-wizard-schema-${VERSION}.tgz#Quarto Wizard Schema (tgz)" \
               --title ${VERSION} \
               --notes-file ${CHANGELOG} \
               --generate-notes


### PR DESCRIPTION
## Summary

- Add lint and test steps for `@quarto-wizard/schema` in `build.yml`, mirroring the existing `core` package steps.
- Add schema package packing, attestation, and release asset upload in `release.yml`.
- Include schema step outcomes in the job summary failure/cancelled checks.

## Test plan

- [ ] Trigger a `workflow_dispatch` run of `build.yml` and verify the new `lint-schema` and `test-schema` steps execute.
- [ ] Verify the release workflow includes `quarto-wizard-schema-*.tgz` in the attestation subject-path and `gh release create` assets.