### PR TITLE
fix: suppress suggest menu on backspace in schema definition files

### DIFF
--- a/src/providers/registerYamlProviders.ts
+++ b/src/providers/registerYamlProviders.ts
@@ -5,9 +5,13 @@ import { YamlCompletionProvider, YAML_DOCUMENT_SELECTOR } from "./yamlCompletion
 import { YamlDiagnosticsProvider } from "./yamlDiagnosticsProvider";
 import { YamlHoverProvider } from "./yamlHoverProvider";
 import { SchemaDiagnosticsProvider } from "./schemaDiagnosticsProvider";
-import { SchemaDefinitionCompletionProvider, SCHEMA_DEFINITION_SELECTOR } from "./schemaDefinitionCompletionProvider";
+import {
+	SchemaDefinitionCompletionProvider,
+	SCHEMA_DEFINITION_SELECTOR,
+	shouldRetriggerSchemaFileSuggest,
+} from "./schemaDefinitionCompletionProvider";
 import { debounce } from "../utils/debounce";
-import { isInYamlRegion, shouldRetriggerSuggest } from "../utils/yamlPosition";
+import { shouldRetriggerSuggest } from "../utils/yamlPosition";
 import { logMessage } from "../utils/log";
 
 /**
@@ -88,7 +92,7 @@ export function registerYamlProviders(context: vscode.ExtensionContext, schemaCa
 			const cursorCharacter = editor.selection.active.character;
 			const isSchemaFile = vscode.languages.match(SCHEMA_DEFINITION_SELECTOR, event.document) > 0;
 			const shouldTrigger = isSchemaFile
-				? isInYamlRegion(lines, cursorLine, event.document.languageId)
+				? shouldRetriggerSchemaFileSuggest(lines, cursorLine, cursorCharacter, event.document.languageId)
 				: shouldRetriggerSuggest(lines, cursorLine, cursorCharacter, event.document.languageId);
 			if (shouldTrigger) {
 				retriggerSuggest();

--- a/src/test/suite/schemaDefinitionCompletion.test.ts
+++ b/src/test/suite/schemaDefinitionCompletion.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { getSchemaContext } from "../../providers/schemaDefinitionCompletionProvider";
+import { getSchemaContext, shouldRetriggerSchemaFileSuggest } from "../../providers/schemaDefinitionCompletionProvider";
 import type { SchemaContext } from "../../providers/schemaDefinitionCompletionProvider";
 
 suite("Schema Definition Completion Test Suite", () => {
@@ -160,6 +160,87 @@ suite("Schema Definition Completion Test Suite", () => {
 			test("['shortcodes', 'mysc', 'arguments', 'type'] with value returns type", () => {
 				const result = getSchemaContext(["shortcodes", "mysc", "arguments", "type"], true);
 				assert.deepStrictEqual(result, { kind: "value", valueType: "type" });
+			});
+		});
+	});
+
+	suite("shouldRetriggerSchemaFileSuggest", () => {
+		suite("returns true", () => {
+			test("root level (empty document)", () => {
+				const lines = [""];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 0, 0, "yaml"), true);
+			});
+
+			test("field descriptor key under options.<name>", () => {
+				const lines = ["options:", "  myField:", "    typ"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 2, 7, "yaml"), true);
+			});
+
+			test("shortcode entry key under shortcodes.<name>", () => {
+				const lines = ["shortcodes:", "  mysc:", "    arg"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 2, 7, "yaml"), true);
+			});
+
+			test("value position for type:", () => {
+				const lines = ["options:", "  myField:", "    type: str"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 2, 13, "yaml"), true);
+			});
+
+			test("value position for $schema:", () => {
+				const lines = ["$schema: http"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 0, 13, "yaml"), true);
+			});
+
+			test("value position for boolean property (required:)", () => {
+				const lines = ["options:", "  myField:", "    required: t"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 2, 15, "yaml"), true);
+			});
+
+			test("blank line at field descriptor indent", () => {
+				const lines = ["options:", "  myField:", "    type: string", "    "];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 3, 4, "yaml"), true);
+			});
+		});
+
+		suite("returns false", () => {
+			test("under options: at depth 1 (user-defined name)", () => {
+				const lines = ["options:", "  my"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 1, 4, "yaml"), false);
+			});
+
+			test("under projects:", () => {
+				const lines = ["projects:", "  proj"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 1, 6, "yaml"), false);
+			});
+
+			test("under formats: at depth 1 (user-defined format)", () => {
+				const lines = ["formats:", "  htm"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 1, 5, "yaml"), false);
+			});
+
+			test("under formats: at depth 2 (user-defined field name)", () => {
+				const lines = ["formats:", "  html:", "    col"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 2, 7, "yaml"), false);
+			});
+
+			test("under shortcodes: at depth 1 (user-defined shortcode name)", () => {
+				const lines = ["shortcodes:", "  my"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 1, 4, "yaml"), false);
+			});
+
+			test("under shortcodes.<name>.attributes: at depth 3 (user-defined attr)", () => {
+				const lines = ["shortcodes:", "  mysc:", "    attributes:", "      fla"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 3, 9, "yaml"), false);
+			});
+
+			test("value position for non-completable key (description:)", () => {
+				const lines = ["options:", "  myField:", "    description: some text"];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 2, 25, "yaml"), false);
+			});
+
+			test("blank line at user-defined name indent under options:", () => {
+				const lines = ["options:", "  "];
+				assert.strictEqual(shouldRetriggerSchemaFileSuggest(lines, 1, 2, "yaml"), false);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

- Add `shouldRetriggerSchemaFileSuggest` in `schemaDefinitionCompletionProvider.ts` that delegates to `getSchemaContext` to check whether completions would actually be produced before re-triggering the suggest widget on backspace.
- Replace the `isInYamlRegion` call in the backspace handler (`registerYamlProviders.ts`) with the new function, so schema definition files behave the same as regular YAML files and do not show "No suggestions." at non-completable positions.
- Add 15 unit tests covering both true and false cases for the new function.

## Test plan

- [x] Existing tests pass (`npm run test`; 10 pre-existing failures in `activate.test.ts` unrelated to this change).
- [x] New `shouldRetriggerSchemaFileSuggest` tests cover root level, field descriptor keys, shortcode entry keys, value positions, blank lines, user-defined name positions, `projects:`, and non-completable value positions.
- [ ] Manual: open a `_schema.yml` file, press backspace at a user-defined name position (e.g. under `options:`) and confirm no "No suggestions." popup appears.