### PR TITLE
docs: dd snippet specification

### DIFF
--- a/docs/_sidebar-reference.yml
+++ b/docs/_sidebar-reference.yml
@@ -10,4 +10,5 @@ website:
             - reference/commands.qmd
             - reference/configuration.qmd
             - reference/schema-specification.qmd
+            - reference/snippet-specification.qmd
             - reference/environment-variables.qmd

--- a/docs/_templates/reference-index.qmd
+++ b/docs/_templates/reference-index.qmd
@@ -27,6 +27,11 @@ See [Configuration Reference](configuration.qmd) for all available options.
 Quarto extensions can provide a `_schema.yml` file to declare their configuration options, shortcode parameters, format options, and element attributes.
 See [Extension Schema Specification](schema-specification.qmd) for the full format reference.
 
+## Extension Snippets
+
+Quarto extensions can provide a `_snippets.json` file for snippets in Explorer and IntelliSense.
+See [Extension Snippet Specification](snippet-specification.qmd) for Quarto Wizard specifics.
+
 ## API Reference
 
 For developers integrating with the `@quarto-wizard/core`, `@quarto-wizard/schema`, or `@quarto-wizard/snippets` packages, see the [API Reference](../api/index.qmd).

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -45,6 +45,11 @@ See [Configuration Reference](configuration.qmd) for all available options.
 Quarto extensions can provide a `_schema.yml` file to declare their configuration options, shortcode parameters, format options, and element attributes.
 See [Extension Schema Specification](schema-specification.qmd) for the full format reference.
 
+## Extension Snippets
+
+Quarto extensions can provide a `_snippets.json` file for snippets in Explorer and IntelliSense.
+See [Extension Snippet Specification](snippet-specification.qmd) for Quarto Wizard specifics.
+
 ## API Reference
 
 For developers integrating with the `@quarto-wizard/core`, `@quarto-wizard/schema`, or `@quarto-wizard/snippets` packages, see the [API Reference](../api/index.qmd).

--- a/docs/reference/snippet-specification.qmd
+++ b/docs/reference/snippet-specification.qmd
@@ -1,0 +1,39 @@
+---
+title: "Extension Snippet Specification"
+---
+
+Quarto extensions can provide a `_snippets.json` file for snippet completion and insertion in Quarto Wizard.
+The file format follows the standard VS Code snippet JSON specification.
+For the complete format reference, see [VS Code: Snippet syntax](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax).
+
+## File Location
+
+Place `_snippets.json` in the same directory as `_extension.yml`.
+
+```text
+_extensions/
+  my-extension/
+    _extension.yml
+    _snippets.json
+```
+
+Quarto Wizard discovers snippet files automatically when scanning installed extensions.
+
+## Minimal Example
+
+```json
+{
+  "Callout Note": {
+    "prefix": "callout-note",
+    "body": ["::: {.callout-note}", "$0", ":::"],
+    "description": "Insert a callout note block."
+  }
+}
+```
+
+## Quarto Wizard Behaviour
+
+- Snippets are shown under each installed extension in the Explorer view.
+- Snippets are available in IntelliSense for Quarto documents.
+- Snippet prefixes are namespaced as `<owner>-<extension>:<prefix>` (or `<extension>:<prefix>` when no owner exists) to avoid collisions.
+- Selecting **Insert Snippet** from the Explorer inserts the snippet body into the active editor.

--- a/scripts/process-api-docs.mjs
+++ b/scripts/process-api-docs.mjs
@@ -901,6 +901,7 @@ function generateReferenceSidebar() {
             - reference/commands.qmd
             - reference/configuration.qmd
             - reference/schema-specification.qmd
+            - reference/snippet-specification.qmd
             - reference/environment-variables.qmd
 `;
 


### PR DESCRIPTION
Introduce documentation for using `_snippets.json` files in Quarto extensions, enhancing snippet completion and IntelliSense support in Quarto Wizard. Update sidebar and reference index to include this new section.