### PR TITLE
ci: add use-main-as-release option to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,11 @@ name: Deploy Documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      use-main-as-release:
+        description: "Render release site from main instead of latest tag"
+        type: boolean
+        default: false
   release:
     types:
       - published
@@ -39,6 +44,7 @@ jobs:
           version: pre-release
 
       - name: Get latest tag
+        if: inputs.use-main-as-release != true
         id: latest-tag
         shell: bash
         run: |
@@ -51,6 +57,7 @@ jobs:
           echo "Latest tag: ${LATEST_TAG}"
 
       - name: Checkout latest tag
+        if: inputs.use-main-as-release != true
         shell: bash
         env:
           LATEST_TAG: ${{ steps.latest-tag.outputs.tag }}


### PR DESCRIPTION
## Summary

- Add a `use-main-as-release` boolean input to the `workflow_dispatch` trigger in the deploy workflow.
- When set to `true`, the "Get latest tag" and "Checkout latest tag" steps are skipped, so the release site renders from main.
- Default behaviour (`false`) is unchanged: the release site renders from the latest git tag.

## Test plan

- [ ] Run the workflow manually with `use-main-as-release: false` and confirm it renders from the latest tag.
- [ ] Run the workflow manually with `use-main-as-release: true` and confirm it renders from main.