### PR TITLE
fix: guard against false linting diagnostics with CRLF line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix: guard against false linting diagnostics inside code blocks with CRLF line endings (#301).
+
 ## 2.2.0 (2026-02-25)
 
 ### New Features

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -249,10 +249,22 @@ interface BlockMatch {
 }
 
 /**
+ * Check whether a match range overlaps any code block range.
+ * Tests both endpoints and spanning (match starts before and ends inside a block).
+ */
+function overlapsCodeBlock(ranges: TextRange[], matchStart: number, matchEnd: number): boolean {
+	return (
+		isInCodeBlockRange(ranges, matchStart) ||
+		isInCodeBlockRange(ranges, matchEnd) ||
+		ranges.some((r) => matchStart < r.start && matchEnd >= r.start)
+	);
+}
+
+/**
  * Extract all attribute blocks and shortcode blocks from document text,
  * excluding matches that fall inside fenced code blocks.
  */
-function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[] {
+export function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[] {
 	const ranges = codeBlockRanges ?? getCodeBlockRanges(text);
 	const blocks: BlockMatch[] = [];
 
@@ -260,7 +272,7 @@ function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[
 		if (match.index === undefined) {
 			continue;
 		}
-		if (isInCodeBlockRange(ranges, match.index)) {
+		if (overlapsCodeBlock(ranges, match.index, match.index + match[0].length - 1)) {
 			continue;
 		}
 		// Content is everything between { and }.
@@ -273,7 +285,7 @@ function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[
 		if (match.index === undefined) {
 			continue;
 		}
-		if (isInCodeBlockRange(ranges, match.index)) {
+		if (overlapsCodeBlock(ranges, match.index, match.index + match[0].length - 1)) {
 			continue;
 		}
 		// Content is everything between {{< and >}}.

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -5,6 +5,7 @@ import {
 	findKeyValueOffset,
 	findArgumentOffset,
 	extractBareWords,
+	extractBlocks,
 	validateInlineValue,
 } from "../../providers/inlineAttributeDiagnosticsProvider";
 import type { FieldDescriptor } from "@quarto-wizard/schema";
@@ -544,6 +545,61 @@ suite("Inline Attribute Diagnostics", () => {
 		test("should not flag = not preceded by an identifier", () => {
 			const results = findEmptyValueAssignments("=");
 			assert.strictEqual(results.length, 0);
+		});
+	});
+
+	suite("extractBlocks (CRLF)", () => {
+		test("should not return blocks from inside a code block with CRLF", () => {
+			const text = "---\r\ntitle: Test\r\n---\r\n\r\n```{r}\r\nfunction(x) {\r\n  x + 1\r\n}\r\n```\r\n";
+			const blocks = extractBlocks(text);
+			// Only the {r} on the fence header should be returned, not the
+			// curly braces inside the code body.
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, "r");
+		});
+
+		test("should return {r} from fence header with CRLF", () => {
+			const text = "text\r\n```{r}\r\ncode\r\n```\r\nmore";
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, "r");
+			assert.strictEqual(blocks[0].type, "element");
+		});
+
+		test("should not produce spaces-around-equals findings inside code blocks with CRLF", () => {
+			const text = ["---", "title: Test", "---", "", "```{r}", "x = 1", "y = 2", "```", ""].join("\r\n");
+			const blocks = extractBlocks(text);
+			// Only {r} from the fence header.
+			const codeBlocks = blocks.filter((b) => b.content !== "r");
+			for (const block of codeBlocks) {
+				const findings = findSpacesAroundEquals(block.content);
+				assert.strictEqual(findings.length, 0, `Unexpected finding in block content: "${block.content}"`);
+			}
+		});
+
+		test("should not return blocks from R code with key = value patterns and CRLF", () => {
+			const text = [
+				"---",
+				"title: Example document",
+				"---",
+				"",
+				"```{r}",
+				"#| label: example-code",
+				"",
+				"theme_simulation <- function() {",
+				"  theme_minimal() +",
+				"    theme(",
+				'      axis.text.y = element_text(face = "bold"),',
+				"      axis.text.x = element_text(angle = 45, hjust = 1),",
+				'      strip.background = element_rect(fill = "#F0F0F0", colour = NA),',
+				"    )",
+				"}",
+				"```",
+			].join("\r\n");
+			const blocks = extractBlocks(text);
+			// Only {r} from the fence header should be extracted.
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, "r");
 		});
 	});
 

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -363,6 +363,38 @@ suite("YAML Position Utils Test Suite", () => {
 			const ranges = getCodeBlockRanges(text);
 			assert.strictEqual(ranges.length, 0);
 		});
+
+		test("should detect a backtick-fenced code block with CRLF line endings", () => {
+			const text = "before\r\n```\r\ncode\r\n```\r\nafter";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			// Range includes trailing \r on the closing fence line.
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "code\r\n```\r");
+		});
+
+		test("should exclude opening fence header with info string and CRLF", () => {
+			const text = "text\r\n```{r}\r\nx <- 1\r\n```\r\nmore";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			// The {r} header is NOT inside the range.
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "x <- 1\r\n```\r");
+		});
+
+		test("should cover curly-brace content inside code block body with CRLF", () => {
+			const text = "text\r\n```{r}\r\nfunction(x) {\r\n  x + 1\r\n}\r\n```\r\nafter";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			const block = text.slice(ranges[0].start, ranges[0].end);
+			assert.ok(block.includes("function(x) {"));
+			assert.ok(block.includes("}"));
+			assert.ok(!block.includes("```{r}"));
+		});
+
+		test("should handle multiple code blocks with CRLF", () => {
+			const text = "a\r\n```\r\nb\r\n```\r\nc\r\n~~~\r\nd\r\n~~~\r\ne";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 2);
+		});
 	});
 
 	suite("isInCodeBlockRange", () => {
@@ -428,6 +460,28 @@ suite("YAML Position Utils Test Suite", () => {
 			const text = "```\ncode\n```";
 			const ranges = getCodeBlockRanges(text);
 			assert.strictEqual(isInCodeBlockRange(ranges, ranges[0].end - 1), true);
+		});
+
+		test("should return true for offset inside code block body with CRLF", () => {
+			const text = "before\r\n```\r\ncode\r\n```\r\nafter";
+			const ranges = getCodeBlockRanges(text);
+			// "code" starts after "before\r\n```\r\n" = 13 chars.
+			const codeOffset = text.indexOf("code");
+			assert.strictEqual(isInCodeBlockRange(ranges, codeOffset), true);
+		});
+
+		test("should return false for {r} on fence header with CRLF", () => {
+			const text = "text\r\n```{r}\r\nx <- 1\r\n```\r\nmore";
+			const ranges = getCodeBlockRanges(text);
+			const braceOffset = text.indexOf("{r}");
+			assert.strictEqual(isInCodeBlockRange(ranges, braceOffset), false);
+		});
+
+		test("should return true for curly braces inside code body with CRLF", () => {
+			const text = "text\r\n```{r}\r\nfunction(x) {\r\n  x + 1\r\n}\r\n```\r\nafter";
+			const ranges = getCodeBlockRanges(text);
+			const innerBrace = text.indexOf("function(x) {") + "function(x) ".length;
+			assert.strictEqual(isInCodeBlockRange(ranges, innerBrace), true);
 		});
 	});
 });

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -38,9 +38,10 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 	let closingFenceRe: RegExp | undefined;
 
 	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
+		const rawLine = lines[i];
+		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
 		const lineStart = offset;
-		const lineEnd = lineStart + line.length;
+		const lineEnd = lineStart + rawLine.length;
 		// Advance offset past the newline for the next iteration.
 		offset = lineEnd + (i < lines.length - 1 ? 1 : 0);
 


### PR DESCRIPTION
Fixes #301.

JavaScript's `.` regex metacharacter does not match `\r`.
The opening fence regex in `getCodeBlockRanges` failed on lines with trailing `\r` from CRLF endings, so no code blocks were detected.
This caused curly braces and `=` signs inside fenced code blocks to be flagged as attribute blocks, producing false `spaces-around-equals` diagnostics.

Strip trailing `\r` before regex matching while preserving the raw line length for offset calculations.
Add an `overlapsCodeBlock` helper that checks both endpoints of a match against code block ranges.
Eleven new CRLF-specific tests cover `getCodeBlockRanges`, `isInCodeBlockRange`, and `extractBlocks`.