### PR TITLE
fix: guard against false linting diagnostics with indented code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix: guard against false linting diagnostics with indented fenced code blocks.
+
 ## 2.2.1 (2026-03-12)
 
 ### Fixes

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -601,6 +601,33 @@ suite("Inline Attribute Diagnostics", () => {
 			assert.strictEqual(blocks.length, 1);
 			assert.strictEqual(blocks[0].content, "r");
 		});
+		test("should not return blocks from inside an indented code block", () => {
+			const text = [
+				"- demo",
+				"",
+				'  ```{.r filename="demo.qmd"}',
+				"  function(x = 1) {",
+				"    x = 1",
+				"  }",
+				"  ```",
+				"",
+				"- test",
+			].join("\n");
+			const blocks = extractBlocks(text);
+			// Only {.r filename="demo.qmd"} from the fence header.
+			assert.strictEqual(blocks.length, 1);
+			assert.ok(blocks[0].content.startsWith(".r"));
+		});
+
+		test("should not produce spaces-around-equals findings inside indented code blocks", () => {
+			const text = ["- demo", "", "  ```{r}", "  x = 1", "  y = 2", "  ```"].join("\n");
+			const blocks = extractBlocks(text);
+			const codeBlocks = blocks.filter((b) => b.content !== "r");
+			for (const block of codeBlocks) {
+				const findings = findSpacesAroundEquals(block.content);
+				assert.strictEqual(findings.length, 0, `Unexpected finding in block content: "${block.content}"`);
+			}
+		});
 	});
 
 	suite("extractBareWords", () => {

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -395,6 +395,30 @@ suite("YAML Position Utils Test Suite", () => {
 			const ranges = getCodeBlockRanges(text);
 			assert.strictEqual(ranges.length, 2);
 		});
+
+		test("should detect indented fenced code block (2-space indent)", () => {
+			const text = "- item\n\n  ```{r}\n  x = 1\n  ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			const body = text.substring(ranges[0].start, ranges[0].end);
+			assert.ok(body.includes("x = 1"));
+		});
+
+		test("should detect indented fenced code block (4-space indent)", () => {
+			const text = "- item\n\n    ```{r}\n    x = 1\n    ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			const body = text.substring(ranges[0].start, ranges[0].end);
+			assert.ok(body.includes("x = 1"));
+		});
+
+		test("should detect indented tilde-fenced code block", () => {
+			const text = "- item\n\n  ~~~python\n  x = 1\n  ~~~\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			const body = text.substring(ranges[0].start, ranges[0].end);
+			assert.ok(body.includes("x = 1"));
+		});
 	});
 
 	suite("isInCodeBlockRange", () => {

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -419,6 +419,14 @@ suite("YAML Position Utils Test Suite", () => {
 			const body = text.substring(ranges[0].start, ranges[0].end);
 			assert.ok(body.includes("x = 1"));
 		});
+
+		test("should detect indented fenced code block with CRLF", () => {
+			const text = "- item\r\n\r\n  ```{r}\r\n  x = 1\r\n  ```\r\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			const body = text.substring(ranges[0].start, ranges[0].end);
+			assert.ok(body.includes("x = 1"));
+		});
 	});
 
 	suite("isInCodeBlockRange", () => {

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -55,11 +55,11 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			continue;
 		}
 
-		// Check for opening fence at the start of the line.
-		const openMatch = /^(`{3,}|~{3,})(.*)$/.exec(line);
+		// Check for opening fence, optionally indented.
+		const openMatch = /^(\s*)(`{3,}|~{3,})(.*)$/.exec(line);
 		if (openMatch) {
 			// The info string must not contain backticks when using backtick fences.
-			if (openMatch[1][0] === "`" && openMatch[2].includes("`")) {
+			if (openMatch[2][0] === "`" && openMatch[3].includes("`")) {
 				continue;
 			}
 			inBlock = true;
@@ -68,7 +68,7 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			blockStart = offset;
 			// Compile the closing fence regex once per block.
 			// fenceChar is always ` or ~, neither is a regex metacharacter.
-			closingFenceRe = new RegExp(`^${openMatch[1][0]}{${openMatch[1].length},}\\s*$`);
+			closingFenceRe = new RegExp(`^\\s*${openMatch[2][0]}{${openMatch[2].length},}\\s*$`);
 		}
 	}
 


### PR DESCRIPTION
The opening fence regex in `getCodeBlockRanges()` required backticks/tildes at column 0, so indented fenced code blocks (e.g., inside list items) were not detected as code blocks. This caused false "remove spaces around '='" diagnostics on code like `x = 1` inside those blocks.

The fix allows optional leading whitespace in both opening and closing fence regexes. All existing consumers of `getCodeBlockRanges()` (inline attribute diagnostics, shortcode parser, element attribute parser) automatically benefit from the fix.