### PR TITLE
fix: allow backticks inside quoted values in fence info strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix: allow backticks inside quoted values in fence info strings, preventing false "Remove spaces around =" diagnostics.
+
 ## 2.3.0 (2026-04-13)
 
 ### New Features

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -628,6 +628,29 @@ suite("Inline Attribute Diagnostics", () => {
 				assert.strictEqual(findings.length, 0, `Unexpected finding in block content: "${block.content}"`);
 			}
 		});
+
+		test("should not extract blocks from code body when fence info has quoted backticks", () => {
+			const text = [
+				'```{.r code-summary="Show `theme_brand()` implementation"}',
+				"theme_brand <- function() {",
+				"  amount = 0.25",
+				"}",
+				"```",
+			].join("\n");
+			const blocks = extractBlocks(text);
+			// Only the fence header block should be extracted.
+			assert.strictEqual(blocks.length, 1);
+			assert.ok(blocks[0].content.startsWith(".r"));
+		});
+
+		test("should not produce spaces-around-equals findings when fence info has quoted backticks", () => {
+			const text = ['```{.r code-summary="Show `theme_brand()` implementation"}', "amount = 0.25", "```"].join("\n");
+			const blocks = extractBlocks(text);
+			for (const block of blocks) {
+				const findings = findSpacesAroundEquals(block.content);
+				assert.strictEqual(findings.length, 0, `Unexpected finding in block content: "${block.content}"`);
+			}
+		});
 	});
 
 	suite("extractBareWords", () => {

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -6,6 +6,7 @@ import {
 	getExistingKeysAtPath,
 	getCodeBlockRanges,
 	isInCodeBlockRange,
+	hasUnquotedBacktick,
 } from "../../utils/yamlPosition";
 
 suite("YAML Position Utils Test Suite", () => {
@@ -364,6 +365,27 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.strictEqual(ranges.length, 0);
 		});
 
+		test("should recognise backtick fence when backticks are inside double-quoted info string", () => {
+			const text = '```{.r code-summary="Show `theme_brand()` implementation"}\namount = 0.25\n```';
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.slice(ranges[0].start, ranges[0].end).includes("amount = 0.25"));
+		});
+
+		test("should recognise backtick fence when backticks are inside single-quoted info string", () => {
+			const text = "```{.r code-summary='Show `x` usage'}\ncode here\n```";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.slice(ranges[0].start, ranges[0].end).includes("code here"));
+		});
+
+		test("should reject backtick fence with backticks both inside and outside quotes", () => {
+			// The first line has a bare backtick outside quotes so it is not a valid fence.
+			const text = '```{.r code-summary="Show `x`"} `bare\ncontent';
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 0);
+		});
+
 		test("should detect a backtick-fenced code block with CRLF line endings", () => {
 			const text = "before\r\n```\r\ncode\r\n```\r\nafter";
 			const ranges = getCodeBlockRanges(text);
@@ -514,6 +536,40 @@ suite("YAML Position Utils Test Suite", () => {
 			const ranges = getCodeBlockRanges(text);
 			const innerBrace = text.indexOf("function(x) {") + "function(x) ".length;
 			assert.strictEqual(isInCodeBlockRange(ranges, innerBrace), true);
+		});
+	});
+
+	suite("hasUnquotedBacktick", () => {
+		test("should return false for empty string", () => {
+			assert.strictEqual(hasUnquotedBacktick(""), false);
+		});
+
+		test("should return true for bare backtick", () => {
+			assert.strictEqual(hasUnquotedBacktick("foo`bar"), true);
+		});
+
+		test("should return false when backtick is inside double quotes", () => {
+			assert.strictEqual(hasUnquotedBacktick('{.r code-summary="Show `theme_brand()` implementation"}'), false);
+		});
+
+		test("should return false when backtick is inside single quotes", () => {
+			assert.strictEqual(hasUnquotedBacktick("{.r code-summary='Show `theme_brand()` implementation'}"), false);
+		});
+
+		test("should return true when backtick is outside quotes even if some are inside", () => {
+			assert.strictEqual(hasUnquotedBacktick('{.r code-summary="Show `x`"} `bare'), true);
+		});
+
+		test("should return false when no backticks are present", () => {
+			assert.strictEqual(hasUnquotedBacktick('{.r code-summary="no ticks"}'), false);
+		});
+
+		test("should return false for backtick inside double quotes only", () => {
+			assert.strictEqual(hasUnquotedBacktick('"`"'), false);
+		});
+
+		test("should return false for backtick inside single quotes only", () => {
+			assert.strictEqual(hasUnquotedBacktick("'`'"), false);
 		});
 	});
 });

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -16,6 +16,32 @@ export interface TextRange {
 }
 
 /**
+ * Check whether a fence info string contains a backtick outside of any
+ * quoted context.  Pandoc attribute syntax allows backticks inside
+ * single- or double-quoted values (e.g.
+ * `code-summary="Show \`fn()\` usage"`), so a naive `includes` check
+ * would incorrectly reject valid Quarto fence headers.
+ *
+ * @param infoString - The portion of the fence line after the opening
+ *   backticks/tildes (i.e. the info string).
+ * @returns `true` if any backtick appears outside single or double quotes.
+ */
+export function hasUnquotedBacktick(infoString: string): boolean {
+	let inDouble = false;
+	let inSingle = false;
+	for (const ch of infoString) {
+		if (ch === '"' && !inSingle) {
+			inDouble = !inDouble;
+		} else if (ch === "'" && !inDouble) {
+			inSingle = !inSingle;
+		} else if (ch === "`" && !inDouble && !inSingle) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Find all fenced code block body regions in the document text.
  *
  * Recognises both backtick (`` ``` ``) and tilde (`~~~`) fences, with
@@ -58,8 +84,10 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 		// Check for opening fence, optionally indented.
 		const openMatch = /^(\s*)(`{3,}|~{3,})(.*)$/.exec(line);
 		if (openMatch) {
-			// The info string must not contain backticks when using backtick fences.
-			if (openMatch[2][0] === "`" && openMatch[3].includes("`")) {
+			// The info string must not contain bare backticks when using backtick
+			// fences (CommonMark spec).  Backticks inside quoted attribute values
+			// are allowed (Pandoc/Quarto extension).
+			if (openMatch[2][0] === "`" && hasUnquotedBacktick(openMatch[3])) {
 				continue;
 			}
 			inBlock = true;


### PR DESCRIPTION
Code block detection rejected backtick fences whose info string contained any backtick character per CommonMark spec. Quarto/Pandoc allows backticks inside quoted attribute values in fence headers (e.g., `code-summary="Show `fn()` usage"`), so these fences were not recognised as code blocks. The inline attribute diagnostics then incorrectly flagged assignments like `amount = 0.25` inside the code body with "Remove spaces around '='".

The naive `String.includes` check is replaced with a quote-aware scanner (`hasUnquotedBacktick`) that only rejects backticks outside single- or double-quoted contexts. Unit tests for the new function and integration tests for the fence detection and diagnostics pipeline are included.