### PR TITLE
feat: respect source-type during update checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- feat: update checks now follow the recorded `source-type`. Extensions installed via the registry resolve against the Quarto registry, while extensions installed with `quarto add owner/repo` resolve against GitHub releases and tags directly. A new `quartoWizard.update.crossSource` setting (disabled by default) restores the previous behaviour of falling back to the registry for GitHub-sourced extensions.
+
+### Fixes
+
+- fix: skip prerelease tags (e.g. `v2.0.0-beta.1`) when falling back to GitHub tags for update discovery, matching the prerelease filtering already applied to GitHub releases.
+
 ## 2.3.1 (2026-04-15)
 
 ### Dependency Updates

--- a/package.json
+++ b/package.json
@@ -660,6 +660,15 @@
 					"title": "Confirm Installation",
 					"description": "Prompt before installing."
 				},
+				"quartoWizard.update.crossSource": {
+					"order": 3,
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Allow cross-source update discovery. When disabled (default), update checks respect the recorded `source-type`: extensions installed via the registry are resolved against the registry, and extensions installed with `quarto add owner/repo` are resolved against GitHub releases directly. When enabled, GitHub-sourced extensions also fall back to the registry when GitHub has no releases or tags.",
+					"title": "Cross-source Updates",
+					"description": "Allow registry lookup for GitHub-sourced extensions."
+				},
 				"quartoWizard.cache.ttlMinutes": {
 					"order": 10,
 					"scope": "resource",

--- a/packages/core/src/operations/update.ts
+++ b/packages/core/src/operations/update.ts
@@ -281,7 +281,10 @@ async function buildGitHubUpdate(
 	if (!latestTag) {
 		try {
 			const tags = await fetchTags(owner, repo, githubOptions);
-			const tag = tags[0];
+			// Match `fetchReleases`'s default filtering: skip prerelease-style tags
+			// so a repo that only ships v2.0.0-beta.1 via tags doesn't get flagged
+			// as an update.
+			const tag = tags.find((t) => !isPrereleaseTag(t.name));
 			if (tag) {
 				latestTag = tag.name;
 			}
@@ -406,6 +409,20 @@ function extractCommitFromSource(source: string): string | null {
 		return ref.toLowerCase();
 	}
 	return null;
+}
+
+/**
+ * Determine whether a tag name encodes a prerelease (e.g. `v2.0.0-beta.1`).
+ * `normaliseVersion` runs through `semver.coerce`, which strips prerelease
+ * identifiers, so this check operates on the raw tag.
+ */
+function isPrereleaseTag(tag: string): boolean {
+	const cleaned = tag.replace(/^v/, "").trim();
+	const parsed = semver.parse(cleaned, { loose: true });
+	if (parsed) {
+		return parsed.prerelease.length > 0;
+	}
+	return semver.prerelease(cleaned, { loose: true }) !== null;
 }
 
 /**

--- a/packages/core/src/operations/update.ts
+++ b/packages/core/src/operations/update.ts
@@ -11,13 +11,16 @@ import * as semver from "semver";
 import type { AuthConfig } from "../types/auth.js";
 import type { ExtensionId } from "../types/extension.js";
 import { formatExtensionId } from "../types/extension.js";
+import { getEffectiveSourceType, splitSourceRef } from "../types/manifest.js";
 import {
 	discoverInstalledExtensions,
 	findInstalledExtension,
 	type InstalledExtension,
 } from "../filesystem/discovery.js";
+import type { Registry } from "../types/registry.js";
 import { fetchRegistry, type RegistryOptions } from "../registry/fetcher.js";
 import { lookupRegistryEntry } from "../registry/search.js";
+import { fetchReleases, fetchTags } from "../github/releases.js";
 import { install, parseInstallSource } from "./install.js";
 import { getErrorMessage } from "../errors.js";
 
@@ -45,6 +48,15 @@ export interface UpdateCheckOptions extends RegistryOptions {
 	projectDir: string;
 	/** Specific extension to check (all if omitted). */
 	extension?: ExtensionId;
+	/**
+	 * Allow registry lookup to resolve updates for GitHub-sourced extensions.
+	 *
+	 * When false (default), extensions with `sourceType: "github"` are resolved
+	 * against GitHub releases/tags directly, respecting how they were installed.
+	 * When true, if the GitHub lookup yields no tag, fall back to the registry
+	 * (legacy behaviour).
+	 */
+	crossSource?: boolean;
 }
 
 /**
@@ -86,7 +98,7 @@ export interface UpdateResult {
  * @returns Array of available updates
  */
 export async function checkForUpdates(options: UpdateCheckOptions): Promise<UpdateInfo[]> {
-	const { projectDir, extension: targetExtension, ...registryOptions } = options;
+	const { projectDir, extension: targetExtension, crossSource = false, ...registryOptions } = options;
 
 	let extensions: InstalledExtension[];
 
@@ -97,76 +109,213 @@ export async function checkForUpdates(options: UpdateCheckOptions): Promise<Upda
 		extensions = await discoverInstalledExtensions(projectDir);
 	}
 
-	const registry = await fetchRegistry(registryOptions);
+	// Group extensions by the path they'll use for update discovery so we only
+	// fetch the registry when something actually needs it.
+	const registryBound: InstalledExtension[] = [];
+	const githubBound: InstalledExtension[] = [];
+	for (const ext of extensions) {
+		if (!ext.manifest.source) {
+			continue;
+		}
+		const effectiveType = getEffectiveSourceType(ext.manifest);
+		if (effectiveType === "github") {
+			githubBound.push(ext);
+		} else if (effectiveType === "registry") {
+			registryBound.push(ext);
+		}
+		// url/local/unknown are intentionally skipped: they aren't resolvable.
+	}
+
+	const needsRegistry = registryBound.length > 0 || (crossSource && githubBound.length > 0);
+	const registry = needsRegistry ? await fetchRegistry(registryOptions) : null;
 	const updates: UpdateInfo[] = [];
 
-	for (const ext of extensions) {
+	for (const ext of registryBound) {
 		const source = ext.manifest.source;
-
-		if (!source) {
+		if (!source || !registry) {
 			continue;
 		}
-
-		// Strip @ref unconditionally for registry lookup. Non-registry sources
-		// (URLs, local paths) won't match any registry entry and are skipped.
-		const atIndex = source.lastIndexOf("@");
-		const baseName = atIndex > 0 ? source.substring(0, atIndex) : source;
-		const entry = lookupRegistryEntry(registry, baseName);
-
-		if (!entry) {
-			continue;
+		const update = buildRegistryUpdate(ext, source, registry);
+		if (update) {
+			updates.push(update);
 		}
+	}
 
-		// Check for commit-based installation
-		const currentCommit = extractCommitFromSource(source);
-
-		if (currentCommit && entry.latestCommit) {
-			// Commit-based comparison
-			const latestCommit = entry.latestCommit.substring(0, 7).toLowerCase();
-
-			if (currentCommit !== latestCommit) {
-				updates.push({
-					extension: ext,
-					currentVersion: currentCommit,
-					latestVersion: latestCommit,
-					releaseUrl: entry.htmlUrl,
-					source: `${entry.fullName}@${latestCommit}`,
-				});
+	const githubResults = await Promise.all(
+		githubBound.map(async (ext) => {
+			const source = ext.manifest.source;
+			if (!source) {
+				return null;
 			}
-			continue; // Skip semver comparison for commit-based
-		}
-
-		// Semver-based comparison for tagged releases
-		if (!entry.latestVersion) {
-			continue;
-		}
-
-		const currentVersion = normaliseVersion(ext.manifest.version);
-		const latestVersion = normaliseVersion(entry.latestVersion);
-
-		if (!currentVersion || !latestVersion) {
-			continue;
-		}
-
-		try {
-			if (semver.gt(latestVersion, currentVersion)) {
-				updates.push({
-					extension: ext,
-					currentVersion,
-					latestVersion,
-					releaseUrl: entry.latestReleaseUrl,
-					source: entry.latestTag ? `${entry.fullName}@${entry.latestTag}` : entry.fullName,
-				});
+			const update = await buildGitHubUpdate(ext, source, registryOptions);
+			if (update) {
+				return update;
 			}
-		} catch {
-			// semver.gt throws if versions are invalid (e.g., "1.0" vs proper semver "1.0.0").
-			// Skip this extension rather than failing the entire update check since
-			// one malformed version shouldn't prevent checking other extensions.
-			continue;
+			if (crossSource && registry) {
+				return buildRegistryUpdate(ext, source, registry);
+			}
+			return null;
+		}),
+	);
+
+	for (const update of githubResults) {
+		if (update) {
+			updates.push(update);
 		}
 	}
 
 	return updates;
+}
+
+/**
+ * Resolve a registry-sourced extension against the registry, producing an
+ * UpdateInfo only if a newer tag or commit is advertised.
+ */
+function buildRegistryUpdate(ext: InstalledExtension, source: string, registry: Registry): UpdateInfo | null {
+	const { base: baseName } = splitSourceRef(source);
+	const entry = lookupRegistryEntry(registry, baseName);
+
+	if (!entry) {
+		return null;
+	}
+
+	const currentCommit = extractCommitFromSource(source);
+
+	if (currentCommit && entry.latestCommit) {
+		const latestCommit = entry.latestCommit.substring(0, 7).toLowerCase();
+		if (currentCommit === latestCommit) {
+			return null;
+		}
+		return {
+			extension: ext,
+			currentVersion: currentCommit,
+			latestVersion: latestCommit,
+			releaseUrl: entry.htmlUrl,
+			source: `${entry.fullName}@${latestCommit}`,
+		};
+	}
+
+	if (currentCommit) {
+		// Current install is pinned to a commit but the registry doesn't track
+		// commits; we can't meaningfully compare, so report no update.
+		return null;
+	}
+
+	if (!entry.latestVersion) {
+		return null;
+	}
+
+	const currentVersion = normaliseVersion(ext.manifest.version);
+	const latestVersion = normaliseVersion(entry.latestVersion);
+
+	if (!currentVersion || !latestVersion) {
+		return null;
+	}
+
+	try {
+		if (semver.gt(latestVersion, currentVersion)) {
+			return {
+				extension: ext,
+				currentVersion,
+				latestVersion,
+				releaseUrl: entry.latestReleaseUrl,
+				source: entry.latestTag ? `${entry.fullName}@${entry.latestTag}` : entry.fullName,
+			};
+		}
+	} catch {
+		// Invalid semver — treat as no update rather than aborting the batch.
+		return null;
+	}
+
+	return null;
+}
+
+/**
+ * Resolve a github-sourced extension against GitHub's releases/tags APIs
+ * directly, bypassing the registry.
+ */
+async function buildGitHubUpdate(
+	ext: InstalledExtension,
+	source: string,
+	registryOptions: RegistryOptions,
+): Promise<UpdateInfo | null> {
+	// Commit-pinned installs have no comparable data outside the registry; bail
+	// before issuing any network calls.
+	if (extractCommitFromSource(source)) {
+		return null;
+	}
+
+	const { base: baseName } = splitSourceRef(source);
+	const slashIndex = baseName.indexOf("/");
+	if (slashIndex <= 0 || slashIndex === baseName.length - 1) {
+		return null;
+	}
+	const owner = baseName.substring(0, slashIndex);
+	// GitHub's releases API only addresses the repository, so drop any
+	// "owner/repo/subdir" suffix and keep the first segment after the owner.
+	const rest = baseName.substring(slashIndex + 1);
+	const nextSlash = rest.indexOf("/");
+	const repo = nextSlash === -1 ? rest : rest.substring(0, nextSlash);
+	const fullName = `${owner}/${repo}`;
+	const htmlUrl = `https://github.com/${fullName}`;
+
+	const { auth, timeout } = registryOptions;
+	const githubOptions = { auth, timeout };
+
+	let latestTag: string | undefined;
+	let latestReleaseUrl: string | null = null;
+
+	try {
+		const releases = await fetchReleases(owner, repo, githubOptions);
+		const release = releases[0];
+		if (release) {
+			latestTag = release.tagName;
+			latestReleaseUrl = release.htmlUrl;
+		}
+	} catch (error) {
+		// Network or auth failures shouldn't abort the entire update check; the
+		// caller may still fall back to the registry. No logger dependency here.
+		console.error(`Failed to fetch releases for ${fullName}: ${getErrorMessage(error)}`);
+	}
+
+	if (!latestTag) {
+		try {
+			const tags = await fetchTags(owner, repo, githubOptions);
+			const tag = tags[0];
+			if (tag) {
+				latestTag = tag.name;
+			}
+		} catch (error) {
+			console.error(`Failed to fetch tags for ${fullName}: ${getErrorMessage(error)}`);
+		}
+	}
+
+	if (!latestTag) {
+		return null;
+	}
+
+	const currentVersion = normaliseVersion(ext.manifest.version);
+	const latestVersion = normaliseVersion(latestTag);
+
+	if (!currentVersion || !latestVersion) {
+		return null;
+	}
+
+	try {
+		if (semver.gt(latestVersion, currentVersion)) {
+			return {
+				extension: ext,
+				currentVersion,
+				latestVersion,
+				releaseUrl: latestReleaseUrl ?? htmlUrl,
+				source: `${fullName}@${latestTag}`,
+			};
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -19,8 +19,11 @@ export {
 	type ExtensionManifest,
 	type RawManifest,
 	type SourceType,
+	getEffectiveSourceType,
 	getExtensionTypes,
+	inferSourceType,
 	normaliseManifest,
+	splitSourceRef,
 } from "./manifest.js";
 
 export {

--- a/packages/core/src/types/manifest.ts
+++ b/packages/core/src/types/manifest.ts
@@ -143,7 +143,11 @@ function parseSourceType(value: string | undefined): SourceType | undefined {
 	return value as SourceType;
 }
 
-const GITHUB_REPOSITORY_PATTERN = /^[^/\s:\\]+\/[^/\s:\\]+(?:\/[^/\s:\\]+)*(?:@[^/\s:\\]+)?$/;
+// Restrict to the characters GitHub permits in owner and repo names so that
+// inputs like `!/!@!@...` don't get misclassified and the pattern isn't
+// susceptible to polynomial backtracking (CodeQL `js/polynomial-redos`).
+// Callers must strip any `@ref` suffix first (see `splitSourceRef`).
+const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+$/;
 
 /**
  * Split a source string of the form `base@ref` into its base and an indicator

--- a/packages/core/src/types/manifest.ts
+++ b/packages/core/src/types/manifest.ts
@@ -142,3 +142,75 @@ function parseSourceType(value: string | undefined): SourceType | undefined {
 	}
 	return value as SourceType;
 }
+
+const GITHUB_REPOSITORY_PATTERN = /^[^/\s:\\]+\/[^/\s:\\]+(?:\/[^/\s:\\]+)*(?:@[^/\s:\\]+)?$/;
+
+/**
+ * Split a source string of the form `base@ref` into its base and an indicator
+ * of whether an explicit ref was present.
+ *
+ * @param source - Raw source string (e.g. `owner/repo@v1.2.3`)
+ * @returns Tuple of base and whether a ref was present
+ */
+export function splitSourceRef(source: string): { base: string; hasRef: boolean } {
+	const atIndex = source.lastIndexOf("@");
+	if (atIndex <= 0) {
+		return { base: source, hasRef: false };
+	}
+	return {
+		base: source.substring(0, atIndex),
+		hasRef: true,
+	};
+}
+
+function isLocalSourcePath(source: string): boolean {
+	return (
+		source.startsWith("file://") ||
+		source.startsWith("/") ||
+		source.startsWith("~/") ||
+		source.startsWith("\\\\") ||
+		source.startsWith(".") ||
+		/^[A-Za-z]:[/\\]/.test(source)
+	);
+}
+
+function isLegacyGitHubSource(source: string): boolean {
+	return GITHUB_REPOSITORY_PATTERN.test(source) && !source.startsWith(".");
+}
+
+/**
+ * Infer the source type from a raw source string when no explicit `source-type`
+ * was recorded in the manifest (legacy installations).
+ *
+ * @param source - Raw source string from the manifest
+ * @returns Inferred source type, or undefined if the string is unrecognised
+ */
+export function inferSourceType(source: string | undefined): SourceType | undefined {
+	if (!source) {
+		return undefined;
+	}
+	if (/^https?:\/\//.test(source)) {
+		return "url";
+	}
+	if (isLocalSourcePath(source)) {
+		return "local";
+	}
+	if (isLegacyGitHubSource(splitSourceRef(source).base)) {
+		return "registry";
+	}
+	return undefined;
+}
+
+/**
+ * Resolve the effective source type for a manifest, preferring the explicit
+ * `sourceType` field and falling back to inference from the source string.
+ *
+ * @param manifest - Parsed extension manifest
+ * @returns The resolved source type, or undefined if it cannot be determined
+ */
+export function getEffectiveSourceType(manifest: ExtensionManifest): SourceType | undefined {
+	if (manifest.sourceType) {
+		return manifest.sourceType;
+	}
+	return inferSourceType(manifest.source);
+}

--- a/packages/core/tests/manifest.test.ts
+++ b/packages/core/tests/manifest.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { normaliseManifest, getExtensionTypes } from "../src/types/manifest.js";
+import { normaliseManifest, getExtensionTypes, inferSourceType } from "../src/types/manifest.js";
 import {
 	parseManifestContent,
 	parseManifestFile,
@@ -650,5 +650,46 @@ describe("filesystem manifest functions", () => {
 			expect(content).toContain("source: owner/repo");
 			expect(content).not.toContain("source-type");
 		});
+	});
+});
+
+describe("inferSourceType", () => {
+	it("recognises owner/repo as a registry source", () => {
+		expect(inferSourceType("owner/repo")).toBe("registry");
+	});
+
+	it("recognises owner/repo/subdir as a registry source", () => {
+		expect(inferSourceType("owner/repo/subdir")).toBe("registry");
+	});
+
+	it("recognises a pinned registry source and ignores the ref", () => {
+		expect(inferSourceType("owner/repo@v1.2.3")).toBe("registry");
+	});
+
+	it("recognises https URLs as url sources", () => {
+		expect(inferSourceType("https://example.com/ext.zip")).toBe("url");
+	});
+
+	it("recognises absolute and relative paths as local sources", () => {
+		expect(inferSourceType("/tmp/my-ext")).toBe("local");
+		expect(inferSourceType("./vendor/local-ext")).toBe("local");
+	});
+
+	it("returns undefined for an empty or unrecognised source", () => {
+		expect(inferSourceType(undefined)).toBeUndefined();
+		expect(inferSourceType("")).toBeUndefined();
+		expect(inferSourceType("single-segment")).toBeUndefined();
+	});
+
+	it("completes quickly on inputs crafted to trigger polynomial backtracking", () => {
+		// Guards against a previous ReDoS shape in the GitHub repository pattern
+		// (see CodeQL rule js/polynomial-redos). Confirm that pathological-looking
+		// input with many `@` characters is rejected in well under a second.
+		const pathological = "!/!" + "@!".repeat(10_000) + "#";
+		const start = Date.now();
+		const result = inferSourceType(pathological);
+		const elapsed = Date.now() - start;
+		expect(result).toBeUndefined();
+		expect(elapsed).toBeLessThan(500);
 	});
 });

--- a/packages/core/tests/operations/update.test.ts
+++ b/packages/core/tests/operations/update.test.ts
@@ -12,7 +12,17 @@ vi.mock("../../src/registry/fetcher.js", () => ({
 	fetchRegistry: vi.fn(),
 }));
 
+vi.mock("../../src/github/releases.js", async () => {
+	const actual = await vi.importActual<typeof import("../../src/github/releases.js")>("../../src/github/releases.js");
+	return {
+		...actual,
+		fetchReleases: vi.fn().mockResolvedValue([]),
+		fetchTags: vi.fn().mockResolvedValue([]),
+	};
+});
+
 import { fetchRegistry } from "../../src/registry/fetcher.js";
+import { fetchReleases, fetchTags } from "../../src/github/releases.js";
 
 describe("checkForUpdates", () => {
 	let tempDir: string;
@@ -308,5 +318,135 @@ describe("checkForUpdates", () => {
 		const updates = await checkForUpdates({ projectDir: tempDir });
 
 		expect(updates).toHaveLength(0);
+	});
+
+	describe("source-type awareness", () => {
+		function setupExtensionWithType(
+			owner: string,
+			name: string,
+			version: string,
+			source: string,
+			sourceType: string,
+		): void {
+			const extDir = path.join(tempDir, "_extensions", owner, name);
+			fs.mkdirSync(extDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(extDir, "_extension.yml"),
+				`title: ${name}\nversion: ${version}\nsource: ${source}\nsource-type: ${sourceType}\n`,
+			);
+		}
+
+		it("resolves github-sourced extensions against GitHub releases, not the registry", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockResolvedValue([
+				{
+					tagName: "v2.5.0",
+					name: "v2.5.0",
+					zipballUrl: "",
+					tarballUrl: "",
+					htmlUrl: "https://github.com/quarto-ext/fontawesome/releases/tag/v2.5.0",
+					publishedAt: "",
+					prerelease: false,
+					draft: false,
+				},
+			]);
+			vi.mocked(fetchRegistry).mockResolvedValue({
+				"quarto-ext/fontawesome": {
+					fullName: "quarto-ext/fontawesome",
+					latestVersion: "2.0.0",
+					latestTag: "v2.0.0",
+					latestReleaseUrl: null,
+				},
+			});
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(fetchRegistry).not.toHaveBeenCalled();
+			expect(updates).toHaveLength(1);
+			expect(updates[0].latestVersion).toBe("2.5.0");
+			expect(updates[0].source).toBe("quarto-ext/fontawesome@v2.5.0");
+			expect(updates[0].releaseUrl).toBe("https://github.com/quarto-ext/fontawesome/releases/tag/v2.5.0");
+		});
+
+		it("falls back to tags when a github-sourced repo has no releases", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockResolvedValue([]);
+			vi.mocked(fetchTags).mockResolvedValue([
+				{ name: "v3.0.0", sha: "abc", zipballUrl: "", tarballUrl: "" },
+			]);
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(updates).toHaveLength(1);
+			expect(updates[0].latestVersion).toBe("3.0.0");
+			expect(updates[0].source).toBe("quarto-ext/fontawesome@v3.0.0");
+		});
+
+		it("does not emit an update for github sources with no releases or tags by default", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockResolvedValue([]);
+			vi.mocked(fetchTags).mockResolvedValue([]);
+			vi.mocked(fetchRegistry).mockResolvedValue({
+				"quarto-ext/fontawesome": {
+					fullName: "quarto-ext/fontawesome",
+					latestVersion: "2.0.0",
+					latestTag: "v2.0.0",
+					latestReleaseUrl: null,
+				},
+			});
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(fetchRegistry).not.toHaveBeenCalled();
+			expect(updates).toHaveLength(0);
+		});
+
+		it("falls back to the registry for github sources when crossSource is enabled", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockResolvedValue([]);
+			vi.mocked(fetchTags).mockResolvedValue([]);
+			vi.mocked(fetchRegistry).mockResolvedValue({
+				"quarto-ext/fontawesome": {
+					fullName: "quarto-ext/fontawesome",
+					latestVersion: "2.0.0",
+					latestTag: "v2.0.0",
+					latestReleaseUrl: "https://github.com/quarto-ext/fontawesome/releases/tag/v2.0.0",
+				},
+			});
+
+			const updates = await checkForUpdates({ projectDir: tempDir, crossSource: true });
+
+			expect(fetchRegistry).toHaveBeenCalledTimes(1);
+			expect(updates).toHaveLength(1);
+			expect(updates[0].latestVersion).toBe("2.0.0");
+		});
+
+		it("never checks updates for url-sourced extensions", async () => {
+			setupExtensionWithType("vendor", "zipped", "1.0.0", "https://example.com/ext.zip", "url");
+
+			vi.mocked(fetchRegistry).mockResolvedValue({});
+
+			const updates = await checkForUpdates({ projectDir: tempDir, crossSource: true });
+
+			expect(updates).toHaveLength(0);
+			expect(fetchReleases).not.toHaveBeenCalled();
+			expect(fetchTags).not.toHaveBeenCalled();
+		});
+
+		it("never checks updates for local-sourced extensions", async () => {
+			setupExtensionWithType("vendor", "local", "1.0.0", "/tmp/my-ext", "local");
+
+			vi.mocked(fetchRegistry).mockResolvedValue({});
+
+			const updates = await checkForUpdates({ projectDir: tempDir, crossSource: true });
+
+			expect(updates).toHaveLength(0);
+			expect(fetchReleases).not.toHaveBeenCalled();
+			expect(fetchTags).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/core/tests/operations/update.test.ts
+++ b/packages/core/tests/operations/update.test.ts
@@ -448,5 +448,21 @@ describe("checkForUpdates", () => {
 			expect(fetchReleases).not.toHaveBeenCalled();
 			expect(fetchTags).not.toHaveBeenCalled();
 		});
+
+		it("skips GitHub network calls for commit-pinned github-sourced extensions", async () => {
+			setupExtensionWithType(
+				"quarto-ext",
+				"fontawesome",
+				"abc1234",
+				"quarto-ext/fontawesome@abc1234",
+				"github",
+			);
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(fetchReleases).not.toHaveBeenCalled();
+			expect(fetchTags).not.toHaveBeenCalled();
+			expect(updates).toHaveLength(0);
+		});
 	});
 });

--- a/packages/core/tests/operations/update.test.ts
+++ b/packages/core/tests/operations/update.test.ts
@@ -449,6 +449,65 @@ describe("checkForUpdates", () => {
 			expect(fetchTags).not.toHaveBeenCalled();
 		});
 
+		it("skips prerelease tags when falling back to tags for a github-sourced repo", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockResolvedValue([]);
+			vi.mocked(fetchTags).mockResolvedValue([
+				{ name: "v3.0.0-beta.1", sha: "abc", zipballUrl: "", tarballUrl: "" },
+				{ name: "v2.1.0", sha: "def", zipballUrl: "", tarballUrl: "" },
+			]);
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(updates).toHaveLength(1);
+			expect(updates[0].latestVersion).toBe("2.1.0");
+			expect(updates[0].source).toBe("quarto-ext/fontawesome@v2.1.0");
+		});
+
+		it("continues with tags when fetching releases throws", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockRejectedValue(new Error("boom"));
+			vi.mocked(fetchTags).mockResolvedValue([{ name: "v2.0.0", sha: "abc", zipballUrl: "", tarballUrl: "" }]);
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(updates).toHaveLength(1);
+			expect(updates[0].latestVersion).toBe("2.0.0");
+		});
+
+		it("emits no update when both releases and tags throw", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockRejectedValue(new Error("releases boom"));
+			vi.mocked(fetchTags).mockRejectedValue(new Error("tags boom"));
+
+			const updates = await checkForUpdates({ projectDir: tempDir });
+
+			expect(updates).toHaveLength(0);
+		});
+
+		it("falls back to the registry with crossSource when both GitHub calls throw", async () => {
+			setupExtensionWithType("quarto-ext", "fontawesome", "1.0.0", "quarto-ext/fontawesome", "github");
+
+			vi.mocked(fetchReleases).mockRejectedValue(new Error("releases boom"));
+			vi.mocked(fetchTags).mockRejectedValue(new Error("tags boom"));
+			vi.mocked(fetchRegistry).mockResolvedValue({
+				"quarto-ext/fontawesome": {
+					fullName: "quarto-ext/fontawesome",
+					latestVersion: "2.0.0",
+					latestTag: "v2.0.0",
+					latestReleaseUrl: null,
+				},
+			});
+
+			const updates = await checkForUpdates({ projectDir: tempDir, crossSource: true });
+
+			expect(updates).toHaveLength(1);
+			expect(updates[0].latestVersion).toBe("2.0.0");
+		});
+
 		it("skips GitHub network calls for commit-pinned github-sourced extensions", async () => {
 			setupExtensionWithType(
 				"quarto-ext",

--- a/src/test/suite/extensions.test.ts
+++ b/src/test/suite/extensions.test.ts
@@ -359,7 +359,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "github");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "github");
 		});
 
 		test("Should infer url from https source", async () => {
@@ -371,7 +371,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "url");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "url");
 		});
 
 		test("Should infer local from relative path", async () => {
@@ -383,7 +383,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "local");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "local");
 		});
 
 		test("Should infer local from absolute path", async () => {
@@ -395,7 +395,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "local");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "local");
 		});
 
 		test("Should infer registry from owner/repo pattern without explicit sourceType", async () => {
@@ -407,7 +407,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "registry");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "registry");
 		});
 
 		test("Should infer registry from owner/repo/subdir pattern without explicit sourceType", async () => {
@@ -419,7 +419,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "registry");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "registry");
 		});
 
 		test("Should infer registry from unrelated owner/repo pattern without explicit sourceType", async () => {
@@ -431,7 +431,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), "registry");
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), "registry");
 		});
 
 		test("Should not infer local from backslash in non-path source", async () => {
@@ -443,7 +443,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), undefined);
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), undefined);
 		});
 
 		test("Should return undefined for no source", async () => {
@@ -455,7 +455,7 @@ contributes:\n`;
 			const extensions = await getInstalledExtensions(tempDir);
 			const ext = extensions[0];
 
-			assert.strictEqual(getEffectiveSourceType(ext), undefined);
+			assert.strictEqual(getEffectiveSourceType(ext.manifest), undefined);
 		});
 	});
 

--- a/src/ui/extensionTreeDataProvider.ts
+++ b/src/ui/extensionTreeDataProvider.ts
@@ -7,7 +7,7 @@ import { REGISTRY_FETCH_TIMEOUT_MS } from "../constants";
 import { debounce } from "../utils/debounce";
 import { logMessage } from "../utils/log";
 import { getInstalledExtensionsRecord, getExtensionContributes, getEffectiveSourceType } from "../utils/extensions";
-import { getRegistryUrl, getCacheTTL } from "../utils/extensionDetails";
+import { getCacheTTL, getCrossSourceUpdateEnabled, getRegistryUrl } from "../utils/extensionDetails";
 import { getAuthConfig } from "../utils/auth";
 import { getQuartoVersionInfo, type QuartoVersionInfo } from "../services/quartoVersion";
 import { validateQuartoRequirement } from "../utils/versionValidation";
@@ -205,7 +205,7 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 				element.workspaceFolder,
 			),
 			new ExtensionTreeItem(
-				`Source type: ${getEffectiveSourceType(ext) ?? "N/A"}`,
+				`Source type: ${getEffectiveSourceType(ext.manifest) ?? "N/A"}`,
 				vscode.TreeItemCollapsibleState.None,
 				element.workspaceFolder,
 			),
@@ -492,7 +492,7 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 						extensionId: ext,
 						workspaceFolder: workspacePath,
 						source: extension?.manifest.source,
-						sourceType: extension ? getEffectiveSourceType(extension) : undefined,
+						sourceType: extension ? getEffectiveSourceType(extension.manifest) : undefined,
 						latestVersion: version,
 					});
 				}
@@ -550,6 +550,7 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 						cacheTtl,
 						auth: auth ?? undefined,
 						timeout: REGISTRY_FETCH_TIMEOUT_MS,
+						crossSource: getCrossSourceUpdateEnabled(),
 					});
 
 					// Only reset after successful fetch to preserve previous state on error

--- a/src/ui/extensionTreeItems.ts
+++ b/src/ui/extensionTreeItems.ts
@@ -62,7 +62,7 @@ export class ExtensionTreeItem extends vscode.TreeItem {
 		const noSource = extension && !extension.manifest.source;
 
 		// Set context value based on source type for VS Code context menus
-		const sourceType = extension ? getEffectiveSourceType(extension) : undefined;
+		const sourceType = extension ? getEffectiveSourceType(extension.manifest) : undefined;
 
 		let contextValue: string;
 		if (!extension) {

--- a/src/utils/extensionDetails.ts
+++ b/src/utils/extensionDetails.ts
@@ -35,6 +35,15 @@ export function getRegistryUrl(): string {
 }
 
 /**
+ * Whether GitHub-sourced extensions should also be resolved against the registry.
+ * @returns True when the user has opted into cross-source update discovery.
+ */
+export function getCrossSourceUpdateEnabled(): boolean {
+	const config = vscode.workspace.getConfiguration("quartoWizard");
+	return config.get<boolean>("update.crossSource", false);
+}
+
+/**
  * Interface representing the details of a Quarto extension.
  */
 export interface ExtensionDetails {

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -3,53 +3,14 @@ import * as path from "node:path";
 import {
 	discoverInstalledExtensions,
 	formatExtensionId,
+	getEffectiveSourceType,
 	getExtensionTypes,
 	type InstalledExtension,
 	type SourceType,
 	getErrorMessage,
+	splitSourceRef,
 } from "@quarto-wizard/core";
 import { logMessage } from "./log";
-
-const GITHUB_REPOSITORY_PATTERN = /^[^/\s:\\]+\/[^/\s:\\]+(?:\/[^/\s:\\]+)*(?:@[^/\s:\\]+)?$/;
-
-function splitSourceRef(source: string): { base: string; hasRef: boolean } {
-	const atIndex = source.lastIndexOf("@");
-	if (atIndex <= 0) {
-		return { base: source, hasRef: false };
-	}
-	return {
-		base: source.substring(0, atIndex),
-		hasRef: true,
-	};
-}
-
-function isLocalSourcePath(source: string): boolean {
-	return (
-		source.startsWith("file://") ||
-		source.startsWith("/") ||
-		source.startsWith("~/") ||
-		source.startsWith("\\\\") ||
-		source.startsWith(".") ||
-		/^[A-Za-z]:[/\\]/.test(source)
-	);
-}
-
-function isLegacyGitHubSource(source: string): boolean {
-	return GITHUB_REPOSITORY_PATTERN.test(source) && !source.startsWith(".");
-}
-
-function inferLegacySourceType(source: string): SourceType | undefined {
-	if (/^https?:\/\//.test(source)) {
-		return "url";
-	}
-	if (isLocalSourcePath(source)) {
-		return "local";
-	}
-	if (isLegacyGitHubSource(splitSourceRef(source).base)) {
-		return "registry";
-	}
-	return undefined;
-}
 
 export function getSourceBase(source: string, sourceType?: SourceType): string {
 	if (sourceType === "github" || sourceType === "registry") {
@@ -132,7 +93,7 @@ export function getExtensionRepository(ext: InstalledExtension): string | undefi
 	if (!source) {
 		return undefined;
 	}
-	const type = getEffectiveSourceType(ext);
+	const type = getEffectiveSourceType(ext.manifest);
 	if (type === "github" || type === "registry") {
 		return getSourceBase(source, type);
 	}
@@ -150,7 +111,7 @@ export function getExtensionSourceUrl(ext: InstalledExtension): string | undefin
 	if (!source) {
 		return undefined;
 	}
-	const type = getEffectiveSourceType(ext);
+	const type = getEffectiveSourceType(ext.manifest);
 	const base = getSourceBase(source, type);
 	if (type === "github" || type === "registry") {
 		return `https://github.com/${base}`;
@@ -159,24 +120,6 @@ export function getExtensionSourceUrl(ext: InstalledExtension): string | undefin
 		return base;
 	}
 	return undefined;
-}
-
-/**
- * Determines the effective source type from an installed extension.
- * Uses the explicit sourceType field if available, otherwise infers from the source string.
- *
- * @param ext - The installed extension.
- * @returns The source type or undefined if not determinable.
- */
-export function getEffectiveSourceType(ext: InstalledExtension): SourceType | undefined {
-	if (ext.manifest.sourceType) {
-		return ext.manifest.sourceType;
-	}
-	const source = ext.manifest.source;
-	if (!source) {
-		return undefined;
-	}
-	return inferLegacySourceType(source);
 }
 
 /**
@@ -190,4 +133,4 @@ export function getExtensionContributes(ext: InstalledExtension): string | undef
 	return types.length > 0 ? types.join(", ") : undefined;
 }
 
-export { formatExtensionId, type InstalledExtension } from "@quarto-wizard/core";
+export { formatExtensionId, getEffectiveSourceType, type InstalledExtension } from "@quarto-wizard/core";


### PR DESCRIPTION
Update discovery now follows how each extension was installed.
Extensions installed through the registry resolve against the Quarto extensions registry as before.
Extensions installed with `quarto add owner/repo` resolve against GitHub releases and tags directly, so an offered update reflects the actual latest upstream release rather than whatever the registry last indexed.
Extensions with `url` or `local` sources are never checked, since they can't be re-resolved.

A new `quartoWizard.update.crossSource` setting (disabled by default) restores the previous behaviour of falling back to the registry for GitHub-sourced extensions when GitHub exposes no releases or tags.

Falling back to GitHub tags now skips prerelease-style tags (e.g. `v2.0.0-beta.1`), matching the filtering that `fetchReleases` already applies to release entries.

Source-type inference (`inferSourceType`, `getEffectiveSourceType`, `splitSourceRef`) lives in `@quarto-wizard/core`, so the extension layer and the core update logic share one definition.