### PR TITLE
docs: stage dev-profile assets via pre-render hook

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,6 @@
 /.quarto/
 **/*.quarto_ipynb
 /_site/
+
+# Assets staged by scripts/dev-copy-assets.sh during `quarto render --profile dev`.
+/assets/social/

--- a/docs/_quarto-dev.yml
+++ b/docs/_quarto-dev.yml
@@ -5,11 +5,8 @@ project:
   pre-render: scripts/dev-copy-assets.sh
   post-render: scripts/dev-clean-assets.sh
 
-image: "assets/social/social-card.png"
-
 website:
   site-url: "https://m.canouil.dev/quarto-wizard/dev"
-  image: "assets/social/social-card.png"
   announcement:
     icon: exclamation-circle
     dismissable: false

--- a/docs/_quarto-dev.yml
+++ b/docs/_quarto-dev.yml
@@ -2,12 +2,14 @@ project:
   output-dir: _site/dev
   resources:
     - quarto-wizard-dev.vsix
+  pre-render: scripts/dev-copy-assets.sh
+  post-render: scripts/dev-clean-assets.sh
 
-image: "../assets/social/social-card.png"
+image: "assets/social/social-card.png"
 
 website:
   site-url: "https://m.canouil.dev/quarto-wizard/dev"
-  image: "../assets/social/social-card.png"
+  image: "assets/social/social-card.png"
   announcement:
     icon: exclamation-circle
     dismissable: false

--- a/docs/scripts/dev-clean-assets.sh
+++ b/docs/scripts/dev-clean-assets.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Remove dev-profile-only assets that `dev-copy-assets.sh` brought in so the
-# working tree stays clean after `quarto render --profile dev`.
-
+# Undo dev-copy-assets.sh so the working tree stays clean post-render.
 dst="assets/social/social-card.png"
 
 if [[ -f "${dst}" ]]; then
 	rm -f "${dst}"
-	# Remove the containing directory if it's now empty.
 	dir="$(dirname "${dst}")"
 	if [[ -d "${dir}" ]]; then
 		rmdir "${dir}" 2>/dev/null || true

--- a/docs/scripts/dev-clean-assets.sh
+++ b/docs/scripts/dev-clean-assets.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove dev-profile-only assets that `dev-copy-assets.sh` brought in so the
+# working tree stays clean after `quarto render --profile dev`.
+
+dst="assets/social/social-card.png"
+
+if [[ -f "${dst}" ]]; then
+	rm -f "${dst}"
+	# Remove the containing directory if it's now empty.
+	dir="$(dirname "${dst}")"
+	if [[ -d "${dir}" ]]; then
+		rmdir "${dir}" 2>/dev/null || true
+	fi
+fi

--- a/docs/scripts/dev-copy-assets.sh
+++ b/docs/scripts/dev-copy-assets.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Copy dev-profile-only assets from outside the Quarto project dir into the
+# project tree so `_quarto-dev.yml` can reference them with plain relative
+# paths rather than `../` escapes. `dev-clean-assets.sh` undoes the copy.
+
+src="../assets/social/social-card.png"
+dst="assets/social/social-card.png"
+
+if [[ -f "${src}" ]]; then
+	mkdir -p "$(dirname "${dst}")"
+	cp "${src}" "${dst}"
+fi

--- a/docs/scripts/dev-copy-assets.sh
+++ b/docs/scripts/dev-copy-assets.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Copy dev-profile-only assets from outside the Quarto project dir into the
-# project tree so `_quarto-dev.yml` can reference them with plain relative
-# paths rather than `../` escapes. `dev-clean-assets.sh` undoes the copy.
-
+# Stage dev-profile assets inside the project so `_quarto-dev.yml` avoids `../` paths.
 src="../assets/social/social-card.png"
 dst="assets/social/social-card.png"
 


### PR DESCRIPTION
Replaces the `../` parent-directory paths in `docs/_quarto-dev.yml` with a pre-render script that stages the social-card asset inside the Quarto project and a post-render script that cleans it up. The dev profile now inherits the base `image:` settings cleanly, and `docs/.gitignore` covers the staged copy so an interrupted render cannot leave it behind.