### PR TITLE
feat: auto-detect Quarto project roots in workspace subfolders

### DIFF
--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -4,6 +4,17 @@ title: "Changelog"
 
 ## 2 {#version-2}
 
+### 2.5 {#version-2-5}
+
+#### 2.5.0 (Unreleased) {#version-2-5-0}
+
+##### New Features
+
+- feat: auto-detect Quarto project roots in workspace subfolders via the new `quartoWizard.autoProjectDetection` setting, modelled on VSCode's `git.autoRepositoryDetection`.
+  A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml` or an `_extensions/` directory with at least one installed extension.
+  Detected roots populate the Extensions Installed view and every folder-targeted command (Install, Use Template, Use Brand, ...).
+  The setting accepts `true` (default), `false`, `"subFolders"`, and `"openEditors"` with the same semantics as the Git extension.
+
 ### 2.4 {#version-2-4}
 
 #### 2.4.1 (2026-04-19) {#version-2-4-1}

--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -41,6 +41,37 @@ Ask for confirmation before installing an extension. `ask` to ask for confirmati
 }
 ```
 
+## Project Discovery
+
+### Auto Project Detection
+
+**Setting**: `quartoWizard.autoProjectDetection`
+
+Configures when Quarto project roots should be automatically detected.
+A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, or an `_extensions/` directory with at least one installed extension.
+The second marker makes single-document workspaces work: a folder with just `mydoc.qmd` and `_extensions/quarto-ext/typst-function/_extension.yml` is recognised even without `_quarto.yml`.
+
+Detected project roots populate the Extensions Installed view and are offered by every command that targets a folder, such as Install Extension, Use Template, and Use Brand.
+
+When the workspace folder itself qualifies, only that folder is used as the project root.
+Otherwise, every detected sub-folder is shown.
+If nothing is detected, the workspace folder is used as a fallback.
+
+| Value           | Description                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `true`          | Scan both subfolders of the current opened folder and parent folders of open files (default). |
+| `"subFolders"`  | Scan only subfolders of the currently opened folder.                                          |
+| `"openEditors"` | Scan only parent folders of open files.                                                       |
+| `false`         | Disable automatic Quarto project scanning; treat each workspace folder as the project root.   |
+
+```json
+{
+  "quartoWizard.autoProjectDetection": true
+}
+```
+
+The scan honours your `files.exclude` and `search.exclude` settings, matching the behaviour of VSCode's built-in Git auto-detection.
+
 ## Cache Settings
 
 ### Cache Duration
@@ -100,6 +131,7 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.ask.trustAuthors": "ask",
   "quartoWizard.ask.confirmInstall": "ask",
   "quartoWizard.update.crossSource": false,
+  "quartoWizard.autoProjectDetection": true,
   "quartoWizard.cache.ttlMinutes": 30,
   "quartoWizard.registry.url": "https://m.canouil.dev/quarto-extensions/extensions.json"
 }

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -33,13 +33,14 @@ See [Configuration Reference](configuration.qmd) for all available options.
 
 ### Quick Reference
 
-| Setting                           | Default                                    | Description                                          |
-| --------------------------------- | ------------------------------------------ | ---------------------------------------------------- |
-| `quartoWizard.ask.trustAuthors`   | `ask`                                      | Prompt before trusting authors.                      |
-| `quartoWizard.ask.confirmInstall` | `ask`                                      | Prompt before installing.                            |
-| `quartoWizard.update.crossSource` | `false`                                    | Allow registry lookup for GitHub-sourced extensions. |
-| `quartoWizard.cache.ttlMinutes`   | `30`                                       | Cache duration in minutes.                           |
-| `quartoWizard.registry.url`       | [see docs](configuration.qmd#registry-url) | Custom registry URL.                                 |
+| Setting                             | Default                                    | Description                                          |
+| ----------------------------------- | ------------------------------------------ | ---------------------------------------------------- |
+| `quartoWizard.ask.trustAuthors`     | `ask`                                      | Prompt before trusting authors.                      |
+| `quartoWizard.ask.confirmInstall`   | `ask`                                      | Prompt before installing.                            |
+| `quartoWizard.update.crossSource`   | `false`                                    | Allow registry lookup for GitHub-sourced extensions. |
+| `quartoWizard.autoProjectDetection` | `true`                                     | When to auto-detect Quarto projects.                 |
+| `quartoWizard.cache.ttlMinutes`     | `30`                                       | Cache duration in minutes.                           |
+| `quartoWizard.registry.url`         | [see docs](configuration.qmd#registry-url) | Custom registry URL.                                 |
 
 ## Extension Schema
 

--- a/package.json
+++ b/package.json
@@ -669,6 +669,30 @@
 					"title": "Cross-source Updates",
 					"description": "Allow registry lookup for GitHub-sourced extensions."
 				},
+				"quartoWizard.autoProjectDetection": {
+					"order": 4,
+					"scope": "resource",
+					"type": [
+						"boolean",
+						"string"
+					],
+					"enum": [
+						true,
+						false,
+						"subFolders",
+						"openEditors"
+					],
+					"enumDescriptions": [
+						"Scan for both subfolders of the current opened folder and parent folders of open files.",
+						"Disable automatic Quarto project scanning.",
+						"Scan for subfolders of the currently opened folder.",
+						"Scan for parent folders of open files."
+					],
+					"default": true,
+					"markdownDescription": "Configures when Quarto project roots should be automatically detected. A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, **or** an `_extensions/` directory with at least one installed extension. Detected roots are used by the Extensions Installed view and by every command that needs a target folder (Install, Use Template, Use Brand, ...).",
+					"title": "Auto Project Detection",
+					"description": "When to auto-detect Quarto projects."
+				},
 				"quartoWizard.cache.ttlMinutes": {
 					"order": 10,
 					"scope": "resource",

--- a/packages/core/src/filesystem/discovery.ts
+++ b/packages/core/src/filesystem/discovery.ts
@@ -15,7 +15,7 @@ import { readManifest } from "./manifest.js";
 import { pathExists } from "./walk.js";
 
 /** Name of the extensions directory. */
-const EXTENSIONS_DIR = "_extensions";
+export const EXTENSIONS_DIR = "_extensions";
 
 /**
  * An installed extension discovered on the filesystem.

--- a/packages/core/src/filesystem/index.ts
+++ b/packages/core/src/filesystem/index.ts
@@ -17,6 +17,7 @@ export {
 export {
 	type InstalledExtension,
 	type DiscoveryOptions,
+	EXTENSIONS_DIR,
 	getExtensionsDir,
 	hasExtensionsDir,
 	discoverInstalledExtensions,

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -153,6 +153,18 @@ suite("Quarto Project Discovery Test Suite", () => {
 		assert.strictEqual(roots[0].label, "workspace");
 	});
 
+	test("smart-merges: workspace root _quarto.yml subsumes sibling _extensions/-only sub-roots", async () => {
+		// Workspace IS a Quarto project; a sibling using `_extensions/` is part of that
+		// project and must not appear as its own root.
+		writeQuartoYml(tempDir);
+		writeExtensionManifest(path.join(tempDir, "scratch"), "quarto-ext", "fontawesome");
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+	});
+
 	test("returns all detected sub-roots when workspace root has no _quarto.yml", async () => {
 		writeQuartoYml(path.join(tempDir, "site-a"));
 		writeQuartoYml(path.join(tempDir, "site-b"));
@@ -284,5 +296,30 @@ suite("Quarto Project Discovery Test Suite", () => {
 		assert.strictEqual(roots.length, 1);
 		assert.strictEqual(roots[0].fsPath, projectDir);
 		assert.strictEqual(roots[0].label, "workspace/nested/ext-only");
+	});
+
+	test("setting=openEditors: symlink loops in _extensions/ do not cause infinite recursion", async function () {
+		// Skip on Windows; symlinks need elevated privileges there.
+		if (process.platform === "win32") {
+			this.skip();
+			return;
+		}
+		const projectDir = path.join(tempDir, "with-loop");
+		const extensionsDir = path.join(projectDir, "_extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+		// Self-referential symlink: `_extensions/loop -> _extensions`.
+		fs.symlinkSync(extensionsDir, path.join(extensionsDir, "loop"), "dir");
+		const docPath = path.join(projectDir, "doc.qmd");
+		fs.writeFileSync(docPath, "", "utf8");
+
+		mockedConfig.autoProjectDetection = "openEditors";
+		mockedTextDocuments = [makeDocument(docPath)];
+
+		// No assertion on the precise result; the test passes if discovery returns at all.
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		// Empty `_extensions/` (only a symlink loop, no manifests) must not promote the folder.
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
 	});
 });

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -1,0 +1,288 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import { MANIFEST_FILENAMES } from "@quarto-wizard/core";
+import {
+	discoverQuartoProjectRoots,
+	EXTENSION_MANIFEST_GLOB,
+	QUARTO_PROJECT_FILENAMES,
+	QUARTO_PROJECT_GLOB,
+} from "../../utils/quartoProjectDiscovery";
+
+type AutoProjectDetection = boolean | "subFolders" | "openEditors";
+
+interface MockedConfig {
+	autoProjectDetection?: AutoProjectDetection;
+}
+
+const GLOB_MATCHERS: Record<string, ReadonlySet<string>> = {
+	[QUARTO_PROJECT_GLOB]: new Set<string>(QUARTO_PROJECT_FILENAMES),
+	[EXTENSION_MANIFEST_GLOB]: new Set<string>(MANIFEST_FILENAMES),
+};
+
+suite("Quarto Project Discovery Test Suite", () => {
+	let tempDir: string;
+	let originalFindFiles: typeof vscode.workspace.findFiles;
+	let originalTextDocumentsDescriptor: PropertyDescriptor | undefined;
+	let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+
+	let mockedTextDocuments: readonly vscode.TextDocument[];
+	let mockedConfig: MockedConfig;
+
+	setup(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quarto-wizard-discovery-"));
+
+		mockedTextDocuments = [];
+		mockedConfig = { autoProjectDetection: true };
+
+		originalFindFiles = vscode.workspace.findFiles;
+		// Default: scan the temp tree on disk and dispatch by glob to mirror the real findFiles.
+		vscode.workspace.findFiles = ((include: vscode.GlobPattern) => {
+			if (typeof include === "object" && "baseUri" in include) {
+				const rel = include as vscode.RelativePattern;
+				const matcher = GLOB_MATCHERS[rel.pattern];
+				if (matcher) {
+					return Promise.resolve(scanForFiles(rel.baseUri.fsPath, matcher));
+				}
+			}
+			return Promise.resolve([]);
+		}) as typeof vscode.workspace.findFiles;
+
+		originalTextDocumentsDescriptor = Object.getOwnPropertyDescriptor(vscode.workspace, "textDocuments");
+		Object.defineProperty(vscode.workspace, "textDocuments", {
+			get: () => mockedTextDocuments,
+			configurable: true,
+		});
+
+		originalGetConfiguration = vscode.workspace.getConfiguration;
+		vscode.workspace.getConfiguration = ((section?: string) => {
+			if (section === "quartoWizard") {
+				return {
+					get: <T>(key: string, defaultValue?: T): T => {
+						if (key === "autoProjectDetection") {
+							const value = mockedConfig.autoProjectDetection;
+							return (value !== undefined ? value : defaultValue) as T;
+						}
+						return defaultValue as T;
+					},
+					has: () => true,
+					inspect: () => undefined,
+					update: async () => {
+						/* no-op */
+					},
+				} as unknown as vscode.WorkspaceConfiguration;
+			}
+			return originalGetConfiguration(section);
+		}) as typeof vscode.workspace.getConfiguration;
+	});
+
+	teardown(() => {
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+		vscode.workspace.findFiles = originalFindFiles;
+		vscode.workspace.getConfiguration = originalGetConfiguration;
+		if (originalTextDocumentsDescriptor) {
+			Object.defineProperty(vscode.workspace, "textDocuments", originalTextDocumentsDescriptor);
+		}
+	});
+
+	function makeFolder(name: string, fsPath: string, index = 0): vscode.WorkspaceFolder {
+		return { uri: vscode.Uri.file(fsPath), name, index };
+	}
+
+	function writeQuartoYml(dir: string): string {
+		fs.mkdirSync(dir, { recursive: true });
+		const file = path.join(dir, "_quarto.yml");
+		fs.writeFileSync(file, "project:\n  type: website\n", "utf8");
+		return file;
+	}
+
+	function writeExtensionManifest(projectDir: string, owner: string, name: string): string {
+		const dir = path.join(projectDir, "_extensions", owner, name);
+		fs.mkdirSync(dir, { recursive: true });
+		const file = path.join(dir, "_extension.yml");
+		fs.writeFileSync(file, `title: ${name}\nauthor: ${owner}\nversion: 1.0.0\n`, "utf8");
+		return file;
+	}
+
+	function scanForFiles(base: string, matcher: ReadonlySet<string>): vscode.Uri[] {
+		const matches: vscode.Uri[] = [];
+		const walk = (current: string) => {
+			let entries: fs.Dirent[];
+			try {
+				entries = fs.readdirSync(current, { withFileTypes: true });
+			} catch {
+				return;
+			}
+			for (const entry of entries) {
+				const fullPath = path.join(current, entry.name);
+				if (entry.isDirectory()) {
+					walk(fullPath);
+				} else if (entry.isFile() && matcher.has(entry.name)) {
+					matches.push(vscode.Uri.file(fullPath));
+				}
+			}
+		};
+		walk(base);
+		return matches;
+	}
+
+	function makeDocument(filePath: string): vscode.TextDocument {
+		return {
+			uri: vscode.Uri.file(filePath),
+			isUntitled: false,
+		} as unknown as vscode.TextDocument;
+	}
+
+	test("returns empty array for no workspace folders", async () => {
+		const roots = await discoverQuartoProjectRoots([]);
+		assert.deepStrictEqual(roots, []);
+	});
+
+	test("smart-merges: workspace root with _quarto.yml hides nested ones", async () => {
+		writeQuartoYml(tempDir);
+		writeQuartoYml(path.join(tempDir, "child"));
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+		assert.strictEqual(roots[0].label, "workspace");
+	});
+
+	test("returns all detected sub-roots when workspace root has no _quarto.yml", async () => {
+		writeQuartoYml(path.join(tempDir, "site-a"));
+		writeQuartoYml(path.join(tempDir, "site-b"));
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 2);
+		const labels = roots.map((r) => r.label).sort();
+		assert.deepStrictEqual(labels, ["workspace/site-a", "workspace/site-b"]);
+		for (const root of roots) {
+			assert.strictEqual(root.workspaceFolder.name, "workspace");
+		}
+	});
+
+	test("falls back to workspace folder when nothing is detected", async () => {
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+		assert.strictEqual(roots[0].label, "workspace");
+	});
+
+	test("setting=false: returns workspace folder only and does not scan", async () => {
+		writeQuartoYml(path.join(tempDir, "site-a"));
+		mockedConfig.autoProjectDetection = false;
+		let findFilesCalled = false;
+		vscode.workspace.findFiles = (() => {
+			findFilesCalled = true;
+			return Promise.resolve([]);
+		}) as typeof vscode.workspace.findFiles;
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(findFilesCalled, false);
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+	});
+
+	test("setting=openEditors: detects project root from an open document", async () => {
+		const projectDir = path.join(tempDir, "nested", "site");
+		writeQuartoYml(projectDir);
+		const docPath = path.join(projectDir, "post", "index.qmd");
+		fs.mkdirSync(path.dirname(docPath), { recursive: true });
+		fs.writeFileSync(docPath, "", "utf8");
+
+		mockedConfig.autoProjectDetection = "openEditors";
+		mockedTextDocuments = [makeDocument(docPath)];
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, projectDir);
+		assert.strictEqual(roots[0].label, "workspace/nested/site");
+	});
+
+	test("setting=subFolders: ignores open editors and only scans subfolders", async () => {
+		const editorOnlyProject = path.join(tempDir, "editor-only");
+		writeQuartoYml(editorOnlyProject);
+		const docPath = path.join(editorOnlyProject, "doc.qmd");
+		fs.writeFileSync(docPath, "", "utf8");
+
+		mockedConfig.autoProjectDetection = "subFolders";
+		mockedTextDocuments = [makeDocument(docPath)];
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		// editor-only is still found because subFolders scans the on-disk tree.
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, editorOnlyProject);
+	});
+
+	test("detects workspace root via _extensions/ when _quarto.yml is absent", async () => {
+		writeExtensionManifest(tempDir, "quarto-ext", "fontawesome");
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+		assert.strictEqual(roots[0].label, "workspace");
+	});
+
+	test("returns mixed _quarto.yml and _extensions/ sub-roots", async () => {
+		const siteA = path.join(tempDir, "site-a");
+		const siteB = path.join(tempDir, "site-b");
+		writeQuartoYml(siteA);
+		writeExtensionManifest(siteB, "quarto-ext", "fontawesome");
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		const paths = roots.map((r) => r.fsPath).sort();
+		assert.deepStrictEqual(paths, [siteA, siteB]);
+	});
+
+	test("empty _extensions/ directory does not qualify; falls back to workspace folder", async () => {
+		fs.mkdirSync(path.join(tempDir, "lonely", "_extensions"), { recursive: true });
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+	});
+
+	test("nested _extensions/ inside another extension is not treated as a separate root", async () => {
+		// Outer: /temp/_extensions/outer/_extension.yml
+		// Nested: /temp/_extensions/outer/template/_extensions/inner/_extension.yml
+		writeExtensionManifest(tempDir, "outer", "ext");
+		const nested = path.join(tempDir, "_extensions", "outer", "ext", "template", "_extensions", "inner");
+		fs.mkdirSync(nested, { recursive: true });
+		fs.writeFileSync(path.join(nested, "_extension.yml"), "title: inner\n", "utf8");
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		// Only the workspace root is reported; the nested `_extensions/` stays inside the outer extension.
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+	});
+
+	test("setting=openEditors: ascend finds _extensions/-only folder", async () => {
+		const projectDir = path.join(tempDir, "nested", "ext-only");
+		writeExtensionManifest(projectDir, "quarto-ext", "fontawesome");
+		const docPath = path.join(projectDir, "doc.qmd");
+		fs.writeFileSync(docPath, "", "utf8");
+
+		mockedConfig.autoProjectDetection = "openEditors";
+		mockedTextDocuments = [makeDocument(docPath)];
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, projectDir);
+		assert.strictEqual(roots[0].label, "workspace/nested/ext-only");
+	});
+});

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -32,7 +32,9 @@ suite("Quarto Project Discovery Test Suite", () => {
 	let mockedConfig: MockedConfig;
 
 	setup(() => {
-		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quarto-wizard-discovery-"));
+		// Normalise via Uri.file so Windows drive-letter casing matches what `findFiles`
+		// and other VSCode APIs return for paths in this directory.
+		tempDir = vscode.Uri.file(fs.mkdtempSync(path.join(os.tmpdir(), "quarto-wizard-discovery-"))).fsPath;
 
 		mockedTextDocuments = [];
 		mockedConfig = { autoProjectDetection: true };

--- a/src/test/suite/workspace.test.ts
+++ b/src/test/suite/workspace.test.ts
@@ -2,139 +2,145 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { selectWorkspaceFolder } from "../../utils/workspace";
 
+interface MockQuickPickResult {
+	root: { fsPath: string };
+}
+
 suite("Workspace Utils Test Suite", () => {
 	let originalWorkspaceFolders: typeof vscode.workspace.workspaceFolders;
-	let originalShowWorkspaceFolderPick: typeof vscode.window.showWorkspaceFolderPick;
+	let originalShowQuickPick: typeof vscode.window.showQuickPick;
+	let originalFindFiles: typeof vscode.workspace.findFiles;
+	let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+	let originalTextDocumentsDescriptor: PropertyDescriptor | undefined;
 
 	let mockWorkspaceFolders: vscode.WorkspaceFolder[] | undefined;
-	let workspaceFolderPickResult: vscode.WorkspaceFolder | undefined;
+	let quickPickResult: MockQuickPickResult | undefined;
+	let lastQuickPickItems: readonly vscode.QuickPickItem[] | undefined;
+	let lastQuickPickOptions: vscode.QuickPickOptions | undefined;
 
 	setup(() => {
-		// Store original methods
 		originalWorkspaceFolders = vscode.workspace.workspaceFolders;
-		originalShowWorkspaceFolderPick = vscode.window.showWorkspaceFolderPick;
+		originalShowQuickPick = vscode.window.showQuickPick;
+		originalFindFiles = vscode.workspace.findFiles;
+		originalGetConfiguration = vscode.workspace.getConfiguration;
+		originalTextDocumentsDescriptor = Object.getOwnPropertyDescriptor(vscode.workspace, "textDocuments");
 
-		// Reset test state
 		mockWorkspaceFolders = undefined;
-		workspaceFolderPickResult = undefined;
+		quickPickResult = undefined;
+		lastQuickPickItems = undefined;
+		lastQuickPickOptions = undefined;
 
-		// Mock workspace folders
 		Object.defineProperty(vscode.workspace, "workspaceFolders", {
 			get: () => mockWorkspaceFolders,
 			configurable: true,
 		});
 
-		// Mock showWorkspaceFolderPick
-		vscode.window.showWorkspaceFolderPick = async () => workspaceFolderPickResult;
+		// No on-disk Quarto projects: discovery falls back to workspace folder roots.
+		vscode.workspace.findFiles = (() => Promise.resolve([])) as typeof vscode.workspace.findFiles;
+
+		// `openEditors` mode would otherwise iterate the live editor list.
+		Object.defineProperty(vscode.workspace, "textDocuments", {
+			get: () => [],
+			configurable: true,
+		});
+
+		// Force discovery to skip findFiles entirely and short-circuit to folder roots.
+		vscode.workspace.getConfiguration = ((section?: string) => {
+			if (section === "quartoWizard") {
+				return {
+					get: <T>(key: string, defaultValue?: T): T => {
+						if (key === "autoProjectDetection") {
+							return false as unknown as T;
+						}
+						return defaultValue as T;
+					},
+					has: () => true,
+					inspect: () => undefined,
+					update: async () => {
+						/* no-op */
+					},
+				} as unknown as vscode.WorkspaceConfiguration;
+			}
+			return originalGetConfiguration(section);
+		}) as typeof vscode.workspace.getConfiguration;
+
+		vscode.window.showQuickPick = (async (
+			items: readonly vscode.QuickPickItem[] | Thenable<readonly vscode.QuickPickItem[]>,
+			options?: vscode.QuickPickOptions,
+		) => {
+			lastQuickPickItems = await Promise.resolve(items);
+			lastQuickPickOptions = options;
+			return quickPickResult as unknown as vscode.QuickPickItem;
+		}) as unknown as typeof vscode.window.showQuickPick;
 	});
 
 	teardown(() => {
-		// Restore original methods
 		Object.defineProperty(vscode.workspace, "workspaceFolders", {
 			value: originalWorkspaceFolders,
 			configurable: true,
 		});
-		vscode.window.showWorkspaceFolderPick = originalShowWorkspaceFolderPick;
+		vscode.window.showQuickPick = originalShowQuickPick;
+		vscode.workspace.findFiles = originalFindFiles;
+		vscode.workspace.getConfiguration = originalGetConfiguration;
+		if (originalTextDocumentsDescriptor) {
+			Object.defineProperty(vscode.workspace, "textDocuments", originalTextDocumentsDescriptor);
+		}
 	});
 
-	/**
-	 * Helper function to create a mock workspace folder
-	 */
-	function createMockWorkspaceFolder(name: string, path: string): vscode.WorkspaceFolder {
-		return {
-			uri: vscode.Uri.file(path),
-			name,
-			index: 0,
-		};
+	function createMockWorkspaceFolder(name: string, fsPath: string, index = 0): vscode.WorkspaceFolder {
+		return { uri: vscode.Uri.file(fsPath), name, index };
 	}
 
 	suite("selectWorkspaceFolder", () => {
-		test("should return undefined when no workspace folders exist", async () => {
+		test("returns undefined when no workspace folders exist", async () => {
 			mockWorkspaceFolders = undefined;
-
 			const result = await selectWorkspaceFolder();
-
 			assert.strictEqual(result, undefined);
 		});
 
-		test("should return undefined when workspace folders array is empty", async () => {
+		test("returns undefined when workspace folders array is empty", async () => {
 			mockWorkspaceFolders = [];
-
 			const result = await selectWorkspaceFolder();
-
 			assert.strictEqual(result, undefined);
 		});
 
-		test("should return the single workspace folder path when only one exists", async () => {
-			const mockFolder = createMockWorkspaceFolder("test-project", "/path/to/test-project");
-			mockWorkspaceFolders = [mockFolder];
+		test("returns the single workspace folder path when only one root is detected", async () => {
+			const folder = createMockWorkspaceFolder("test-project", "/path/to/test-project");
+			mockWorkspaceFolders = [folder];
 
 			const result = await selectWorkspaceFolder();
 
-			assert.strictEqual(result, mockFolder.uri.fsPath);
+			assert.strictEqual(result, folder.uri.fsPath);
 		});
 
-		test("should prompt user selection when multiple workspace folders exist and return selected folder", async () => {
-			const folder1 = createMockWorkspaceFolder("project1", "/path/to/project1");
-			const folder2 = createMockWorkspaceFolder("project2", "/path/to/project2");
+		test("prompts the user when multiple roots exist and returns the picked path", async () => {
+			const folder1 = createMockWorkspaceFolder("project1", "/path/to/project1", 0);
+			const folder2 = createMockWorkspaceFolder("project2", "/path/to/project2", 1);
 			mockWorkspaceFolders = [folder1, folder2];
-			workspaceFolderPickResult = folder2;
+			quickPickResult = { root: { fsPath: folder2.uri.fsPath } };
 
 			const result = await selectWorkspaceFolder();
 
 			assert.strictEqual(result, folder2.uri.fsPath);
+			assert.ok(lastQuickPickItems);
+			assert.strictEqual(lastQuickPickItems.length, 2);
+			assert.ok(lastQuickPickOptions);
+			assert.strictEqual(lastQuickPickOptions.placeHolder, "Select a Quarto project folder");
+			assert.strictEqual(lastQuickPickOptions.ignoreFocusOut, true);
 		});
 
-		test("should return undefined when user cancels workspace folder selection", async () => {
-			const folder1 = createMockWorkspaceFolder("project1", "/path/to/project1");
-			const folder2 = createMockWorkspaceFolder("project2", "/path/to/project2");
+		test("returns undefined when the user dismisses the picker", async () => {
+			const folder1 = createMockWorkspaceFolder("project1", "/path/to/project1", 0);
+			const folder2 = createMockWorkspaceFolder("project2", "/path/to/project2", 1);
 			mockWorkspaceFolders = [folder1, folder2];
-			workspaceFolderPickResult = undefined; // User cancelled
+			quickPickResult = undefined;
 
 			const result = await selectWorkspaceFolder();
 
 			assert.strictEqual(result, undefined);
 		});
 
-		test("should call showWorkspaceFolderPick with correct options", async () => {
-			const folder1 = createMockWorkspaceFolder("project1", "/path/to/project1");
-			const folder2 = createMockWorkspaceFolder("project2", "/path/to/project2");
-			mockWorkspaceFolders = [folder1, folder2];
-
-			let capturedOptions: vscode.WorkspaceFolderPickOptions | undefined;
-
-			vscode.window.showWorkspaceFolderPick = async (options?: vscode.WorkspaceFolderPickOptions) => {
-				capturedOptions = options;
-				return workspaceFolderPickResult;
-			};
-
-			await selectWorkspaceFolder();
-
-			assert.ok(capturedOptions);
-			assert.strictEqual(capturedOptions.placeHolder, "Select a workspace folder");
-			assert.strictEqual(capturedOptions.ignoreFocusOut, true);
-		});
-
-		test("should handle workspace folders with different indices", async () => {
-			const folder1: vscode.WorkspaceFolder = {
-				uri: vscode.Uri.file("/path/to/project1"),
-				name: "project1",
-				index: 0,
-			};
-			const folder2: vscode.WorkspaceFolder = {
-				uri: vscode.Uri.file("/path/to/project2"),
-				name: "project2",
-				index: 1,
-			};
-			mockWorkspaceFolders = [folder1, folder2];
-			workspaceFolderPickResult = folder1;
-
-			const result = await selectWorkspaceFolder();
-
-			assert.strictEqual(result, folder1.uri.fsPath);
-		});
-
-		test("should handle workspace folders with special characters in paths", async () => {
+		test("handles workspace folders with special characters in paths", async () => {
 			const specialPath = "/path/to/project with spaces & special-chars!";
 			const folder = createMockWorkspaceFolder("special-project", specialPath);
 			mockWorkspaceFolders = [folder];
@@ -144,7 +150,7 @@ suite("Workspace Utils Test Suite", () => {
 			assert.strictEqual(result, folder.uri.fsPath);
 		});
 
-		test("should handle workspace folders with Windows-style paths", async () => {
+		test("handles workspace folders with Windows-style paths", async () => {
 			const windowsPath = "C:\\Users\\test\\Documents\\project";
 			const folder = createMockWorkspaceFolder("windows-project", windowsPath);
 			mockWorkspaceFolders = [folder];

--- a/src/ui/extensionTreeDataProvider.ts
+++ b/src/ui/extensionTreeDataProvider.ts
@@ -8,6 +8,7 @@ import { debounce } from "../utils/debounce";
 import { logMessage } from "../utils/log";
 import { getInstalledExtensionsRecord, getExtensionContributes, getEffectiveSourceType } from "../utils/extensions";
 import { getCacheTTL, getCrossSourceUpdateEnabled, getRegistryUrl } from "../utils/extensionDetails";
+import type { QuartoProjectRoot } from "../utils/quartoProjectDiscovery";
 import { getAuthConfig } from "../utils/auth";
 import { getQuartoVersionInfo, type QuartoVersionInfo } from "../services/quartoVersion";
 import { validateQuartoRequirement } from "../utils/versionValidation";
@@ -48,11 +49,24 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 	private pendingCheck: Promise<number> | null = null;
 
 	constructor(
-		private workspaceFolders: readonly vscode.WorkspaceFolder[],
+		private projectRoots: readonly QuartoProjectRoot[],
 		private schemaCache: SchemaCache,
 		private snippetCache: SnippetCache,
 	) {
 		this.refreshAllExtensionsData();
+	}
+
+	/**
+	 * Replaces the set of Quarto project roots. Returns `true` when the new set differs from
+	 * the previous one. The caller decides whether to trigger a refresh, so this method does
+	 * not fire the change event itself: a typical follow-up is `refreshAfterAction(...)`.
+	 */
+	setProjectRoots(projectRoots: readonly QuartoProjectRoot[]): boolean {
+		if (sameProjectRoots(this.projectRoots, projectRoots)) {
+			return false;
+		}
+		this.projectRoots = projectRoots;
+		return true;
 	}
 
 	dispose(): void {
@@ -66,7 +80,7 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 
 	getChildren(element?: TreeItemType): Thenable<TreeItemType[]> {
 		if (!element) {
-			if (this.workspaceFolders.length === 0) {
+			if (this.projectRoots.length === 0) {
 				return Promise.resolve([
 					new ExtensionTreeItem(
 						"No workspace folders open.",
@@ -112,17 +126,15 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 	}
 
 	private getWorkspaceFolderItems(): WorkspaceFolderTreeItem[] {
-		if (this.workspaceFolders.length > 1) {
-			return this.workspaceFolders.map((folder) => {
-				return new WorkspaceFolderTreeItem(folder.name, folder.uri.fsPath);
-			});
+		if (this.projectRoots.length > 1) {
+			return this.projectRoots.map((root) => new WorkspaceFolderTreeItem(root.label, root.fsPath));
 		}
-		return this.workspaceFolders
-			.filter((folder) => {
-				const folderCache = this.cache[folder.uri.fsPath];
+		return this.projectRoots
+			.filter((root) => {
+				const folderCache = this.cache[root.fsPath];
 				return folderCache && Object.keys(folderCache.extensions).length > 0;
 			})
-			.map((folder) => new WorkspaceFolderTreeItem(folder.name, folder.uri.fsPath));
+			.map((root) => new WorkspaceFolderTreeItem(root.label, root.fsPath));
 	}
 
 	private getExtensionItems(workspacePath: string): ExtensionTreeItem[] {
@@ -426,9 +438,9 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 			const newCache: Record<string, FolderCache> = {};
 			const quartoInfo = await getQuartoVersionInfo();
 
-			for (const folder of this.workspaceFolders) {
-				const workspaceFolder = folder.uri.fsPath;
-				const extensions = await getInstalledExtensionsRecord(workspaceFolder);
+			for (const root of this.projectRoots) {
+				const projectPath = root.fsPath;
+				const extensions = await getInstalledExtensionsRecord(projectPath);
 
 				const parseErrors = new Set<string>();
 				const compatibility: Record<string, ExtensionCompatibility> = {};
@@ -441,9 +453,9 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 					}
 				}
 
-				newCache[workspaceFolder] = {
+				newCache[projectPath] = {
 					extensions,
-					latestVersions: this.cache[workspaceFolder]?.latestVersions || {},
+					latestVersions: this.cache[projectPath]?.latestVersions || {},
 					parseErrors,
 					compatibility,
 				};
@@ -479,9 +491,9 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 			latestVersion: string;
 		}[] = [];
 
-		for (const folder of this.workspaceFolders) {
-			const workspacePath = folder.uri.fsPath;
-			const folderCache = this.cache[workspacePath];
+		for (const root of this.projectRoots) {
+			const projectPath = root.fsPath;
+			const folderCache = this.cache[projectPath];
 			if (!folderCache) continue;
 
 			for (const ext of Object.keys(folderCache.latestVersions)) {
@@ -490,7 +502,7 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 					const extension = folderCache.extensions[ext];
 					outdated.push({
 						extensionId: ext,
-						workspaceFolder: workspacePath,
+						workspaceFolder: projectPath,
 						source: extension?.manifest.source,
 						sourceType: extension ? getEffectiveSourceType(extension.manifest) : undefined,
 						latestVersion: version,
@@ -538,14 +550,14 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 			const updatesAvailable: string[] = [];
 			let totalUpdates = 0;
 
-			for (const folder of this.workspaceFolders) {
-				const workspacePath = folder.uri.fsPath;
-				const folderCache = this.cache[workspacePath];
+			for (const root of this.projectRoots) {
+				const projectPath = root.fsPath;
+				const folderCache = this.cache[projectPath];
 				if (!folderCache) continue;
 
 				try {
 					const updates = await checkForUpdates({
-						projectDir: workspacePath,
+						projectDir: projectPath,
 						registryUrl,
 						cacheTtl,
 						auth: auth ?? undefined,
@@ -562,11 +574,11 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 						const versionRef = atIndex > 0 ? update.source.substring(atIndex + 1) : update.latestVersion;
 
 						folderCache.latestVersions[extId] = versionRef;
-						updatesAvailable.push(`${folder.name}/${extId}`);
+						updatesAvailable.push(`${root.label}/${extId}`);
 						totalUpdates++;
 					}
 				} catch (error) {
-					logMessage(`Failed to check updates for ${workspacePath}: ${getErrorMessage(error)}.`, "error");
+					logMessage(`Failed to check updates for ${projectPath}: ${getErrorMessage(error)}.`, "error");
 				}
 			}
 
@@ -594,4 +606,16 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 
 		return this.pendingCheck;
 	}
+}
+
+function sameProjectRoots(a: readonly QuartoProjectRoot[], b: readonly QuartoProjectRoot[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	for (let i = 0; i < a.length; i++) {
+		if (a[i].fsPath !== b[i].fsPath) {
+			return false;
+		}
+	}
+	return true;
 }

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -77,6 +77,7 @@ export class ExtensionsInstalled {
 				}
 			})();
 		}, PROJECT_ROOTS_REFRESH_DEBOUNCE_MS);
+		context.subscriptions.push({ dispose: () => refreshProjectRoots.cancel() });
 
 		// Explicit trigger (activation, manual refresh): always re-fetch downstream data.
 		const refreshAll = () => {

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -11,8 +11,16 @@ import { getAuthConfig } from "../utils/auth";
 import { getSourceBase, resolveLocalSourcePath } from "../utils/extensions";
 import { invalidateInstalledExtensionsCache } from "../utils/installedExtensionsCache";
 import { invalidateWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import {
+	discoverQuartoProjectRoots,
+	QUARTO_PROJECT_GLOB,
+	EXTENSION_MANIFEST_GLOB,
+} from "../utils/quartoProjectDiscovery";
+import { debounce } from "../utils/debounce";
 import { WorkspaceFolderTreeItem, ExtensionTreeItem, SnippetItemTreeItem } from "./extensionTreeItems";
 import { QuartoExtensionTreeDataProvider } from "./extensionTreeDataProvider";
+
+const PROJECT_ROOTS_REFRESH_DEBOUNCE_MS = 500;
 
 /**
  * Manages the installed Quarto extensions.
@@ -33,7 +41,9 @@ export class ExtensionsInstalled {
 			return;
 		}
 
-		this.treeDataProvider = new QuartoExtensionTreeDataProvider(workspaceFolders, schemaCache, snippetCache);
+		// Project roots are discovered asynchronously; start with an empty set so the view can
+		// render immediately, then update once discovery completes.
+		this.treeDataProvider = new QuartoExtensionTreeDataProvider([], schemaCache, snippetCache);
 		context.subscriptions.push(this.treeDataProvider);
 		const view = vscode.window.createTreeView("quartoWizard.extensionsInstalled", {
 			treeDataProvider: this.treeDataProvider,
@@ -48,8 +58,36 @@ export class ExtensionsInstalled {
 			return vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath;
 		};
 
-		// Initial setup with update check and refresh
-		this.treeDataProvider.refreshAfterAction(context, view);
+		const updateProjectRoots = async (): Promise<boolean> => {
+			const folders = vscode.workspace.workspaceFolders ?? [];
+			try {
+				const roots = await discoverQuartoProjectRoots(folders);
+				return this.treeDataProvider.setProjectRoots(roots);
+			} catch (error) {
+				logMessage(`Failed to discover Quarto project roots: ${getErrorMessage(error)}.`, "error");
+				return false;
+			}
+		};
+
+		// Background trigger: run discovery; only re-fetch extensions/updates if roots changed.
+		const refreshProjectRoots = debounce(() => {
+			void (async () => {
+				if (await updateProjectRoots()) {
+					this.treeDataProvider.refreshAfterAction(context, view);
+				}
+			})();
+		}, PROJECT_ROOTS_REFRESH_DEBOUNCE_MS);
+
+		// Explicit trigger (activation, manual refresh): always re-fetch downstream data.
+		const refreshAll = () => {
+			refreshProjectRoots.cancel();
+			void (async () => {
+				await updateProjectRoots();
+				this.treeDataProvider.refreshAfterAction(context, view);
+			})();
+		};
+
+		refreshAll();
 
 		const visibilityDisposable = view.onDidChangeVisibility((e) => {
 			if (e.visible) {
@@ -58,15 +96,53 @@ export class ExtensionsInstalled {
 		});
 		context.subscriptions.push(visibilityDisposable);
 
-		// Watch for changes to _extensions directories for real-time tree view updates
-		const extensionWatcher = vscode.workspace.createFileSystemWatcher("**/_extensions/**/_extension.{yml,yaml}");
-		const invalidateAndRefreshExtensions = (uri: vscode.Uri) => {
+		context.subscriptions.push(
+			vscode.workspace.onDidChangeConfiguration((event) => {
+				if (event.affectsConfiguration("quartoWizard.autoProjectDetection")) {
+					refreshProjectRoots();
+				}
+			}),
+		);
+
+		context.subscriptions.push(
+			vscode.workspace.onDidChangeWorkspaceFolders(() => {
+				refreshProjectRoots();
+			}),
+		);
+
+		const projectFileWatcher = vscode.workspace.createFileSystemWatcher(QUARTO_PROJECT_GLOB);
+		const onProjectFileChanged = (uri: vscode.Uri) => {
 			invalidateProviderCaches(resolveWorkspacePath(uri));
-			this.treeDataProvider.refresh();
+			refreshProjectRoots();
 		};
-		context.subscriptions.push(extensionWatcher.onDidCreate(invalidateAndRefreshExtensions));
-		context.subscriptions.push(extensionWatcher.onDidDelete(invalidateAndRefreshExtensions));
-		context.subscriptions.push(extensionWatcher.onDidChange(invalidateAndRefreshExtensions));
+		context.subscriptions.push(projectFileWatcher.onDidCreate(onProjectFileChanged));
+		context.subscriptions.push(projectFileWatcher.onDidDelete(onProjectFileChanged));
+		context.subscriptions.push(projectFileWatcher);
+
+		// `openEditors` mode walks parents of open documents; refresh when the doc set changes.
+		// Filter to real files so output channels and untitled buffers don't queue work.
+		const onEditorChanged = (document: vscode.TextDocument) => {
+			if (document.uri.scheme === "file" && !document.isUntitled) {
+				refreshProjectRoots();
+			}
+		};
+		context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(onEditorChanged));
+		context.subscriptions.push(vscode.workspace.onDidCloseTextDocument(onEditorChanged));
+
+		// Create/delete also re-runs discovery so installing the first extension in a folder
+		// promotes it into the detected roots without a manual refresh.
+		const extensionWatcher = vscode.workspace.createFileSystemWatcher(EXTENSION_MANIFEST_GLOB);
+		const onExtensionManifestEvent = (rediscover: boolean) => (uri: vscode.Uri) => {
+			invalidateProviderCaches(resolveWorkspacePath(uri));
+			if (rediscover) {
+				refreshProjectRoots();
+			} else {
+				this.treeDataProvider.refresh();
+			}
+		};
+		context.subscriptions.push(extensionWatcher.onDidCreate(onExtensionManifestEvent(true)));
+		context.subscriptions.push(extensionWatcher.onDidDelete(onExtensionManifestEvent(true)));
+		context.subscriptions.push(extensionWatcher.onDidChange(onExtensionManifestEvent(false)));
 		context.subscriptions.push(extensionWatcher);
 
 		// Watch for changes to schema files for real-time tree view updates
@@ -96,7 +172,7 @@ export class ExtensionsInstalled {
 		context.subscriptions.push(
 			vscode.commands.registerCommand("quartoWizard.extensionsInstalled.refresh", () => {
 				invalidateProviderCaches();
-				this.treeDataProvider.refreshAfterAction(context, view);
+				refreshAll();
 			}),
 		);
 

--- a/src/utils/extensionDetails.ts
+++ b/src/utils/extensionDetails.ts
@@ -44,6 +44,21 @@ export function getCrossSourceUpdateEnabled(): boolean {
 }
 
 /**
+ * Possible values for `quartoWizard.autoProjectDetection`.
+ * Mirrors VSCode's `git.autoRepositoryDetection` shape.
+ */
+export type AutoProjectDetection = boolean | "subFolders" | "openEditors";
+
+/**
+ * Reads the `quartoWizard.autoProjectDetection` setting.
+ * Defaults to `true` when unset, matching the default of VSCode's `git.autoRepositoryDetection`.
+ */
+export function getAutoProjectDetection(): AutoProjectDetection {
+	const config = vscode.workspace.getConfiguration("quartoWizard");
+	return config.get<AutoProjectDetection>("autoProjectDetection", true);
+}
+
+/**
  * Interface representing the details of a Quarto extension.
  */
 export interface ExtensionDetails {

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -90,7 +90,7 @@ export async function discoverQuartoProjectRoots(
 		}
 
 		const sorted = [...candidates].sort((a, b) =>
-			path.posix.relative(folderPath, a).localeCompare(path.posix.relative(folderPath, b)),
+			path.relative(folderPath, a).localeCompare(path.relative(folderPath, b)),
 		);
 		for (const dir of sorted) {
 			results.push(buildRoot(folder, dir));

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -220,6 +220,8 @@ async function isFile(uri: vscode.Uri): Promise<boolean> {
 /**
  * Lazily walks `extensionsDir` and returns true on the first `_extension.{yml,yaml}` found.
  * Empty `_extensions/` directories return false so they don't promote a folder to a root.
+ * Symlinks are skipped so a loop (e.g. `_extensions/loop -> _extensions`) cannot drive the
+ * walk into an unbounded ancestor chain.
  */
 async function directoryHasInstalledExtension(extensionsDir: vscode.Uri): Promise<boolean> {
 	let entries: [string, vscode.FileType][];
@@ -229,15 +231,20 @@ async function directoryHasInstalledExtension(extensionsDir: vscode.Uri): Promis
 		return false;
 	}
 	for (const [name, type] of entries) {
-		const child = vscode.Uri.joinPath(extensionsDir, name);
+		if ((type & vscode.FileType.SymbolicLink) !== 0) {
+			continue;
+		}
 		if ((type & vscode.FileType.File) !== 0) {
 			if (MANIFEST_FILENAMES.some((filename) => filename === name)) {
 				return true;
 			}
 			continue;
 		}
-		if ((type & vscode.FileType.Directory) !== 0 && (await directoryHasInstalledExtension(child))) {
-			return true;
+		if ((type & vscode.FileType.Directory) !== 0) {
+			const child = vscode.Uri.joinPath(extensionsDir, name);
+			if (await directoryHasInstalledExtension(child)) {
+				return true;
+			}
 		}
 	}
 	return false;

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -1,0 +1,255 @@
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { EXTENSIONS_DIR, MANIFEST_FILENAMES, getErrorMessage } from "@quarto-wizard/core";
+import { getAutoProjectDetection, type AutoProjectDetection } from "./extensionDetails";
+import { logMessage } from "./log";
+
+/**
+ * Glob pattern matching Quarto project marker files at any depth within a workspace folder.
+ */
+export const QUARTO_PROJECT_GLOB = "**/_quarto.{yml,yaml}";
+
+/**
+ * Glob pattern matching installed extension manifests at any depth.
+ * The presence of one of these promotes the enclosing project folder (the parent of the
+ * outermost `_extensions/` ancestor) to a Quarto root.
+ */
+export const EXTENSION_MANIFEST_GLOB = `**/${EXTENSIONS_DIR}/**/_extension.{yml,yaml}`;
+
+/**
+ * Filenames that mark a directory as a Quarto project root via `_quarto.{yml,yaml}`.
+ */
+export const QUARTO_PROJECT_FILENAMES = ["_quarto.yml", "_quarto.yaml"] as const;
+
+/**
+ * A discovered Quarto project root.
+ */
+export interface QuartoProjectRoot {
+	/**
+	 * Absolute path to the project root directory (containing `_quarto.{yml,yaml}` and/or
+	 * an `_extensions/` directory with at least one installed extension).
+	 */
+	fsPath: string;
+	/**
+	 * The workspace folder that owns this root.
+	 */
+	workspaceFolder: vscode.WorkspaceFolder;
+	/**
+	 * Display label.
+	 * Equal to `workspaceFolder.name` when the root is the workspace folder itself,
+	 * otherwise `workspaceFolder.name/<relative path>` (POSIX-separated).
+	 */
+	label: string;
+}
+
+/**
+ * Discovers Quarto project roots across the given workspace folders, honouring the
+ * `quartoWizard.autoProjectDetection` setting.
+ *
+ * Smart merge per workspace folder:
+ *  - if the folder root itself contains `_quarto.{yml,yaml}`, only that root is returned;
+ *  - else, all detected sub-roots are returned;
+ *  - if nothing is detected, the folder root is returned as a fallback so the tree view
+ *    keeps its empty-state messaging.
+ */
+export async function discoverQuartoProjectRoots(
+	workspaceFolders: readonly vscode.WorkspaceFolder[],
+): Promise<QuartoProjectRoot[]> {
+	if (workspaceFolders.length === 0) {
+		return [];
+	}
+
+	const setting = getAutoProjectDetection();
+	const results: QuartoProjectRoot[] = [];
+
+	for (const folder of workspaceFolders) {
+		const folderPath = folder.uri.fsPath;
+
+		if (setting === false) {
+			results.push(buildRoot(folder, folderPath));
+			continue;
+		}
+
+		const candidates = new Set<string>();
+
+		if (shouldScanSubFolders(setting)) {
+			for (const dir of await findSubFolderProjectDirs(folder)) {
+				candidates.add(dir);
+			}
+		}
+
+		if (shouldScanOpenEditors(setting)) {
+			for (const dir of await findOpenEditorProjectDirs(folder)) {
+				candidates.add(dir);
+			}
+		}
+
+		if (candidates.has(folderPath) || candidates.size === 0) {
+			results.push(buildRoot(folder, folderPath));
+			continue;
+		}
+
+		const sorted = [...candidates].sort((a, b) =>
+			path.posix.relative(folderPath, a).localeCompare(path.posix.relative(folderPath, b)),
+		);
+		for (const dir of sorted) {
+			results.push(buildRoot(folder, dir));
+		}
+	}
+
+	return results;
+}
+
+function shouldScanSubFolders(setting: AutoProjectDetection): boolean {
+	return setting === true || setting === "subFolders";
+}
+
+function shouldScanOpenEditors(setting: AutoProjectDetection): boolean {
+	return setting === true || setting === "openEditors";
+}
+
+function buildRoot(folder: vscode.WorkspaceFolder, fsPath: string): QuartoProjectRoot {
+	if (fsPath === folder.uri.fsPath) {
+		return { fsPath, workspaceFolder: folder, label: folder.name };
+	}
+	const relative = path.relative(folder.uri.fsPath, fsPath).split(path.sep).join(path.posix.sep);
+	return { fsPath, workspaceFolder: folder, label: `${folder.name}/${relative}` };
+}
+
+async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder): Promise<string[]> {
+	try {
+		// `null` exclude lets VSCode honour the user's `files.exclude` and `search.exclude`,
+		// matching how the Git extension scopes its repository scans.
+		const [quartoUris, manifestUris] = await Promise.all([
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, QUARTO_PROJECT_GLOB), null),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, EXTENSION_MANIFEST_GLOB), null),
+		]);
+		const folderPath = folder.uri.fsPath;
+		const dirs: string[] = [];
+		for (const uri of quartoUris) {
+			if (uri.scheme !== "file") continue;
+			const dir = path.dirname(uri.fsPath);
+			if (isInside(folderPath, dir)) dirs.push(dir);
+		}
+		for (const uri of manifestUris) {
+			if (uri.scheme !== "file") continue;
+			const dir = projectRootFromManifestPath(uri.fsPath);
+			if (dir && isInside(folderPath, dir)) dirs.push(dir);
+		}
+		return dirs;
+	} catch (error) {
+		logMessage(`Failed to scan ${folder.uri.fsPath} for Quarto projects: ${getErrorMessage(error)}.`, "error");
+		return [];
+	}
+}
+
+/**
+ * Maps an extension manifest path to the enclosing project root.
+ *
+ * Picks the outermost `_extensions` segment so a templated `_extensions/` shipped *inside*
+ * another extension does not get treated as its own project.
+ */
+function projectRootFromManifestPath(manifestPath: string): string | undefined {
+	const segments = manifestPath.split(path.sep);
+	const idx = segments.indexOf(EXTENSIONS_DIR);
+	if (idx <= 0) return undefined;
+	return segments.slice(0, idx).join(path.sep);
+}
+
+async function findOpenEditorProjectDirs(folder: vscode.WorkspaceFolder): Promise<string[]> {
+	const folderPath = folder.uri.fsPath;
+	const dirs = new Set<string>();
+	for (const document of vscode.workspace.textDocuments) {
+		if (document.uri.scheme !== "file" || document.isUntitled) {
+			continue;
+		}
+		const documentPath = document.uri.fsPath;
+		if (!isInside(folderPath, documentPath)) {
+			continue;
+		}
+		const projectDir = await ascendForProjectFile(folderPath, path.dirname(documentPath));
+		if (projectDir) {
+			dirs.add(projectDir);
+		}
+	}
+	return [...dirs];
+}
+
+/**
+ * Walks `start` upward (inclusive) until a Quarto project marker is found or the workspace
+ * folder boundary is reached. Returns the deepest directory containing a marker.
+ */
+async function ascendForProjectFile(folderPath: string, start: string): Promise<string | undefined> {
+	let current = start;
+	while (isInside(folderPath, current)) {
+		if (await directoryHasProjectMarker(current)) {
+			return current;
+		}
+		const parent = path.dirname(current);
+		if (parent === current) {
+			return undefined;
+		}
+		current = parent;
+	}
+	return undefined;
+}
+
+/**
+ * True when `dir` qualifies as a Quarto root: it contains `_quarto.{yml,yaml}` or an
+ * `_extensions/` directory with at least one installed extension manifest.
+ */
+async function directoryHasProjectMarker(dir: string): Promise<boolean> {
+	const quartoMarkers = await Promise.all(
+		QUARTO_PROJECT_FILENAMES.map((filename) => isFile(vscode.Uri.file(path.join(dir, filename)))),
+	);
+	if (quartoMarkers.includes(true)) {
+		return true;
+	}
+	return await directoryHasInstalledExtension(vscode.Uri.file(path.join(dir, EXTENSIONS_DIR)));
+}
+
+async function isFile(uri: vscode.Uri): Promise<boolean> {
+	try {
+		const stat = await vscode.workspace.fs.stat(uri);
+		return (stat.type & vscode.FileType.File) !== 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Lazily walks `extensionsDir` and returns true on the first `_extension.{yml,yaml}` found.
+ * Empty `_extensions/` directories return false so they don't promote a folder to a root.
+ */
+async function directoryHasInstalledExtension(extensionsDir: vscode.Uri): Promise<boolean> {
+	let entries: [string, vscode.FileType][];
+	try {
+		entries = await vscode.workspace.fs.readDirectory(extensionsDir);
+	} catch {
+		return false;
+	}
+	for (const [name, type] of entries) {
+		const child = vscode.Uri.joinPath(extensionsDir, name);
+		if ((type & vscode.FileType.File) !== 0) {
+			if (MANIFEST_FILENAMES.some((filename) => filename === name)) {
+				return true;
+			}
+			continue;
+		}
+		if ((type & vscode.FileType.Directory) !== 0 && (await directoryHasInstalledExtension(child))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * True when `child` is `parent` or lives below it (resolved, normalised path comparison).
+ */
+function isInside(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	if (relative === "") {
+		return true;
+	}
+	return !relative.startsWith("..") && !path.isAbsolute(relative);
+}

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,9 +1,22 @@
 import * as vscode from "vscode";
+import { discoverQuartoProjectRoots, type QuartoProjectRoot } from "./quartoProjectDiscovery";
 
 /**
- * Prompts the user to select a workspace folder if multiple workspace folders are detected.
+ * Quick pick item used when prompting the user to choose between detected Quarto project roots.
+ */
+interface ProjectRootQuickPickItem extends vscode.QuickPickItem {
+	root: QuartoProjectRoot;
+}
+
+/**
+ * Resolves the Quarto project root the user wants to act on.
  *
- * @returns {Promise<string | undefined>} - The selected workspace folder path or undefined if no selection is made.
+ * The candidate list comes from {@link discoverQuartoProjectRoots}, so the returned path is
+ * either a workspace folder root or a detected sub-folder containing `_quarto.{yml,yaml}`,
+ * depending on the `quartoWizard.autoProjectDetection` setting.
+ *
+ * @returns The selected project root path, or `undefined` if no workspace folder is open or the
+ *          user dismissed the picker.
  */
 export async function selectWorkspaceFolder(): Promise<string | undefined> {
 	const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -11,16 +24,26 @@ export async function selectWorkspaceFolder(): Promise<string | undefined> {
 		return undefined;
 	}
 
-	if (workspaceFolders.length === 1) {
-		return workspaceFolders[0].uri.fsPath;
+	const roots = await discoverQuartoProjectRoots(workspaceFolders);
+	if (roots.length === 0) {
+		return undefined;
 	}
 
-	const options: vscode.WorkspaceFolderPickOptions = {
-		placeHolder: "Select a workspace folder",
+	if (roots.length === 1) {
+		return roots[0].fsPath;
+	}
+
+	const items: ProjectRootQuickPickItem[] = roots.map((root) => ({
+		label: root.label,
+		description: root.fsPath,
+		root,
+	}));
+
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: "Select a Quarto project folder",
 		ignoreFocusOut: true,
-	};
+		matchOnDescription: true,
+	});
 
-	const selectedFolder = await vscode.window.showWorkspaceFolderPick(options);
-
-	return selectedFolder?.uri.fsPath;
+	return picked?.root.fsPath;
 }


### PR DESCRIPTION
Adds a `quartoWizard.autoProjectDetection` setting modelled on VSCode's `git.autoRepositoryDetection`, so the extension finds Quarto project roots nested below the workspace folder.
A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, or an `_extensions/` directory with at least one installed extension; the second marker handles single-document workspaces that use extensions without being a Quarto project.

Detected roots populate the Extensions Installed view and are offered as targets by every command that needs a folder (Install, Use Template, Use Brand, and the reproducible-example command).
A smart merge keeps only the workspace folder when it qualifies, otherwise lists every detected sub-root, and falls back to the workspace folder if nothing is found.

The setting accepts `true` (default), `false`, `"subFolders"`, and `"openEditors"` with the same semantics as the Git extension.
Detection refreshes when the setting changes, when the workspace changes, when `_quarto.yml` files are created or deleted, when extension manifests are created or deleted, and when a file editor opens or closes.
The recursive walk of `_extensions/` skips symlinks to avoid following loops.
A pending debounced refresh is cancelled when the extension deactivates.

Core gains a single new export: the previously private `EXTENSIONS_DIR` constant is now public so the UI can build globs without duplicating the literal.