### PR TITLE
docs: move 2.5.0 entry to root CHANGELOG.md as Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- feat: auto-detect Quarto project roots in workspace subfolders via the new `quartoWizard.autoProjectDetection` setting, modelled on VSCode's `git.autoRepositoryDetection`.
+  A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml` or an `_extensions/` directory with at least one installed extension.
+  Detected roots populate the Extensions Installed view and every folder-targeted command (Install, Use Template, Use Brand, ...).
+  The setting accepts `true` (default), `false`, `"subFolders"`, and `"openEditors"` with the same semantics as the Git extension.
+
 ## 2.4.1 (2026-04-19)
 
 - chore: no user-facing changes.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,18 +2,16 @@
 title: "Changelog"
 ---
 
-## 2 {#version-2}
+## Unreleased {#unreleased}
 
-### 2.5 {#version-2-5}
-
-#### 2.5.0 (Unreleased) {#version-2-5-0}
-
-##### New Features
+### New Features
 
 - feat: auto-detect Quarto project roots in workspace subfolders via the new `quartoWizard.autoProjectDetection` setting, modelled on VSCode's `git.autoRepositoryDetection`.
   A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml` or an `_extensions/` directory with at least one installed extension.
   Detected roots populate the Extensions Installed view and every folder-targeted command (Install, Use Template, Use Brand, ...).
   The setting accepts `true` (default), `false`, `"subFolders"`, and `"openEditors"` with the same semantics as the Git extension.
+
+## 2 {#version-2}
 
 ### 2.4 {#version-2-4}
 


### PR DESCRIPTION
The release workflow looks for `## Unreleased` in the root `CHANGELOG.md` to decide whether to bump and patch the version.
The previous PR placed the 2.5.0 entry only in `docs/changelog.qmd`, which is generated from the root file by `scripts/process-api-docs.mjs`, so the workflow never picked it up.
This moves the bullet into `CHANGELOG.md` and regenerates the QMD so both stay in sync until the next release fills in the version and date.