### PR TITLE
feat!: refine auto-detected project root behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- feat!: narrow the default scope of `quartoWizard.autoProjectDetection`. The default is now `"subFolders"`, which scans only direct children of the workspace folder. Set the value to `true` for the previous recursive behaviour.
+- feat!: `quartoWizard.autoProjectDetection: true` now means "recursive subfolder scan only". It no longer also walks up from open files; set the value to `"openEditors"` for that behaviour.
+- feat: render auto-detected project roots hierarchically in the Extensions Installed view. Sibling sub-projects under a shared parent (for example `docs/A` and `docs/B`) are grouped under that parent; projects without shared parents stay flat.
+
 ## 2.5.0 (2026-04-23)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - feat!: `quartoWizard.autoProjectDetection: true` now means "recursive subfolder scan only". It no longer also walks up from open files; set the value to `"openEditors"` for that behaviour.
 - feat: render auto-detected project roots hierarchically in the Extensions Installed view. Sibling sub-projects under a shared parent (for example `docs/A` and `docs/B`) are grouped under that parent; projects without shared parents stay flat.
 
+### Bug Fixes
+
+- fix: log a warning and fall back to `"subFolders"` when `quartoWizard.autoProjectDetection` is set to an unknown value, instead of silently using the workspace-folder fallback.
+
 ## 2.5.0 (2026-04-23)
 
 ### New Features

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -10,6 +10,10 @@ title: "Changelog"
 - feat!: `quartoWizard.autoProjectDetection: true` now means "recursive subfolder scan only". It no longer also walks up from open files; set the value to `"openEditors"` for that behaviour.
 - feat: render auto-detected project roots hierarchically in the Extensions Installed view. Sibling sub-projects under a shared parent (for example `docs/A` and `docs/B`) are grouped under that parent; projects without shared parents stay flat.
 
+### Bug Fixes
+
+- fix: log a warning and fall back to `"subFolders"` when `quartoWizard.autoProjectDetection` is set to an unknown value, instead of silently using the workspace-folder fallback.
+
 ## 2 {#version-2}
 
 ### 2.5 {#version-2-5}

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -2,6 +2,14 @@
 title: "Changelog"
 ---
 
+## Unreleased {#version-unreleased}
+
+### New Features
+
+- feat!: narrow the default scope of `quartoWizard.autoProjectDetection`. The default is now `"subFolders"`, which scans only direct children of the workspace folder. Set the value to `true` for the previous recursive behaviour.
+- feat!: `quartoWizard.autoProjectDetection: true` now means "recursive subfolder scan only". It no longer also walks up from open files; set the value to `"openEditors"` for that behaviour.
+- feat: render auto-detected project roots hierarchically in the Extensions Installed view. Sibling sub-projects under a shared parent (for example `docs/A` and `docs/B`) are grouped under that parent; projects without shared parents stay flat.
+
 ## 2 {#version-2}
 
 ### 2.5 {#version-2-5}

--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -41,6 +41,31 @@ Ask for confirmation before installing an extension. `ask` to ask for confirmati
 }
 ```
 
+## Project Detection
+
+### Auto Project Detection
+
+**Setting**: `quartoWizard.autoProjectDetection`
+
+Controls how Quarto Wizard discovers project roots.
+A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, or an `_extensions/` directory with at least one installed extension.
+
+| Value          | Description                                                                  |
+| -------------- | ---------------------------------------------------------------------------- |
+| `false`        | Disable scanning. Only the workspace folder itself is treated as a root.     |
+| `"subFolders"` | Scan direct subfolders of the workspace folder only (default).               |
+| `true`         | Scan recursively through all nested subfolders of the workspace folder.      |
+| `"openEditors"`| Walk up from the parent folders of open files until a marker is found.       |
+
+Setting `true` enables a recursive scan only.
+It no longer walks up from open editors; combine with `"openEditors"` only by switching values explicitly.
+
+```json
+{
+  "quartoWizard.autoProjectDetection": "subFolders"
+}
+```
+
 ## Cache Settings
 
 ### Cache Duration
@@ -100,7 +125,7 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.ask.trustAuthors": "ask",
   "quartoWizard.ask.confirmInstall": "ask",
   "quartoWizard.update.crossSource": false,
-  "quartoWizard.autoProjectDetection": true,
+  "quartoWizard.autoProjectDetection": "subFolders",
   "quartoWizard.cache.ttlMinutes": 30,
   "quartoWizard.registry.url": "https://m.canouil.dev/quarto-extensions/extensions.json"
 }

--- a/package.json
+++ b/package.json
@@ -683,13 +683,13 @@
 						"openEditors"
 					],
 					"enumDescriptions": [
-						"Scan for both subfolders of the current opened folder and parent folders of open files.",
+						"Scan recursively through all nested subfolders of the workspace folder.",
 						"Disable automatic Quarto project scanning.",
-						"Scan for subfolders of the currently opened folder.",
-						"Scan for parent folders of open files."
+						"Scan direct subfolders of the workspace folder only.",
+						"Scan parent folders of open files."
 					],
-					"default": true,
-					"markdownDescription": "Configures when Quarto project roots should be automatically detected. A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, **or** an `_extensions/` directory with at least one installed extension. Detected roots are used by the Extensions Installed view and by every command that needs a target folder (Install, Use Template, Use Brand, ...).",
+					"default": "subFolders",
+					"markdownDescription": "Configures when Quarto project roots should be automatically detected. A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, **or** an `_extensions/` directory with at least one installed extension. Detected roots are used by the Extensions Installed view and by every command that needs a target folder (Install, Use Template, Use Brand, ...). The default `subFolders` only inspects direct children of the workspace folder; set the value to `true` for a recursive scan, or `openEditors` to walk up from the parent folders of open files.",
 					"title": "Auto Project Detection",
 					"description": "When to auto-detect Quarto projects."
 				},

--- a/src/test/suite/extensionTreeDataProvider.test.ts
+++ b/src/test/suite/extensionTreeDataProvider.test.ts
@@ -1,10 +1,12 @@
 import * as assert from "assert";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import { SchemaCache } from "@quarto-wizard/schema";
 import { SnippetCache } from "@quarto-wizard/snippets";
 import { QuartoExtensionTreeDataProvider } from "../../ui/extensionTreeDataProvider";
-import { ExtensionTreeItem, WorkspaceFolderTreeItem } from "../../ui/extensionTreeItems";
+import { ExtensionTreeItem, ProjectGroupTreeItem, WorkspaceFolderTreeItem } from "../../ui/extensionTreeItems";
 import type { InstalledExtension } from "../../utils/extensions";
+import { makeFolder, makeRoot } from "./projectFixtures";
 
 suite("Extension Tree Data Provider Test Suite", () => {
 	function createProvider(): QuartoExtensionTreeDataProvider {
@@ -153,5 +155,80 @@ suite("Extension Tree Data Provider Test Suite", () => {
 		const extensionItem = roots[0] as ExtensionTreeItem;
 		const icon = extensionItem.iconPath as vscode.ThemeIcon;
 		assert.strictEqual(icon.id, "package");
+	});
+
+	test("Sibling sub-projects render under a ProjectGroupTreeItem", async () => {
+		const folder = makeFolder("repo", path.resolve(path.sep, "tmp", "repo"));
+		const a = makeRoot(folder, "docs", "A");
+		const b = makeRoot(folder, "docs", "B");
+		const provider = new QuartoExtensionTreeDataProvider([a, b], new SchemaCache(), new SnippetCache());
+		await waitForInitialRefresh(provider);
+
+		const top = await provider.getChildren();
+		assert.strictEqual(top.length, 1);
+		assert.ok(top[0] instanceof ProjectGroupTreeItem);
+		const group = top[0] as ProjectGroupTreeItem;
+		assert.strictEqual(group.label, "repo/docs");
+		assert.strictEqual(group.children.length, 2);
+		assert.ok(group.children[0] instanceof WorkspaceFolderTreeItem);
+		assert.ok(group.children[1] instanceof WorkspaceFolderTreeItem);
+		assert.strictEqual(group.children[0].label, "A");
+		assert.strictEqual(group.children[1].label, "B");
+		assert.strictEqual(group.children[0].folderPath, a.fsPath);
+		assert.strictEqual(group.children[1].folderPath, b.fsPath);
+
+		const expanded = await provider.getChildren(group);
+		assert.deepStrictEqual(expanded, group.children);
+	});
+
+	test("Single sub-project stays flat as a WorkspaceFolderTreeItem", async () => {
+		const folder = makeFolder("repo", path.resolve(path.sep, "tmp", "repo"));
+		const sub = makeRoot(folder, "docs", "only");
+		const provider = new QuartoExtensionTreeDataProvider([sub], new SchemaCache(), new SnippetCache());
+		await waitForInitialRefresh(provider);
+
+		(
+			provider as unknown as {
+				cache: Record<
+					string,
+					{
+						extensions: Record<string, InstalledExtension>;
+						latestVersions: Record<string, string>;
+						parseErrors: Set<string>;
+						compatibility: Record<string, { status: string; detail: string; warningMessage?: string }>;
+					}
+				>;
+			}
+		).cache = {
+			[sub.fsPath]: {
+				extensions: { "quarto-ext/demo": createExtension() },
+				latestVersions: {},
+				parseErrors: new Set<string>(),
+				compatibility: {},
+			},
+		};
+
+		const top = await provider.getChildren();
+		assert.strictEqual(top.length, 1);
+		assert.ok(top[0] instanceof WorkspaceFolderTreeItem);
+		assert.strictEqual(top[0].label, "repo/docs/only");
+	});
+
+	test("Independent workspace folders stay flat", async () => {
+		const repoA = makeFolder("repoA", path.resolve(path.sep, "tmp", "repoA"));
+		const repoB = makeFolder("repoB", path.resolve(path.sep, "tmp", "repoB"));
+		const provider = new QuartoExtensionTreeDataProvider(
+			[makeRoot(repoA), makeRoot(repoB)],
+			new SchemaCache(),
+			new SnippetCache(),
+		);
+		await waitForInitialRefresh(provider);
+
+		const top = await provider.getChildren();
+		assert.strictEqual(top.length, 2);
+		assert.ok(top[0] instanceof WorkspaceFolderTreeItem);
+		assert.ok(top[1] instanceof WorkspaceFolderTreeItem);
+		assert.strictEqual(top[0].label, "repoA");
+		assert.strictEqual(top[1].label, "repoB");
 	});
 });

--- a/src/test/suite/projectFixtures.ts
+++ b/src/test/suite/projectFixtures.ts
@@ -1,0 +1,14 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import type { QuartoProjectRoot } from "../../utils/quartoProjectDiscovery";
+
+export function makeFolder(name: string, fsPath: string, index = 0): vscode.WorkspaceFolder {
+	return { uri: vscode.Uri.file(fsPath), name, index };
+}
+
+export function makeRoot(folder: vscode.WorkspaceFolder, ...subPath: string[]): QuartoProjectRoot {
+	const fsPath = subPath.length === 0 ? folder.uri.fsPath : path.join(folder.uri.fsPath, ...subPath);
+	const relative = subPath.join("/");
+	const label = relative.length === 0 ? folder.name : `${folder.name}/${relative}`;
+	return { fsPath, workspaceFolder: folder, label };
+}

--- a/src/test/suite/projectTreeBuilder.test.ts
+++ b/src/test/suite/projectTreeBuilder.test.ts
@@ -1,0 +1,102 @@
+import * as assert from "assert";
+import * as path from "node:path";
+import { buildProjectTree, type ProjectTreeNode } from "../../ui/projectTreeBuilder";
+import { makeFolder, makeRoot } from "./projectFixtures";
+
+function expectProject(node: ProjectTreeNode, expectedLabel: string): void {
+	assert.strictEqual(node.kind, "project", `Expected project leaf with label "${expectedLabel}"`);
+	assert.strictEqual(node.label, expectedLabel);
+}
+
+function expectGroup(node: ProjectTreeNode, expectedLabel: string, childCount: number): void {
+	assert.strictEqual(node.kind, "group", `Expected group with label "${expectedLabel}"`);
+	if (node.kind === "group") {
+		assert.strictEqual(node.label, expectedLabel);
+		assert.strictEqual(node.children.length, childCount);
+	}
+}
+
+suite("Project Tree Builder Test Suite", () => {
+	test("Empty input yields empty tree", () => {
+		assert.deepStrictEqual(buildProjectTree([]), []);
+	});
+
+	test("Single project at workspace root renders as a leaf", () => {
+		const folder = makeFolder("myrepo", path.resolve(path.sep, "tmp", "myrepo"));
+		const root = makeRoot(folder);
+		const tree = buildProjectTree([root]);
+		assert.strictEqual(tree.length, 1);
+		expectProject(tree[0], "myrepo");
+		if (tree[0].kind === "project") {
+			assert.strictEqual(tree[0].root, root);
+		}
+	});
+
+	test("Single sub-project collapses into a flat label", () => {
+		const folder = makeFolder("myrepo", path.resolve(path.sep, "tmp", "myrepo"));
+		const root = makeRoot(folder, "docs", "projectA");
+		const tree = buildProjectTree([root]);
+		assert.strictEqual(tree.length, 1);
+		expectProject(tree[0], "myrepo/docs/projectA");
+	});
+
+	test("Sibling sub-projects sharing a parent are grouped", () => {
+		const folder = makeFolder("myrepo", path.resolve(path.sep, "tmp", "myrepo"));
+		const a = makeRoot(folder, "docs", "A");
+		const b = makeRoot(folder, "docs", "B");
+		const tree = buildProjectTree([a, b]);
+		assert.strictEqual(tree.length, 1);
+		expectGroup(tree[0], "myrepo/docs", 2);
+		if (tree[0].kind === "group") {
+			expectProject(tree[0].children[0], "A");
+			expectProject(tree[0].children[1], "B");
+		}
+	});
+
+	test("Sub-projects under different parents share a workspace group with collapsed children", () => {
+		const folder = makeFolder("myrepo", path.resolve(path.sep, "tmp", "myrepo"));
+		const a = makeRoot(folder, "docs", "A");
+		const b = makeRoot(folder, "other", "B");
+		const tree = buildProjectTree([a, b]);
+		assert.strictEqual(tree.length, 1);
+		expectGroup(tree[0], "myrepo", 2);
+		if (tree[0].kind === "group") {
+			const labels = tree[0].children.map((child) => child.label).sort();
+			assert.deepStrictEqual(labels, ["docs/A", "other/B"]);
+			for (const child of tree[0].children) {
+				assert.strictEqual(child.kind, "project");
+			}
+		}
+	});
+
+	test("Deeper shared parents collapse the workspace name into the group label", () => {
+		const folder = makeFolder("myrepo", path.resolve(path.sep, "tmp", "myrepo"));
+		const a = makeRoot(folder, "docs", "sub", "A");
+		const b = makeRoot(folder, "docs", "sub", "B");
+		const tree = buildProjectTree([a, b]);
+		assert.strictEqual(tree.length, 1);
+		expectGroup(tree[0], "myrepo/docs/sub", 2);
+		if (tree[0].kind === "group") {
+			expectProject(tree[0].children[0], "A");
+			expectProject(tree[0].children[1], "B");
+		}
+	});
+
+	test("Multiple workspaces with one project each remain flat", () => {
+		const repoA = makeFolder("repoA", path.resolve(path.sep, "tmp", "repoA"));
+		const repoB = makeFolder("repoB", path.resolve(path.sep, "tmp", "repoB"));
+		const tree = buildProjectTree([makeRoot(repoA), makeRoot(repoB)]);
+		assert.strictEqual(tree.length, 2);
+		expectProject(tree[0], "repoA");
+		expectProject(tree[1], "repoB");
+	});
+
+	test("Mixed workspaces: one with siblings, one with a single root", () => {
+		const repoA = makeFolder("repoA", path.resolve(path.sep, "tmp", "repoA"));
+		const repoB = makeFolder("repoB", path.resolve(path.sep, "tmp", "repoB"));
+		const tree = buildProjectTree([makeRoot(repoA, "docs", "A"), makeRoot(repoA, "docs", "B"), makeRoot(repoB)]);
+		assert.strictEqual(tree.length, 2);
+		expectGroup(tree[0], "repoA/docs", 2);
+		expectProject(tree[1], "repoB");
+	});
+});

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -3,21 +3,25 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
-import { MANIFEST_FILENAMES } from "@quarto-wizard/core";
+import { EXTENSIONS_DIR, MANIFEST_FILENAMES } from "@quarto-wizard/core";
 import {
 	discoverQuartoProjectRoots,
+	EXTENSION_MANIFEST_DIRECT_GLOB,
 	EXTENSION_MANIFEST_GLOB,
+	QUARTO_PROJECT_DIRECT_GLOB,
 	QUARTO_PROJECT_FILENAMES,
 	QUARTO_PROJECT_GLOB,
 } from "../../utils/quartoProjectDiscovery";
-
-type AutoProjectDetection = boolean | "subFolders" | "openEditors";
+import type { AutoProjectDetection } from "../../utils/extensionDetails";
+import { makeFolder } from "./projectFixtures";
 
 interface MockedConfig {
 	autoProjectDetection?: AutoProjectDetection;
 }
 
-const GLOB_MATCHERS: Record<string, ReadonlySet<string>> = {
+const MANIFEST_FILENAME_SET = new Set<string>(MANIFEST_FILENAMES);
+
+const RECURSIVE_GLOB_MATCHERS: Record<string, ReadonlySet<string>> = {
 	[QUARTO_PROJECT_GLOB]: new Set<string>(QUARTO_PROJECT_FILENAMES),
 	[EXTENSION_MANIFEST_GLOB]: new Set<string>(MANIFEST_FILENAMES),
 };
@@ -37,16 +41,22 @@ suite("Quarto Project Discovery Test Suite", () => {
 		tempDir = vscode.Uri.file(fs.mkdtempSync(path.join(os.tmpdir(), "quarto-wizard-discovery-"))).fsPath;
 
 		mockedTextDocuments = [];
-		mockedConfig = { autoProjectDetection: true };
+		mockedConfig = { autoProjectDetection: "subFolders" };
 
 		originalFindFiles = vscode.workspace.findFiles;
 		// Default: scan the temp tree on disk and dispatch by glob to mirror the real findFiles.
 		vscode.workspace.findFiles = ((include: vscode.GlobPattern) => {
 			if (typeof include === "object" && "baseUri" in include) {
 				const rel = include as vscode.RelativePattern;
-				const matcher = GLOB_MATCHERS[rel.pattern];
-				if (matcher) {
-					return Promise.resolve(scanForFiles(rel.baseUri.fsPath, matcher));
+				const recursive = RECURSIVE_GLOB_MATCHERS[rel.pattern];
+				if (recursive) {
+					return Promise.resolve(scanForFiles(rel.baseUri.fsPath, recursive));
+				}
+				if (rel.pattern === QUARTO_PROJECT_DIRECT_GLOB) {
+					return Promise.resolve(scanDirectChildren(rel.baseUri.fsPath, QUARTO_PROJECT_FILENAMES));
+				}
+				if (rel.pattern === EXTENSION_MANIFEST_DIRECT_GLOB) {
+					return Promise.resolve(scanDirectExtensions(rel.baseUri.fsPath));
 				}
 			}
 			return Promise.resolve([]);
@@ -91,10 +101,6 @@ suite("Quarto Project Discovery Test Suite", () => {
 		}
 	});
 
-	function makeFolder(name: string, fsPath: string, index = 0): vscode.WorkspaceFolder {
-		return { uri: vscode.Uri.file(fsPath), name, index };
-	}
-
 	function writeQuartoYml(dir: string): string {
 		fs.mkdirSync(dir, { recursive: true });
 		const file = path.join(dir, "_quarto.yml");
@@ -129,6 +135,49 @@ suite("Quarto Project Discovery Test Suite", () => {
 			}
 		};
 		walk(base);
+		return matches;
+	}
+
+	function forEachDirectChildDir(base: string, visit: (subdir: string) => void): void {
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(base, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (entry.isDirectory()) visit(path.join(base, entry.name));
+		}
+	}
+
+	function scanDirectChildren(base: string, filenames: readonly string[]): vscode.Uri[] {
+		const matches: vscode.Uri[] = [];
+		forEachDirectChildDir(base, (subdir) => {
+			for (const filename of filenames) {
+				const candidate = path.join(subdir, filename);
+				try {
+					if (fs.statSync(candidate).isFile()) {
+						matches.push(vscode.Uri.file(candidate));
+					}
+				} catch {
+					// candidate file doesn't exist; skip
+				}
+			}
+		});
+		return matches;
+	}
+
+	function scanDirectExtensions(base: string): vscode.Uri[] {
+		const matches: vscode.Uri[] = [];
+		forEachDirectChildDir(base, (subdir) => {
+			const extDir = path.join(subdir, EXTENSIONS_DIR);
+			try {
+				if (!fs.statSync(extDir).isDirectory()) return;
+			} catch {
+				return;
+			}
+			matches.push(...scanForFiles(extDir, MANIFEST_FILENAME_SET));
+		});
 		return matches;
 	}
 
@@ -222,7 +271,7 @@ suite("Quarto Project Discovery Test Suite", () => {
 		assert.strictEqual(roots[0].label, "workspace/nested/site");
 	});
 
-	test("setting=subFolders: ignores open editors and only scans subfolders", async () => {
+	test("setting=subFolders: ignores open editors and only scans direct subfolders", async () => {
 		const editorOnlyProject = path.join(tempDir, "editor-only");
 		writeQuartoYml(editorOnlyProject);
 		const docPath = path.join(editorOnlyProject, "doc.qmd");
@@ -233,9 +282,81 @@ suite("Quarto Project Discovery Test Suite", () => {
 
 		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
 
-		// editor-only is still found because subFolders scans the on-disk tree.
+		// editor-only is found because it is a direct subfolder; the open editor is ignored.
 		assert.strictEqual(roots.length, 1);
 		assert.strictEqual(roots[0].fsPath, editorOnlyProject);
+	});
+
+	test("setting=subFolders: skips deeply-nested projects (direct children only)", async () => {
+		const direct = path.join(tempDir, "site-a");
+		const deep = path.join(tempDir, "deep", "nested");
+		writeQuartoYml(direct);
+		writeQuartoYml(deep);
+
+		mockedConfig.autoProjectDetection = "subFolders";
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, direct);
+	});
+
+	test("setting=subFolders: detects workspace root marker via the explicit root check", async () => {
+		writeQuartoYml(tempDir);
+
+		mockedConfig.autoProjectDetection = "subFolders";
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+		assert.strictEqual(roots[0].label, "workspace");
+	});
+
+	test("setting=subFolders: discovers depth-1 _extensions/-only projects", async () => {
+		const extProject = path.join(tempDir, "ext-only");
+		writeExtensionManifest(extProject, "quarto-ext", "fontawesome");
+
+		mockedConfig.autoProjectDetection = "subFolders";
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, extProject);
+	});
+
+	test("setting=true: recursive scan finds deeply-nested projects", async () => {
+		const direct = path.join(tempDir, "site-a");
+		const deep = path.join(tempDir, "deep", "nested");
+		writeQuartoYml(direct);
+		writeQuartoYml(deep);
+
+		mockedConfig.autoProjectDetection = true;
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		const paths = roots.map((r) => r.fsPath).sort();
+		assert.deepStrictEqual(paths, [deep, direct].sort());
+	});
+
+	test("setting=true: does not auto-detect via open editors", async () => {
+		const projectDir = path.join(tempDir, "site");
+		writeQuartoYml(projectDir);
+		const docPath = path.join(projectDir, "doc.qmd");
+		fs.writeFileSync(docPath, "", "utf8");
+
+		// Force findFiles to return no subfolder matches so any detection must come from
+		// the open-editor walk-up. With the narrowed `true` semantics, that path is gated
+		// off and the discovery should fall back to the workspace folder.
+		vscode.workspace.findFiles = (() => Promise.resolve([])) as typeof vscode.workspace.findFiles;
+
+		mockedConfig.autoProjectDetection = true;
+		mockedTextDocuments = [makeDocument(docPath)];
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
 	});
 
 	test("detects workspace root via _extensions/ when _quarto.yml is absent", async () => {

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -339,6 +339,17 @@ suite("Quarto Project Discovery Test Suite", () => {
 		assert.deepStrictEqual(paths, [deep, direct].sort());
 	});
 
+	test("setting=<invalid>: falls back to direct subfolder scan", async () => {
+		writeQuartoYml(path.join(tempDir, "site-a"));
+
+		mockedConfig.autoProjectDetection = "recursive" as unknown as AutoProjectDetection;
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, path.join(tempDir, "site-a"));
+	});
+
 	test("setting=true: does not auto-detect via open editors", async () => {
 		const projectDir = path.join(tempDir, "site");
 		writeQuartoYml(projectDir);

--- a/src/ui/extensionTreeDataProvider.ts
+++ b/src/ui/extensionTreeDataProvider.ts
@@ -12,8 +12,11 @@ import type { QuartoProjectRoot } from "../utils/quartoProjectDiscovery";
 import { getAuthConfig } from "../utils/auth";
 import { getQuartoVersionInfo, type QuartoVersionInfo } from "../services/quartoVersion";
 import { validateQuartoRequirement } from "../utils/versionValidation";
+import { buildProjectTree, type ProjectTreeNode } from "./projectTreeBuilder";
 import {
 	WorkspaceFolderTreeItem,
+	ProjectGroupTreeItem,
+	type ProjectFolderItem,
 	ExtensionTreeItem,
 	SchemaTreeItem,
 	SchemaErrorTreeItem,
@@ -42,6 +45,9 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 	// Consolidated cache for extension data per workspace folder
 	private cache: Record<string, FolderCache> = {};
 
+	// Memoised hierarchical project tree, invalidated when projectRoots changes
+	private projectTreeCache: ProjectTreeNode[] | null = null;
+
 	// Guard against concurrent refresh operations
 	private pendingRefresh: Promise<void> | null = null;
 
@@ -66,7 +72,15 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 			return false;
 		}
 		this.projectRoots = projectRoots;
+		this.projectTreeCache = null;
 		return true;
+	}
+
+	private getProjectTree(): ProjectTreeNode[] {
+		if (!this.projectTreeCache) {
+			this.projectTreeCache = buildProjectTree(this.projectRoots);
+		}
+		return this.projectTreeCache;
 	}
 
 	dispose(): void {
@@ -92,6 +106,10 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 				]);
 			}
 			return Promise.resolve(this.getWorkspaceFolderItems());
+		}
+
+		if (element instanceof ProjectGroupTreeItem) {
+			return Promise.resolve(element.children);
 		}
 
 		if (element instanceof WorkspaceFolderTreeItem) {
@@ -125,16 +143,23 @@ export class QuartoExtensionTreeDataProvider implements vscode.TreeDataProvider<
 		return Promise.resolve([]);
 	}
 
-	private getWorkspaceFolderItems(): WorkspaceFolderTreeItem[] {
-		if (this.projectRoots.length > 1) {
-			return this.projectRoots.map((root) => new WorkspaceFolderTreeItem(root.label, root.fsPath));
+	private getWorkspaceFolderItems(): ProjectFolderItem[] {
+		if (this.projectRoots.length === 1) {
+			const only = this.projectRoots[0];
+			const folderCache = this.cache[only.fsPath];
+			if (!folderCache || Object.keys(folderCache.extensions).length === 0) {
+				return [];
+			}
 		}
-		return this.projectRoots
-			.filter((root) => {
-				const folderCache = this.cache[root.fsPath];
-				return folderCache && Object.keys(folderCache.extensions).length > 0;
-			})
-			.map((root) => new WorkspaceFolderTreeItem(root.label, root.fsPath));
+		return this.getProjectTree().map((node) => this.toTreeItem(node));
+	}
+
+	private toTreeItem(node: ProjectTreeNode): ProjectFolderItem {
+		if (node.kind === "project") {
+			return new WorkspaceFolderTreeItem(node.label, node.root.fsPath);
+		}
+		const children = node.children.map((child) => this.toTreeItem(child));
+		return new ProjectGroupTreeItem(node.label, node.fsPath, children);
 	}
 
 	private getExtensionItems(workspacePath: string): ExtensionTreeItem[] {

--- a/src/ui/extensionTreeItems.ts
+++ b/src/ui/extensionTreeItems.ts
@@ -38,6 +38,28 @@ export class WorkspaceFolderTreeItem extends vscode.TreeItem {
 }
 
 /**
+ * Intermediate folder node grouping sibling Quarto project roots that share a parent path.
+ * Carries no extensions itself: its children are other groups or `WorkspaceFolderTreeItem`s.
+ */
+export class ProjectGroupTreeItem extends vscode.TreeItem {
+	constructor(
+		public readonly label: string,
+		public readonly fsPath: string,
+		public readonly children: ProjectFolderItem[] = [],
+	) {
+		super(label, vscode.TreeItemCollapsibleState.Expanded);
+		this.contextValue = "quartoProjectGroup";
+		this.iconPath = new vscode.ThemeIcon("folder");
+		this.tooltip = fsPath;
+	}
+}
+
+/**
+ * Top-level item in the extensions tree: either a project root or a folder grouping projects.
+ */
+export type ProjectFolderItem = WorkspaceFolderTreeItem | ProjectGroupTreeItem;
+
+/**
  * Represents a tree item for a Quarto extension.
  */
 export class ExtensionTreeItem extends vscode.TreeItem {
@@ -383,6 +405,7 @@ function pluralLabel(kind: SchemaSectionKind): string {
  */
 export type TreeItemType =
 	| WorkspaceFolderTreeItem
+	| ProjectGroupTreeItem
 	| ExtensionTreeItem
 	| SchemaTreeItem
 	| SchemaErrorTreeItem

--- a/src/ui/projectTreeBuilder.ts
+++ b/src/ui/projectTreeBuilder.ts
@@ -1,0 +1,118 @@
+import * as path from "node:path";
+import type { QuartoProjectRoot } from "../utils/quartoProjectDiscovery";
+
+/**
+ * A leaf node representing a single Quarto project root.
+ */
+export interface ProjectLeafNode {
+	kind: "project";
+	label: string;
+	root: QuartoProjectRoot;
+}
+
+/**
+ * An intermediate folder node grouping sibling project roots that share a parent path.
+ */
+export interface ProjectGroupNode {
+	kind: "group";
+	label: string;
+	fsPath: string;
+	children: ProjectTreeNode[];
+}
+
+export type ProjectTreeNode = ProjectLeafNode | ProjectGroupNode;
+
+interface MutableNode {
+	label: string;
+	fsPath: string;
+	project?: QuartoProjectRoot;
+	childrenByLabel: Map<string, MutableNode>;
+}
+
+/**
+ * Builds a hierarchical tree from a flat list of Quarto project roots.
+ *
+ * Each workspace folder owns its own subtree (rooted at the workspace folder name).
+ * Single-child chains are collapsed by joining labels with `/`, so a project that
+ * does not share its parent with any sibling renders as a single flat label.
+ */
+export function buildProjectTree(roots: readonly QuartoProjectRoot[]): ProjectTreeNode[] {
+	if (roots.length === 0) {
+		return [];
+	}
+
+	const workspaceOrder: string[] = [];
+	const byWorkspace = new Map<string, QuartoProjectRoot[]>();
+	for (const root of roots) {
+		const key = root.workspaceFolder.uri.fsPath;
+		let bucket = byWorkspace.get(key);
+		if (!bucket) {
+			bucket = [];
+			byWorkspace.set(key, bucket);
+			workspaceOrder.push(key);
+		}
+		bucket.push(root);
+	}
+
+	const topLevel: ProjectTreeNode[] = [];
+	for (const folderPath of workspaceOrder) {
+		const folderRoots = byWorkspace.get(folderPath) ?? [];
+		const folder = folderRoots[0].workspaceFolder;
+		const trieRoot: MutableNode = {
+			label: folder.name,
+			fsPath: folderPath,
+			childrenByLabel: new Map(),
+		};
+
+		for (const project of folderRoots) {
+			const relative = path.relative(folderPath, project.fsPath);
+			if (relative === "" || relative === ".") {
+				trieRoot.project = project;
+				continue;
+			}
+			const segments = relative.split(path.sep).filter((segment) => segment.length > 0);
+			let current = trieRoot;
+			let currentPath = folderPath;
+			for (const segment of segments) {
+				currentPath = path.join(currentPath, segment);
+				let child = current.childrenByLabel.get(segment);
+				if (!child) {
+					child = {
+						label: segment,
+						fsPath: currentPath,
+						childrenByLabel: new Map(),
+					};
+					current.childrenByLabel.set(segment, child);
+				}
+				current = child;
+			}
+			current.project = project;
+		}
+
+		topLevel.push(collapseAndConvert(trieRoot));
+	}
+
+	return topLevel;
+}
+
+function collapseAndConvert(node: MutableNode): ProjectTreeNode {
+	const childNodes: ProjectTreeNode[] = [];
+	for (const child of node.childrenByLabel.values()) {
+		childNodes.push(collapseAndConvert(child));
+	}
+
+	if (!node.project && childNodes.length === 1) {
+		const only = childNodes[0];
+		const mergedLabel = `${node.label}/${only.label}`;
+		if (only.kind === "project") {
+			return { kind: "project", label: mergedLabel, root: only.root };
+		}
+		return { kind: "group", label: mergedLabel, fsPath: only.fsPath, children: only.children };
+	}
+
+	if (node.project && childNodes.length === 0) {
+		return { kind: "project", label: node.label, root: node.project };
+	}
+
+	return { kind: "group", label: node.label, fsPath: node.fsPath, children: childNodes };
+}

--- a/src/utils/extensionDetails.ts
+++ b/src/utils/extensionDetails.ts
@@ -51,11 +51,11 @@ export type AutoProjectDetection = boolean | "subFolders" | "openEditors";
 
 /**
  * Reads the `quartoWizard.autoProjectDetection` setting.
- * Defaults to `true` when unset, matching the default of VSCode's `git.autoRepositoryDetection`.
+ * Defaults to `"subFolders"` (direct children only) when unset.
  */
 export function getAutoProjectDetection(): AutoProjectDetection {
 	const config = vscode.workspace.getConfiguration("quartoWizard");
-	return config.get<AutoProjectDetection>("autoProjectDetection", true);
+	return config.get<AutoProjectDetection>("autoProjectDetection", "subFolders");
 }
 
 /**

--- a/src/utils/extensionDetails.ts
+++ b/src/utils/extensionDetails.ts
@@ -49,13 +49,29 @@ export function getCrossSourceUpdateEnabled(): boolean {
  */
 export type AutoProjectDetection = boolean | "subFolders" | "openEditors";
 
+const AUTO_PROJECT_DETECTION_DEFAULT: AutoProjectDetection = "subFolders";
+
+function isAutoProjectDetection(value: unknown): value is AutoProjectDetection {
+	return value === true || value === false || value === "subFolders" || value === "openEditors";
+}
+
 /**
  * Reads the `quartoWizard.autoProjectDetection` setting.
- * Defaults to `"subFolders"` (direct children only) when unset.
+ * Defaults to `"subFolders"` (direct children only) when unset, and falls back to
+ * the same default with a warning when the user-supplied value is not one of the
+ * documented options.
  */
 export function getAutoProjectDetection(): AutoProjectDetection {
 	const config = vscode.workspace.getConfiguration("quartoWizard");
-	return config.get<AutoProjectDetection>("autoProjectDetection", "subFolders");
+	const raw: unknown = config.get("autoProjectDetection", AUTO_PROJECT_DETECTION_DEFAULT);
+	if (isAutoProjectDetection(raw)) {
+		return raw;
+	}
+	logMessage(
+		`Unknown quartoWizard.autoProjectDetection value: ${JSON.stringify(raw)}. Falling back to "${AUTO_PROJECT_DETECTION_DEFAULT}".`,
+		"warn",
+	);
+	return AUTO_PROJECT_DETECTION_DEFAULT;
 }
 
 /**

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { EXTENSIONS_DIR, MANIFEST_FILENAMES, getErrorMessage } from "@quarto-wizard/core";
-import { getAutoProjectDetection, type AutoProjectDetection } from "./extensionDetails";
+import { getAutoProjectDetection } from "./extensionDetails";
 import { logMessage } from "./log";
 
 /**
@@ -15,6 +15,18 @@ export const QUARTO_PROJECT_GLOB = "**/_quarto.{yml,yaml}";
  * outermost `_extensions/` ancestor) to a Quarto root.
  */
 export const EXTENSION_MANIFEST_GLOB = `**/${EXTENSIONS_DIR}/**/_extension.{yml,yaml}`;
+
+/**
+ * Glob pattern matching Quarto project marker files in a direct subfolder (one level deep).
+ * The workspace folder root itself must be checked separately.
+ */
+export const QUARTO_PROJECT_DIRECT_GLOB = "*/_quarto.{yml,yaml}";
+
+/**
+ * Glob pattern matching installed extension manifests for projects that live as direct
+ * subfolders of the workspace folder.
+ */
+export const EXTENSION_MANIFEST_DIRECT_GLOB = `*/${EXTENSIONS_DIR}/**/_extension.{yml,yaml}`;
 
 /**
  * Filenames that mark a directory as a Quarto project root via `_quarto.{yml,yaml}`.
@@ -72,13 +84,11 @@ export async function discoverQuartoProjectRoots(
 
 		const candidates = new Set<string>();
 
-		if (shouldScanSubFolders(setting)) {
-			for (const dir of await findSubFolderProjectDirs(folder)) {
+		if (setting === true || setting === "subFolders") {
+			for (const dir of await findSubFolderProjectDirs(folder, setting === true)) {
 				candidates.add(dir);
 			}
-		}
-
-		if (shouldScanOpenEditors(setting)) {
+		} else if (setting === "openEditors") {
 			for (const dir of await findOpenEditorProjectDirs(folder)) {
 				candidates.add(dir);
 			}
@@ -100,14 +110,6 @@ export async function discoverQuartoProjectRoots(
 	return results;
 }
 
-function shouldScanSubFolders(setting: AutoProjectDetection): boolean {
-	return setting === true || setting === "subFolders";
-}
-
-function shouldScanOpenEditors(setting: AutoProjectDetection): boolean {
-	return setting === true || setting === "openEditors";
-}
-
 function buildRoot(folder: vscode.WorkspaceFolder, fsPath: string): QuartoProjectRoot {
 	if (fsPath === folder.uri.fsPath) {
 		return { fsPath, workspaceFolder: folder, label: folder.name };
@@ -116,16 +118,23 @@ function buildRoot(folder: vscode.WorkspaceFolder, fsPath: string): QuartoProjec
 	return { fsPath, workspaceFolder: folder, label: `${folder.name}/${relative}` };
 }
 
-async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder): Promise<string[]> {
+async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder, recursive: boolean): Promise<string[]> {
+	const folderPath = folder.uri.fsPath;
+	const quartoGlob = recursive ? QUARTO_PROJECT_GLOB : QUARTO_PROJECT_DIRECT_GLOB;
+	const manifestGlob = recursive ? EXTENSION_MANIFEST_GLOB : EXTENSION_MANIFEST_DIRECT_GLOB;
 	try {
+		// In direct-only mode the workspace root cannot be matched by the depth-1 glob,
+		// so probe it explicitly: the smart-merge in `discoverQuartoProjectRoots` collapses
+		// to the workspace folder when it is among the candidates.
 		// `null` exclude lets VSCode honour the user's `files.exclude` and `search.exclude`,
 		// matching how the Git extension scopes its repository scans.
-		const [quartoUris, manifestUris] = await Promise.all([
-			vscode.workspace.findFiles(new vscode.RelativePattern(folder, QUARTO_PROJECT_GLOB), null),
-			vscode.workspace.findFiles(new vscode.RelativePattern(folder, EXTENSION_MANIFEST_GLOB), null),
+		const [hasRootMarker, quartoUris, manifestUris] = await Promise.all([
+			recursive ? Promise.resolve(false) : directoryHasProjectMarker(folderPath),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, quartoGlob), null),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, manifestGlob), null),
 		]);
-		const folderPath = folder.uri.fsPath;
 		const dirs: string[] = [];
+		if (hasRootMarker) dirs.push(folderPath);
 		for (const uri of quartoUris) {
 			if (uri.scheme !== "file") continue;
 			const dir = path.dirname(uri.fsPath);


### PR DESCRIPTION
Two related improvements to the auto-detected project tree introduced in 2.5.0.

The Extensions Installed view now renders sub-projects hierarchically: sibling sub-projects under a shared parent (for example `docs/A` and `docs/B`) collapse under that parent, while single-child chains merge into one label so projects without shared parents stay flat.

The default scope of `quartoWizard.autoProjectDetection` is narrowed: the new default `"subFolders"` scans only direct children of the workspace folder. Set the value to `true` for the previous recursive behaviour. `true` no longer also walks up from open files; use `"openEditors"` for that.

Unknown values for the setting now log a warning and fall back to `"subFolders"` instead of silently leaving the workspace-folder fallback.