### PR TITLE
fix: skip inline code spans and YAML front matter in attribute diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - fix: do not flag `{key="value"}` inside inline code spans as needing whitespace removal. Backtick-wrapped attribute syntax in prose (for example, when documenting Pandoc attribute rules) is now correctly recognised as code and skipped by the inline attribute diagnostics.
+- fix: do not extract `{...}` patterns from YAML front matter as Pandoc attribute blocks. Curly braces inside literal block scalars (for example, Typst code under `include-before-body`) no longer trigger false-positive inline attribute diagnostics.
 
 ## 3.0.0 (2026-04-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: do not flag `{key="value"}` inside inline code spans as needing whitespace removal. Backtick-wrapped attribute syntax in prose (for example, when documenting Pandoc attribute rules) is now correctly recognised as code and skipped by the inline attribute diagnostics.
+
 ## 3.0.0 (2026-04-29)
 
 ### New Features

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -11,7 +11,7 @@ import {
 } from "./elementAttributeCompletionProvider";
 import { collectShortcodeSchemas, resolveShortcodeAttribute } from "./shortcodeCompletionProvider";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { getCodeBlockRanges, isInCodeBlockRange, type TextRange } from "../utils/yamlPosition";
+import { getCodeBlockRanges, getInlineCodeSpanRanges, isInCodeBlockRange, type TextRange } from "../utils/yamlPosition";
 import { logMessage } from "../utils/log";
 import { debounce } from "../utils/debounce";
 
@@ -249,30 +249,47 @@ interface BlockMatch {
 }
 
 /**
- * Check whether a match range overlaps any code block range.
- * Tests both endpoints and spanning (match starts before and ends inside a block).
+ * Check whether a match range overlaps any exclusion range.
+ *
+ * Fenced code blocks use full overlap (start, end, or spanning) because an
+ * attribute block can legitimately straddle a fence boundary only when it is
+ * not really an attribute.
+ *
+ * Inline code spans use a stricter rule: only exclude when the match start
+ * lies inside an inline span.  This avoids false exclusion of fence-header
+ * attribute blocks like `` ```{.r code-summary="see `fn()`"} `` whose body
+ * contains quoted backticks that look like an inline code span.
  */
-function overlapsCodeBlock(ranges: TextRange[], matchStart: number, matchEnd: number): boolean {
-	return (
-		isInCodeBlockRange(ranges, matchStart) ||
-		isInCodeBlockRange(ranges, matchEnd) ||
-		ranges.some((r) => matchStart < r.start && matchEnd >= r.start)
-	);
+function overlapsExclusionRanges(
+	fencedRanges: TextRange[],
+	inlineRanges: TextRange[],
+	matchStart: number,
+	matchEnd: number,
+): boolean {
+	if (
+		isInCodeBlockRange(fencedRanges, matchStart) ||
+		isInCodeBlockRange(fencedRanges, matchEnd) ||
+		fencedRanges.some((r) => matchStart < r.start && matchEnd >= r.start)
+	) {
+		return true;
+	}
+	return isInCodeBlockRange(inlineRanges, matchStart);
 }
 
 /**
  * Extract all attribute blocks and shortcode blocks from document text,
- * excluding matches that fall inside fenced code blocks.
+ * excluding matches that fall inside fenced code blocks or inline code spans.
  */
 export function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[] {
-	const ranges = codeBlockRanges ?? getCodeBlockRanges(text);
+	const fencedRanges = codeBlockRanges ?? getCodeBlockRanges(text);
+	const inlineRanges = getInlineCodeSpanRanges(text, fencedRanges);
 	const blocks: BlockMatch[] = [];
 
 	for (const match of text.matchAll(ELEMENT_ATTRIBUTE_RE)) {
 		if (match.index === undefined) {
 			continue;
 		}
-		if (overlapsCodeBlock(ranges, match.index, match.index + match[0].length - 1)) {
+		if (overlapsExclusionRanges(fencedRanges, inlineRanges, match.index, match.index + match[0].length - 1)) {
 			continue;
 		}
 		// Content is everything between { and }.
@@ -285,7 +302,7 @@ export function extractBlocks(text: string, codeBlockRanges?: TextRange[]): Bloc
 		if (match.index === undefined) {
 			continue;
 		}
-		if (overlapsCodeBlock(ranges, match.index, match.index + match[0].length - 1)) {
+		if (overlapsExclusionRanges(fencedRanges, inlineRanges, match.index, match.index + match[0].length - 1)) {
 			continue;
 		}
 		// Content is everything between {{< and >}}.

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -11,7 +11,13 @@ import {
 } from "./elementAttributeCompletionProvider";
 import { collectShortcodeSchemas, resolveShortcodeAttribute } from "./shortcodeCompletionProvider";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { getCodeBlockRanges, getInlineCodeSpanRanges, isInCodeBlockRange, type TextRange } from "../utils/yamlPosition";
+import {
+	getCodeBlockRanges,
+	getInlineCodeSpanRanges,
+	getYamlFrontMatterRange,
+	isInCodeBlockRange,
+	type TextRange,
+} from "../utils/yamlPosition";
 import { logMessage } from "../utils/log";
 import { debounce } from "../utils/debounce";
 
@@ -278,10 +284,13 @@ function overlapsExclusionRanges(
 
 /**
  * Extract all attribute blocks and shortcode blocks from document text,
- * excluding matches that fall inside fenced code blocks or inline code spans.
+ * excluding matches that fall inside fenced code blocks, the YAML front
+ * matter, or inline code spans.
  */
 export function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[] {
-	const fencedRanges = codeBlockRanges ?? getCodeBlockRanges(text);
+	const codeRanges = codeBlockRanges ?? getCodeBlockRanges(text);
+	const yamlRange = getYamlFrontMatterRange(text);
+	const fencedRanges = yamlRange ? [yamlRange, ...codeRanges] : codeRanges;
 	const inlineRanges = getInlineCodeSpanRanges(text, fencedRanges);
 	const blocks: BlockMatch[] = [];
 

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -653,6 +653,50 @@ suite("Inline Attribute Diagnostics", () => {
 		});
 	});
 
+	suite("extractBlocks (inline code spans)", () => {
+		test("should not extract attribute block from inside a single-backtick span", () => {
+			const text = 'Pandoc syntax: `{key="value"}` produces an attribute.';
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+
+		test("should not extract attribute block with spaces around = inside backticks", () => {
+			const text = 'But `{key = "value"}` does not.';
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+
+		test("should not produce spaces-around-equals diagnostic for backtick-wrapped {key = value}", () => {
+			const text = 'see `{key = "value"}` here';
+			const blocks = extractBlocks(text);
+			for (const block of blocks) {
+				assert.strictEqual(findSpacesAroundEquals(block.content).length, 0);
+			}
+		});
+
+		test("should still extract a real {=html} attribute on inline code", () => {
+			// Pandoc raw inline: `code`{=html} — the {=html} attribute is OUTSIDE
+			// the inline code span and is a legitimate attribute block.
+			const text = "x `code`{=html} y";
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, "=html");
+		});
+
+		test("should still extract a normal attribute outside any backticks", () => {
+			const text = '[span]{.cls key="value"} and `inline {a=b}`';
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, '.cls key="value"');
+		});
+
+		test("should not extract attribute from inside a double-backtick span", () => {
+			const text = "before ``contains {key = val} here`` after";
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+	});
+
 	suite("extractBareWords", () => {
 		test("should extract bare word from element content", () => {
 			const results = extractBareWords(".class myword");

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -697,6 +697,71 @@ suite("Inline Attribute Diagnostics", () => {
 		});
 	});
 
+	suite("extractBlocks (YAML front matter)", () => {
+		test("should not extract a {...} block from a YAML literal block scalar", () => {
+			const text = [
+				"---",
+				"format: typst",
+				"include-before-body:",
+				"  - text: |",
+				"      #show raw.where(block: false): it => {",
+				"        let text = it.text();",
+				"        it",
+				"      }",
+				"---",
+				"",
+				"body",
+			].join("\n");
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+
+		test("should not produce spaces-around-equals findings inside YAML front matter", () => {
+			const text = [
+				"---",
+				"format: typst",
+				"include-before-body:",
+				"  - text: |",
+				"      it => {",
+				"        let text = it.text();",
+				"      }",
+				"---",
+			].join("\n");
+			const blocks = extractBlocks(text);
+			for (const block of blocks) {
+				assert.strictEqual(findSpacesAroundEquals(block.content).length, 0);
+			}
+		});
+
+		test("should not extract {a=b} inside a quoted YAML scalar value", () => {
+			const text = ["---", 'title: "literal {a = b} text"', "---", ""].join("\n");
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+
+		test("should still extract attribute blocks after the closing front matter", () => {
+			const text = ["---", "title: Test", "---", "", '[span]{.cls key="value"}'].join("\n");
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, '.cls key="value"');
+		});
+
+		test("should be unaffected when the document has no front matter", () => {
+			const text = '[span]{.cls key="value"}';
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, '.cls key="value"');
+		});
+
+		test("should handle CRLF front matter correctly", () => {
+			const text = ["---", "format: typst", "include-before-body:", "  - text: |", "      it => { x }", "---", ""].join(
+				"\r\n",
+			);
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+	});
+
 	suite("extractBareWords", () => {
 		test("should extract bare word from element content", () => {
 			const results = extractBareWords(".class myword");

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -6,6 +6,7 @@ import {
 	getExistingKeysAtPath,
 	getCodeBlockRanges,
 	getInlineCodeSpanRanges,
+	getYamlFrontMatterRange,
 	isInCodeBlockRange,
 	hasUnquotedBacktick,
 } from "../../utils/yamlPosition";
@@ -601,6 +602,64 @@ suite("YAML Position Utils Test Suite", () => {
 			const text = "`a` and `b` and `c`";
 			const ranges = getInlineCodeSpanRanges(text, []);
 			assert.strictEqual(ranges.length, 3);
+		});
+	});
+
+	suite("getYamlFrontMatterRange", () => {
+		test("should cover the opening, body, and closing delimiter lines", () => {
+			const text = "---\ntitle: Test\n---\nbody\n";
+			const range = getYamlFrontMatterRange(text);
+			assert.ok(range);
+			assert.strictEqual(range!.start, 0);
+			assert.strictEqual(text.slice(range!.start, range!.end), "---\ntitle: Test\n---");
+		});
+
+		test("should return undefined when line 0 is not a fence", () => {
+			const text = "no front matter here\n---\nfoo\n---\n";
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
+		});
+
+		test("should return undefined when there is no closing fence", () => {
+			const text = "---\ntitle: Test\nbody\n";
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
+		});
+
+		test("should handle empty front matter", () => {
+			const text = "---\n---\nbody\n";
+			const range = getYamlFrontMatterRange(text);
+			assert.ok(range);
+			assert.strictEqual(text.slice(range!.start, range!.end), "---\n---");
+		});
+
+		test("should return undefined for empty text", () => {
+			assert.strictEqual(getYamlFrontMatterRange(""), undefined);
+		});
+
+		test("should handle CRLF line endings", () => {
+			const text = "---\r\ntitle: Test\r\n---\r\nbody\r\n";
+			const range = getYamlFrontMatterRange(text);
+			assert.ok(range);
+			assert.strictEqual(range!.start, 0);
+			assert.strictEqual(text.slice(range!.start, range!.end), "---\r\ntitle: Test\r\n---\r");
+		});
+
+		test("should cover multi-line block scalars within the front matter", () => {
+			const text = [
+				"---",
+				"format: typst",
+				"include-before-body:",
+				"  - text: |",
+				"      #show raw.where(block: false): it => {",
+				"        let text = it.text();",
+				"        it",
+				"      }",
+				"---",
+				"body",
+			].join("\n");
+			const range = getYamlFrontMatterRange(text);
+			assert.ok(range);
+			const closingFenceOffset = text.lastIndexOf("---");
+			assert.ok(closingFenceOffset >= range!.start && closingFenceOffset < range!.end);
 		});
 	});
 

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -5,6 +5,7 @@ import {
 	getYamlIndentLevel,
 	getExistingKeysAtPath,
 	getCodeBlockRanges,
+	getInlineCodeSpanRanges,
 	isInCodeBlockRange,
 	hasUnquotedBacktick,
 } from "../../utils/yamlPosition";
@@ -536,6 +537,70 @@ suite("YAML Position Utils Test Suite", () => {
 			const ranges = getCodeBlockRanges(text);
 			const innerBrace = text.indexOf("function(x) {") + "function(x) ".length;
 			assert.strictEqual(isInCodeBlockRange(ranges, innerBrace), true);
+		});
+	});
+
+	suite("getInlineCodeSpanRanges", () => {
+		test("should detect a single-backtick inline code span", () => {
+			const text = "before `code` after";
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "`code`");
+		});
+
+		test("should cover a curly-brace attribute block inside backticks", () => {
+			const text = 'see `{key = "value"}` here';
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 1);
+			const braceStart = text.indexOf("{");
+			assert.ok(braceStart >= ranges[0].start && braceStart < ranges[0].end);
+		});
+
+		test("should require matching backtick run length", () => {
+			// Single backtick start cannot close on a double-backtick run.
+			const text = "a `one`` not closed";
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 0);
+		});
+
+		test("should allow single backticks inside a double-backtick span", () => {
+			const text = "a ``has ` inside`` end";
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "``has ` inside``");
+		});
+
+		test("should leave a {...} after the closing backticks outside the range", () => {
+			// Pandoc inline code with attribute: `code`{=html}
+			const text = "x `code`{=html} y";
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 1);
+			const attrStart = text.indexOf("{=html}");
+			assert.ok(attrStart >= ranges[0].end);
+		});
+
+		test("should return empty array for unclosed backtick run", () => {
+			const text = "no closer `here";
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 0);
+		});
+
+		test("should skip backticks inside fenced code block ranges", () => {
+			const text = "```\n`x`\n```\n`y`";
+			const fenced = getCodeBlockRanges(text);
+			const ranges = getInlineCodeSpanRanges(text, fenced);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "`y`");
+		});
+
+		test("should return empty array for text with no backticks", () => {
+			assert.deepStrictEqual(getInlineCodeSpanRanges("plain text", []), []);
+		});
+
+		test("should detect multiple inline code spans", () => {
+			const text = "`a` and `b` and `c`";
+			const ranges = getInlineCodeSpanRanges(text, []);
+			assert.strictEqual(ranges.length, 3);
 		});
 	});
 

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -211,34 +211,37 @@ export function isInCodeBlockRange(ranges: TextRange[], offset: number): boolean
  *
  * The front matter must open with `---` on line 0 and close with another
  * `---` on a subsequent line (mirroring `isInYamlRegion`).  The returned
- * range covers the opening delimiter line through the end of the closing
- * delimiter line so that any `{...}` content within is fully enclosed.
+ * range starts at offset 0 and ends at the last character of the closing
+ * delimiter line (the trailing newline is excluded), so that any `{...}`
+ * content within is fully enclosed.
  *
  * @param text - The full document text.
  * @returns The front-matter range, or `undefined` when no closed front
  *   matter is present.
  */
 export function getYamlFrontMatterRange(text: string): TextRange | undefined {
-	if (text.length === 0) {
+	const firstNewline = text.indexOf("\n");
+	if (firstNewline === -1) {
 		return undefined;
 	}
 
-	const lines = text.split("\n");
-	const firstLine = lines[0].endsWith("\r") ? lines[0].slice(0, -1) : lines[0];
-	if (firstLine.trim() !== "---") {
+	const firstLineEnd = firstNewline > 0 && text[firstNewline - 1] === "\r" ? firstNewline - 1 : firstNewline;
+	if (text.slice(0, firstLineEnd).trim() !== "---") {
 		return undefined;
 	}
 
-	let offset = lines[0].length + 1;
-	for (let i = 1; i < lines.length; i++) {
-		const rawLine = lines[i];
-		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
-		const lineStart = offset;
-		const lineEnd = lineStart + rawLine.length;
-		if (line.trim() === "---") {
+	let lineStart = firstNewline + 1;
+	while (lineStart <= text.length) {
+		const nextNewline = text.indexOf("\n", lineStart);
+		const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+		const trimmedEnd = lineEnd > lineStart && text[lineEnd - 1] === "\r" ? lineEnd - 1 : lineEnd;
+		if (text.slice(lineStart, trimmedEnd).trim() === "---") {
 			return { start: 0, end: lineEnd };
 		}
-		offset = lineEnd + (i < lines.length - 1 ? 1 : 0);
+		if (nextNewline === -1) {
+			break;
+		}
+		lineStart = nextNewline + 1;
 	}
 
 	return undefined;

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -207,6 +207,44 @@ export function isInCodeBlockRange(ranges: TextRange[], offset: number): boolean
 }
 
 /**
+ * Find the YAML front-matter range in a Quarto document.
+ *
+ * The front matter must open with `---` on line 0 and close with another
+ * `---` on a subsequent line (mirroring `isInYamlRegion`).  The returned
+ * range covers the opening delimiter line through the end of the closing
+ * delimiter line so that any `{...}` content within is fully enclosed.
+ *
+ * @param text - The full document text.
+ * @returns The front-matter range, or `undefined` when no closed front
+ *   matter is present.
+ */
+export function getYamlFrontMatterRange(text: string): TextRange | undefined {
+	if (text.length === 0) {
+		return undefined;
+	}
+
+	const lines = text.split("\n");
+	const firstLine = lines[0].endsWith("\r") ? lines[0].slice(0, -1) : lines[0];
+	if (firstLine.trim() !== "---") {
+		return undefined;
+	}
+
+	let offset = lines[0].length + 1;
+	for (let i = 1; i < lines.length; i++) {
+		const rawLine = lines[i];
+		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+		const lineStart = offset;
+		const lineEnd = lineStart + rawLine.length;
+		if (line.trim() === "---") {
+			return { start: 0, end: lineEnd };
+		}
+		offset = lineEnd + (i < lines.length - 1 ? 1 : 0);
+	}
+
+	return undefined;
+}
+
+/**
  * Compute the indentation level (number of leading spaces) of a line.
  *
  * @param line - The text of the line.

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -109,6 +109,93 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 }
 
 /**
+ * Find all inline code span regions in the document text.
+ *
+ * Inline code spans are delimited by matching backtick runs of equal length
+ * (CommonMark §6.1).  A backtick run is a maximal sequence of backtick
+ * characters; the opening run defines the closing run length.  Backslashes
+ * do not escape backticks for code-span purposes.
+ *
+ * The returned ranges include the opening and closing backtick runs so a
+ * `{...}` attribute that immediately follows the closing backticks (e.g.
+ * `` `code`{=html} ``) remains outside the range and is still extracted as
+ * a real attribute.
+ *
+ * Positions inside fenced code blocks are skipped because backticks there
+ * have no inline-span semantics.
+ *
+ * @param text - The full document text.
+ * @param fencedRanges - Pre-computed fenced code block ranges to skip.
+ * @returns An array of ranges sorted by start offset.
+ */
+export function getInlineCodeSpanRanges(text: string, fencedRanges: TextRange[]): TextRange[] {
+	const ranges: TextRange[] = [];
+	const len = text.length;
+	let i = 0;
+
+	while (i < len) {
+		const fenced = findContainingRange(fencedRanges, i);
+		if (fenced) {
+			i = fenced.end;
+			continue;
+		}
+
+		if (text[i] !== "`") {
+			i++;
+			continue;
+		}
+
+		const openStart = i;
+		while (i < len && text[i] === "`") {
+			i++;
+		}
+		const runLen = i - openStart;
+
+		// Search forward for a closing run of the same length.  When no
+		// matching run is found, `i` already points past the opening run
+		// and the outer loop resumes scanning from there.
+		let j = i;
+		while (j < len) {
+			const innerFenced = findContainingRange(fencedRanges, j);
+			if (innerFenced) {
+				j = innerFenced.end;
+				continue;
+			}
+			if (text[j] !== "`") {
+				j++;
+				continue;
+			}
+			const closeStart = j;
+			while (j < len && text[j] === "`") {
+				j++;
+			}
+			if (j - closeStart === runLen) {
+				ranges.push({ start: openStart, end: j });
+				i = j;
+				break;
+			}
+		}
+	}
+
+	return ranges;
+}
+
+/**
+ * Find the first range that contains the given offset, or undefined.
+ */
+function findContainingRange(ranges: TextRange[], offset: number): TextRange | undefined {
+	for (const range of ranges) {
+		if (offset >= range.start && offset < range.end) {
+			return range;
+		}
+		if (range.start > offset) {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+/**
  * Check whether an offset falls inside any of the given code block ranges.
  *
  * @param ranges - Sorted array of code block ranges.
@@ -116,15 +203,7 @@ export function getCodeBlockRanges(text: string): TextRange[] {
  * @returns True if the offset is inside a code block.
  */
 export function isInCodeBlockRange(ranges: TextRange[], offset: number): boolean {
-	for (const range of ranges) {
-		if (offset >= range.start && offset < range.end) {
-			return true;
-		}
-		if (range.start > offset) {
-			break;
-		}
-	}
-	return false;
+	return findContainingRange(ranges, offset) !== undefined;
 }
 
 /**


### PR DESCRIPTION
The inline attribute diagnostics provider extracted any `{...}` match in the document and ran syntax-level checks on it. Two cases produced false-positive diagnostics:

Documenting Pandoc attribute syntax in prose with backticks, for example `` `{key = "value"}` ``, was treated as a real attribute and the spaces around `=` were flagged.

YAML literal block scalars containing curly braces, for example Typst code under `include-before-body`, spanned the closing brace across newlines and the `let text = it.text()` body fired the spaces-around-`=` diagnostic.

Detect CommonMark inline backtick code spans and the YAML front matter region with two new TextRange helpers in `src/utils/yamlPosition.ts`, and exclude attribute matches whose endpoints fall inside either region. Fence-header attributes that contain quoted backticks in their info string remain unaffected.