### PR TITLE
fix: discover extension schemas across nested Quarto projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: discover extension schemas across nested Quarto projects. YAML completion, hover, diagnostics, shortcode completion, element attribute completion, and snippet completion now resolve schemas through each document's nearest enclosing project root instead of only the workspace folder, so extensions installed in sub-projects (for example `repo/subProj/_extensions/...`) populate IntelliSense for documents inside that sub-project.
+
 ## 3.0.1 (2026-05-12)
 
 ### Bug Fixes

--- a/src/providers/elementAttributeCompletionProvider.ts
+++ b/src/providers/elementAttributeCompletionProvider.ts
@@ -3,6 +3,7 @@ import type { FieldDescriptor, SchemaCache, ExtensionSchema } from "@quarto-wiza
 import { typeIncludes } from "@quarto-wizard/schema";
 import { getErrorMessage } from "@quarto-wizard/core";
 import { getInstalledExtensionsCached } from "../utils/installedExtensionsCache";
+import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 import { parseAttributeAtPosition, type PandocElementType } from "../utils/elementAttributeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
@@ -56,40 +57,40 @@ export type ClassDefinitions = Record<string, ClassWithSource>;
  */
 export async function collectElementAttributeSchemas(schemaCache: SchemaCache): Promise<ElementAttributeSchemas> {
 	const result: ElementAttributeSchemas = {};
-	const workspaceFolders = vscode.workspace.workspaceFolders;
+	const roots = await ensureProjectRoots();
+	const perRoot = await Promise.all(
+		roots.map(async (root) => {
+			try {
+				return await getInstalledExtensionsCached(root.fsPath);
+			} catch (error) {
+				logMessage(
+					`Failed to discover element attribute schemas in ${root.fsPath}: ${getErrorMessage(error)}.`,
+					"warn",
+				);
+				return [];
+			}
+		}),
+	);
 
-	if (!workspaceFolders) {
-		return result;
-	}
+	for (const extensions of perRoot) {
+		for (const ext of extensions) {
+			const schema: ExtensionSchema | null = schemaCache.get(ext.directory);
+			if (!schema?.attributes) {
+				continue;
+			}
 
-	for (const folder of workspaceFolders) {
-		try {
-			const extensions = await getInstalledExtensionsCached(folder.uri.fsPath);
+			const source = ext.manifest.title || ext.id.name;
 
-			for (const ext of extensions) {
-				const schema: ExtensionSchema | null = schemaCache.get(ext.directory);
-				if (!schema?.attributes) {
-					continue;
+			for (const [groupName, groupAttrs] of Object.entries(schema.attributes)) {
+				if (!result[groupName]) {
+					result[groupName] = {};
 				}
-
-				const source = ext.manifest.title || ext.id.name;
-
-				for (const [groupName, groupAttrs] of Object.entries(schema.attributes)) {
-					if (!result[groupName]) {
-						result[groupName] = {};
-					}
-					for (const [attrName, descriptor] of Object.entries(groupAttrs)) {
-						if (!(attrName in result[groupName])) {
-							result[groupName][attrName] = { descriptor, source };
-						}
+				for (const [attrName, descriptor] of Object.entries(groupAttrs)) {
+					if (!(attrName in result[groupName])) {
+						result[groupName][attrName] = { descriptor, source };
 					}
 				}
 			}
-		} catch (error) {
-			logMessage(
-				`Failed to discover element attribute schemas in ${folder.uri.fsPath}: ${getErrorMessage(error)}.`,
-				"warn",
-			);
 		}
 	}
 
@@ -105,51 +106,48 @@ export async function collectElementAttributeSchemas(schemaCache: SchemaCache): 
  */
 export async function collectClassDefinitions(schemaCache: SchemaCache): Promise<ClassDefinitions> {
 	const result: ClassDefinitions = {};
-	const workspaceFolders = vscode.workspace.workspaceFolders;
+	const roots = await ensureProjectRoots();
+	const perRoot = await Promise.all(
+		roots.map(async (root) => {
+			try {
+				return await getInstalledExtensionsCached(root.fsPath);
+			} catch (error) {
+				logMessage(`Failed to discover class definitions in ${root.fsPath}: ${getErrorMessage(error)}.`, "warn");
+				return [];
+			}
+		}),
+	);
 
-	if (!workspaceFolders) {
-		return result;
-	}
+	for (const extensions of perRoot) {
+		for (const ext of extensions) {
+			const schema: ExtensionSchema | null = schemaCache.get(ext.directory);
+			if (!schema) {
+				continue;
+			}
 
-	for (const folder of workspaceFolders) {
-		try {
-			const extensions = await getInstalledExtensionsCached(folder.uri.fsPath);
+			const source = ext.manifest.title || ext.id.name;
 
-			for (const ext of extensions) {
-				const schema: ExtensionSchema | null = schemaCache.get(ext.directory);
-				if (!schema) {
-					continue;
-				}
-
-				const source = ext.manifest.title || ext.id.name;
-
-				// Collect explicit class definitions from schema.classes.
-				if (schema.classes) {
-					for (const [className, classDef] of Object.entries(schema.classes)) {
-						if (!(className in result)) {
-							result[className] = {
-								description: classDef.description,
-								source,
-							};
-						}
-					}
-				}
-
-				// Collect implicit class names from schema.attributes group keys,
-				// excluding reserved element-type and catch-all groups.
-				if (schema.attributes) {
-					for (const groupKey of Object.keys(schema.attributes)) {
-						if (RESERVED_GROUP_NAMES.has(groupKey)) {
-							continue;
-						}
-						if (!(groupKey in result)) {
-							result[groupKey] = { source };
-						}
+			if (schema.classes) {
+				for (const [className, classDef] of Object.entries(schema.classes)) {
+					if (!(className in result)) {
+						result[className] = {
+							description: classDef.description,
+							source,
+						};
 					}
 				}
 			}
-		} catch (error) {
-			logMessage(`Failed to discover class definitions in ${folder.uri.fsPath}: ${getErrorMessage(error)}.`, "warn");
+
+			if (schema.attributes) {
+				for (const groupKey of Object.keys(schema.attributes)) {
+					if (RESERVED_GROUP_NAMES.has(groupKey)) {
+						continue;
+					}
+					if (!(groupKey in result)) {
+						result[groupKey] = { source };
+					}
+				}
+			}
 		}
 	}
 

--- a/src/providers/registerYamlProviders.ts
+++ b/src/providers/registerYamlProviders.ts
@@ -8,6 +8,7 @@ import { SchemaDiagnosticsProvider } from "./schemaDiagnosticsProvider";
 import { SchemaDefinitionCompletionProvider, SCHEMA_DEFINITION_SELECTOR } from "./schemaDefinitionCompletionProvider";
 import { logMessage } from "../utils/log";
 import { invalidateWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import { findOwningProjectRootSync } from "../utils/projectRootsRegistry";
 
 /**
  * Register YAML completion and diagnostics providers for Quarto
@@ -53,9 +54,9 @@ export function registerYamlProviders(context: vscode.ExtensionContext, schemaCa
 	const invalidateAndRevalidate = (uri: vscode.Uri) => {
 		const dir = path.normalize(vscode.Uri.joinPath(uri, "..").fsPath);
 		schemaCache.invalidate(dir);
-		const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-		if (workspaceFolder) {
-			invalidateWorkspaceSchemaIndex(workspaceFolder.uri.fsPath);
+		const owningRoot = uri.scheme === "file" ? findOwningProjectRootSync(uri.fsPath) : undefined;
+		if (owningRoot) {
+			invalidateWorkspaceSchemaIndex(owningRoot);
 		} else {
 			invalidateWorkspaceSchemaIndex();
 		}

--- a/src/providers/shortcodeCompletionProvider.ts
+++ b/src/providers/shortcodeCompletionProvider.ts
@@ -1,8 +1,9 @@
-import * as vscode from "vscode";
 import type { ShortcodeSchema, FieldDescriptor, SchemaCache } from "@quarto-wizard/schema";
 import { typeIncludes } from "@quarto-wizard/schema";
 import { getErrorMessage } from "@quarto-wizard/core";
+import * as vscode from "vscode";
 import { getInstalledExtensionsCached } from "../utils/installedExtensionsCache";
+import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 import { parseShortcodeAtPosition } from "../utils/shortcodeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
@@ -425,30 +426,30 @@ export class ShortcodeCompletionProvider implements vscode.CompletionItemProvide
  */
 export async function collectShortcodeSchemas(schemaCache: SchemaCache): Promise<Map<string, ShortcodeSchema>> {
 	const result = new Map<string, ShortcodeSchema>();
-	const workspaceFolders = vscode.workspace.workspaceFolders;
+	const roots = await ensureProjectRoots();
+	const perRoot = await Promise.all(
+		roots.map(async (root) => {
+			try {
+				return await getInstalledExtensionsCached(root.fsPath);
+			} catch (error) {
+				logMessage(`Failed to discover shortcode schemas in ${root.fsPath}: ${getErrorMessage(error)}.`, "warn");
+				return [];
+			}
+		}),
+	);
 
-	if (!workspaceFolders) {
-		return result;
-	}
+	for (const extensions of perRoot) {
+		for (const ext of extensions) {
+			const schema = schemaCache.get(ext.directory);
+			if (!schema?.shortcodes) {
+				continue;
+			}
 
-	for (const folder of workspaceFolders) {
-		try {
-			const extensions = await getInstalledExtensionsCached(folder.uri.fsPath);
-
-			for (const ext of extensions) {
-				const schema = schemaCache.get(ext.directory);
-				if (!schema?.shortcodes) {
-					continue;
-				}
-
-				for (const [name, shortcodeSchema] of Object.entries(schema.shortcodes)) {
-					if (!result.has(name)) {
-						result.set(name, shortcodeSchema);
-					}
+			for (const [name, shortcodeSchema] of Object.entries(schema.shortcodes)) {
+				if (!result.has(name)) {
+					result.set(name, shortcodeSchema);
 				}
 			}
-		} catch (error) {
-			logMessage(`Failed to discover shortcode schemas in ${folder.uri.fsPath}: ${getErrorMessage(error)}.`, "warn");
 		}
 	}
 

--- a/src/providers/snippetCompletionProvider.ts
+++ b/src/providers/snippetCompletionProvider.ts
@@ -4,6 +4,7 @@ import { snippetNamespace, qualifySnippetPrefix } from "@quarto-wizard/snippets"
 import { getErrorMessage } from "@quarto-wizard/core";
 import { logMessage } from "../utils/log";
 import { getInstalledExtensionsCached } from "../utils/installedExtensionsCache";
+import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 
 /**
  * Provides snippet completions from installed Quarto extensions.
@@ -44,36 +45,36 @@ class SnippetCompletionProvider implements vscode.CompletionItemProvider {
 
 	private async collectAllSnippets(): Promise<vscode.CompletionItem[]> {
 		const items: vscode.CompletionItem[] = [];
-		const workspaceFolders = vscode.workspace.workspaceFolders;
+		const roots = await ensureProjectRoots();
+		const perRoot = await Promise.all(
+			roots.map(async (root) => {
+				try {
+					return await getInstalledExtensionsCached(root.fsPath);
+				} catch (error) {
+					logMessage(`Failed to discover snippets in ${root.fsPath}: ${getErrorMessage(error)}.`, "warn");
+					return [];
+				}
+			}),
+		);
 
-		if (!workspaceFolders) {
-			return items;
-		}
+		for (const extensions of perRoot) {
+			for (const ext of extensions) {
+				const snippets = this.snippetCache.get(ext.directory);
+				if (!snippets) {
+					continue;
+				}
 
-		for (const folder of workspaceFolders) {
-			try {
-				const extensions = await getInstalledExtensionsCached(folder.uri.fsPath);
+				const namespace = snippetNamespace(ext.id);
 
-				for (const ext of extensions) {
-					const snippets = this.snippetCache.get(ext.directory);
-					if (!snippets) {
-						continue;
-					}
+				for (const [name, snippet] of Object.entries(snippets)) {
+					const prefixes = Array.isArray(snippet.prefix) ? snippet.prefix : [snippet.prefix];
 
-					const namespace = snippetNamespace(ext.id);
-
-					for (const [name, snippet] of Object.entries(snippets)) {
-						const prefixes = Array.isArray(snippet.prefix) ? snippet.prefix : [snippet.prefix];
-
-						for (const rawPrefix of prefixes) {
-							const qualifiedPrefix = qualifySnippetPrefix(namespace, rawPrefix);
-							const item = this.buildCompletionItem(name, snippet, qualifiedPrefix, ext.id.name);
-							items.push(item);
-						}
+					for (const rawPrefix of prefixes) {
+						const qualifiedPrefix = qualifySnippetPrefix(namespace, rawPrefix);
+						const item = this.buildCompletionItem(name, snippet, qualifiedPrefix, ext.id.name);
+						items.push(item);
 					}
 				}
-			} catch (error) {
-				logMessage(`Failed to discover snippets in ${folder.uri.fsPath}: ${getErrorMessage(error)}.`, "warn");
 			}
 		}
 

--- a/src/providers/yamlCompletionProvider.ts
+++ b/src/providers/yamlCompletionProvider.ts
@@ -6,6 +6,7 @@ import { getYamlKeyPath, getYamlIndentLevel, isInYamlRegion, getExistingKeysAtPa
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
 import { hasCompletableValues } from "../utils/schemaDocumentation";
 import { getWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
 import { logMessage } from "../utils/log";
 
 /**
@@ -31,12 +32,11 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 			const isBlankLine = currentLineText.trim() === "";
 			const keyPath = getYamlKeyPath(lines, position.line, languageId, isBlankLine ? position.character : undefined);
 
-			const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-			if (!workspaceFolder) {
+			const projectDir = await findOwningProjectRoot(document.uri);
+			if (!projectDir) {
 				return undefined;
 			}
 
-			const projectDir = workspaceFolder.uri.fsPath;
 			const { schemaMap, extMap } = await getWorkspaceSchemaIndex(projectDir, this.schemaCache);
 
 			if (schemaMap.size === 0) {

--- a/src/providers/yamlDiagnosticsProvider.ts
+++ b/src/providers/yamlDiagnosticsProvider.ts
@@ -7,6 +7,7 @@ import { getYamlIndentLevel } from "../utils/yamlPosition";
 import { logMessage } from "../utils/log";
 import { debounce } from "../utils/debounce";
 import { getWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
 
 /**
  * Validate a single value against a field descriptor, returning error messages.
@@ -200,12 +201,12 @@ export class YamlDiagnosticsProvider implements vscode.Disposable {
 		}
 
 		const version = ++this.validationVersion;
-		const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-		if (!workspaceFolder) {
+		const projectDir = await findOwningProjectRoot(document.uri);
+		if (!projectDir) {
+			this.setDiagnostics(document, []);
 			return;
 		}
 
-		const projectDir = workspaceFolder.uri.fsPath;
 		const text = document.getText();
 		const lines = text.split("\n");
 		const languageId = document.languageId;

--- a/src/providers/yamlHoverProvider.ts
+++ b/src/providers/yamlHoverProvider.ts
@@ -5,6 +5,7 @@ import { formatExtensionId, getExtensionTypes, type InstalledExtension, getError
 import { getYamlKeyPath, isInYamlRegion } from "../utils/yamlPosition";
 import { logMessage } from "../utils/log";
 import { getWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
 
 /**
  * Provides hover information for Quarto extension options
@@ -38,12 +39,11 @@ export class YamlHoverProvider implements vscode.HoverProvider {
 				}
 			}
 
-			const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-			if (!workspaceFolder) {
+			const projectDir = await findOwningProjectRoot(document.uri);
+			if (!projectDir) {
 				return null;
 			}
 
-			const projectDir = workspaceFolder.uri.fsPath;
 			const { schemaMap, extMap } = await getWorkspaceSchemaIndex(projectDir, this.schemaCache);
 			const installedExtensions = Array.from(new Set(extMap.values()));
 

--- a/src/test/suite/projectRootsRegistry.test.ts
+++ b/src/test/suite/projectRootsRegistry.test.ts
@@ -1,0 +1,87 @@
+import * as assert from "assert";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+	ensureProjectRoots,
+	findOwningProjectRoot,
+	findOwningProjectRootSync,
+	invalidateProjectRoots,
+	setProjectRoots,
+} from "../../utils/projectRootsRegistry";
+import { makeFolder, makeRoot } from "./projectFixtures";
+
+suite("Project Roots Registry Test Suite", () => {
+	const tmpRoot = vscode.Uri.file(os.tmpdir()).fsPath;
+	const workspaceFsPath = path.join(tmpRoot, "registry-ws");
+	const workspace = makeFolder("registry-ws", workspaceFsPath);
+	const nestedA = makeRoot(workspace, "subA");
+	const nestedADeep = makeRoot(workspace, "subA", "deeper");
+	const nestedB = makeRoot(workspace, "subB");
+
+	teardown(() => {
+		invalidateProjectRoots();
+	});
+
+	test("findOwningProjectRoot returns the deepest matching root", async () => {
+		setProjectRoots([nestedA, nestedADeep]);
+
+		const document = vscode.Uri.file(path.join(nestedADeep.fsPath, "doc.qmd"));
+		const owning = await findOwningProjectRoot(document);
+
+		assert.strictEqual(owning, nestedADeep.fsPath);
+	});
+
+	test("findOwningProjectRoot returns the only matching root when others are siblings", async () => {
+		setProjectRoots([nestedA, nestedB]);
+
+		const document = vscode.Uri.file(path.join(nestedB.fsPath, "doc.qmd"));
+		const owning = await findOwningProjectRoot(document);
+
+		assert.strictEqual(owning, nestedB.fsPath);
+	});
+
+	test("findOwningProjectRoot returns undefined when the document lives outside every root", async () => {
+		setProjectRoots([nestedA]);
+
+		const outside = vscode.Uri.file(path.join(workspaceFsPath, "outside", "doc.qmd"));
+		const owning = await findOwningProjectRoot(outside);
+
+		assert.strictEqual(owning, undefined);
+	});
+
+	test("findOwningProjectRoot returns undefined for non-file URIs", async () => {
+		setProjectRoots([nestedA]);
+
+		const untitled = vscode.Uri.parse("untitled:Untitled-1");
+		const owning = await findOwningProjectRoot(untitled);
+
+		assert.strictEqual(owning, undefined);
+	});
+
+	test("findOwningProjectRootSync mirrors the async lookup against the current snapshot", () => {
+		setProjectRoots([nestedA, nestedADeep]);
+
+		const document = path.join(nestedADeep.fsPath, "doc.qmd");
+
+		assert.strictEqual(findOwningProjectRootSync(document), nestedADeep.fsPath);
+	});
+
+	test("ensureProjectRoots short-circuits to the snapshot once seeded", async () => {
+		setProjectRoots([nestedA]);
+
+		const roots = await ensureProjectRoots();
+
+		assert.deepStrictEqual(
+			roots.map((root) => root.fsPath),
+			[nestedA.fsPath],
+		);
+	});
+
+	test("invalidateProjectRoots empties the synchronous snapshot", () => {
+		setProjectRoots([nestedA, nestedB]);
+		invalidateProjectRoots();
+
+		assert.strictEqual(findOwningProjectRootSync(path.join(nestedA.fsPath, "doc.qmd")), undefined);
+	});
+});

--- a/src/test/suite/projectRootsRegistry.test.ts
+++ b/src/test/suite/projectRootsRegistry.test.ts
@@ -19,8 +19,20 @@ suite("Project Roots Registry Test Suite", () => {
 	const nestedADeep = makeRoot(workspace, "subA", "deeper");
 	const nestedB = makeRoot(workspace, "subB");
 
+	let originalFindFiles: typeof vscode.workspace.findFiles;
+	let originalWorkspaceFoldersDescriptor: PropertyDescriptor | undefined;
+
+	setup(() => {
+		originalFindFiles = vscode.workspace.findFiles;
+		originalWorkspaceFoldersDescriptor = Object.getOwnPropertyDescriptor(vscode.workspace, "workspaceFolders");
+	});
+
 	teardown(() => {
 		invalidateProjectRoots();
+		vscode.workspace.findFiles = originalFindFiles;
+		if (originalWorkspaceFoldersDescriptor) {
+			Object.defineProperty(vscode.workspace, "workspaceFolders", originalWorkspaceFoldersDescriptor);
+		}
 	});
 
 	test("findOwningProjectRoot returns the deepest matching root", async () => {
@@ -83,5 +95,35 @@ suite("Project Roots Registry Test Suite", () => {
 		invalidateProjectRoots();
 
 		assert.strictEqual(findOwningProjectRootSync(path.join(nestedA.fsPath, "doc.qmd")), undefined);
+	});
+
+	test("setProjectRoots wins over an older in-flight ensureProjectRoots discovery", async () => {
+		// Force `ensureProjectRoots` down the discovery branch by leaving state uninitialised.
+		invalidateProjectRoots();
+
+		Object.defineProperty(vscode.workspace, "workspaceFolders", {
+			get: () => [workspace],
+			configurable: true,
+		});
+
+		// Hold discovery open: returning no files means the workspace folder root falls back
+		// to itself, so without the race fix the `.then` would set `currentRoots` to a
+		// fallback `[workspaceRoot]` snapshot — clobbering whatever `setProjectRoots` wrote.
+		let releaseFindFiles: () => void = () => undefined;
+		const blockUntil = new Promise<void>((resolve) => {
+			releaseFindFiles = resolve;
+		});
+		vscode.workspace.findFiles = (() => blockUntil.then(() => [] as vscode.Uri[])) as typeof vscode.workspace.findFiles;
+
+		const pending = ensureProjectRoots();
+		setProjectRoots([nestedADeep]);
+		releaseFindFiles();
+		const resolved = await pending;
+
+		assert.deepStrictEqual(
+			resolved.map((root) => root.fsPath),
+			[nestedADeep.fsPath],
+		);
+		assert.strictEqual(findOwningProjectRootSync(path.join(nestedADeep.fsPath, "doc.qmd")), nestedADeep.fsPath);
 	});
 });

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -16,6 +16,7 @@ import {
 	QUARTO_PROJECT_GLOB,
 	EXTENSION_MANIFEST_GLOB,
 } from "../utils/quartoProjectDiscovery";
+import { findOwningProjectRootSync, invalidateProjectRoots, setProjectRoots } from "../utils/projectRootsRegistry";
 import { debounce } from "../utils/debounce";
 import { WorkspaceFolderTreeItem, ExtensionTreeItem, SnippetItemTreeItem } from "./extensionTreeItems";
 import { QuartoExtensionTreeDataProvider } from "./extensionTreeDataProvider";
@@ -49,12 +50,18 @@ export class ExtensionsInstalled {
 			treeDataProvider: this.treeDataProvider,
 			showCollapseAll: true,
 		});
-		const invalidateProviderCaches = (workspacePath?: string) => {
-			invalidateInstalledExtensionsCache(workspacePath);
-			invalidateWorkspaceSchemaIndex(workspacePath);
+		const invalidateProviderCaches = (cacheKey?: string) => {
+			invalidateInstalledExtensionsCache(cacheKey);
+			invalidateWorkspaceSchemaIndex(cacheKey);
 		};
 
-		const resolveWorkspacePath = (uri: vscode.Uri): string | undefined => {
+		const resolveCacheKeyForUri = (uri: vscode.Uri): string | undefined => {
+			if (uri.scheme === "file") {
+				const owningRoot = findOwningProjectRootSync(uri.fsPath);
+				if (owningRoot) {
+					return owningRoot;
+				}
+			}
 			return vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath;
 		};
 
@@ -62,6 +69,7 @@ export class ExtensionsInstalled {
 			const folders = vscode.workspace.workspaceFolders ?? [];
 			try {
 				const roots = await discoverQuartoProjectRoots(folders);
+				setProjectRoots(roots);
 				return this.treeDataProvider.setProjectRoots(roots);
 			} catch (error) {
 				logMessage(`Failed to discover Quarto project roots: ${getErrorMessage(error)}.`, "error");
@@ -113,7 +121,8 @@ export class ExtensionsInstalled {
 
 		const projectFileWatcher = vscode.workspace.createFileSystemWatcher(QUARTO_PROJECT_GLOB);
 		const onProjectFileChanged = (uri: vscode.Uri) => {
-			invalidateProviderCaches(resolveWorkspacePath(uri));
+			invalidateProviderCaches(resolveCacheKeyForUri(uri));
+			invalidateProjectRoots();
 			refreshProjectRoots();
 		};
 		context.subscriptions.push(projectFileWatcher.onDidCreate(onProjectFileChanged));
@@ -134,8 +143,9 @@ export class ExtensionsInstalled {
 		// promotes it into the detected roots without a manual refresh.
 		const extensionWatcher = vscode.workspace.createFileSystemWatcher(EXTENSION_MANIFEST_GLOB);
 		const onExtensionManifestEvent = (rediscover: boolean) => (uri: vscode.Uri) => {
-			invalidateProviderCaches(resolveWorkspacePath(uri));
+			invalidateProviderCaches(resolveCacheKeyForUri(uri));
 			if (rediscover) {
+				invalidateProjectRoots();
 				refreshProjectRoots();
 			} else {
 				this.treeDataProvider.refresh();
@@ -149,7 +159,7 @@ export class ExtensionsInstalled {
 		// Watch for changes to schema files for real-time tree view updates
 		const schemaWatcher = vscode.workspace.createFileSystemWatcher("**/_extensions/**/_schema.{yml,yaml,json}");
 		const invalidateSchemaAndRefresh = (uri: vscode.Uri) => {
-			invalidateWorkspaceSchemaIndex(resolveWorkspacePath(uri));
+			invalidateWorkspaceSchemaIndex(resolveCacheKeyForUri(uri));
 			schemaCache.invalidate(path.dirname(uri.fsPath));
 			this.treeDataProvider.refresh();
 		};

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -11,6 +11,10 @@ import { discoverQuartoProjectRoots, isInside, type QuartoProjectRoot } from "./
 let currentRoots: readonly QuartoProjectRoot[] = [];
 let initialised = false;
 let inFlight: Promise<readonly QuartoProjectRoot[]> | undefined;
+// Bumped by `setProjectRoots` and `invalidateProjectRoots` so a queued
+// `ensureProjectRoots` continuation from an earlier generation cannot
+// overwrite state written after it started.
+let generation = 0;
 
 /**
  * Returns the cached snapshot, running discovery once if needed.
@@ -24,10 +28,13 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 		return inFlight;
 	}
 	const folders = vscode.workspace.workspaceFolders ?? [];
+	const startedAt = generation;
 	inFlight = discoverQuartoProjectRoots(folders)
 		.then((roots) => {
-			currentRoots = roots;
-			initialised = true;
+			if (generation === startedAt) {
+				currentRoots = roots;
+				initialised = true;
+			}
 			return currentRoots;
 		})
 		.finally(() => {
@@ -44,6 +51,7 @@ export function setProjectRoots(roots: readonly QuartoProjectRoot[]): void {
 	currentRoots = roots;
 	initialised = true;
 	inFlight = undefined;
+	generation += 1;
 }
 
 /**
@@ -54,6 +62,7 @@ export function invalidateProjectRoots(): void {
 	currentRoots = [];
 	initialised = false;
 	inFlight = undefined;
+	generation += 1;
 }
 
 /**

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -1,0 +1,94 @@
+import * as vscode from "vscode";
+import { discoverQuartoProjectRoots, isInside, type QuartoProjectRoot } from "./quartoProjectDiscovery";
+
+/**
+ * Singleton registry of discovered Quarto project roots. Shared source of
+ * truth between the Extensions tree view and the schema-driven providers
+ * (YAML completion/hover/diagnostics, shortcode, element attributes,
+ * snippets).
+ */
+
+let currentRoots: readonly QuartoProjectRoot[] = [];
+let initialised = false;
+let inFlight: Promise<readonly QuartoProjectRoot[]> | undefined;
+
+/**
+ * Returns the cached snapshot, running discovery once if needed.
+ * Concurrent callers share a single in-flight promise.
+ */
+export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]> {
+	if (initialised) {
+		return currentRoots;
+	}
+	if (inFlight) {
+		return inFlight;
+	}
+	const folders = vscode.workspace.workspaceFolders ?? [];
+	inFlight = discoverQuartoProjectRoots(folders)
+		.then((roots) => {
+			currentRoots = roots;
+			initialised = true;
+			return currentRoots;
+		})
+		.finally(() => {
+			inFlight = undefined;
+		});
+	return inFlight;
+}
+
+/**
+ * Overwrites the cached snapshot and cancels any in-flight discovery so
+ * a concurrent `ensureProjectRoots` cannot race-overwrite this snapshot.
+ */
+export function setProjectRoots(roots: readonly QuartoProjectRoot[]): void {
+	currentRoots = roots;
+	initialised = true;
+	inFlight = undefined;
+}
+
+/**
+ * Drops the cached snapshot. The next `ensureProjectRoots` call re-runs
+ * discovery.
+ */
+export function invalidateProjectRoots(): void {
+	currentRoots = [];
+	initialised = false;
+	inFlight = undefined;
+}
+
+/**
+ * Returns the deepest discovered project root that contains
+ * `documentUri`. Returns undefined for non-file URIs or documents
+ * outside every known root.
+ */
+export async function findOwningProjectRoot(documentUri: vscode.Uri): Promise<string | undefined> {
+	if (documentUri.scheme !== "file") {
+		return undefined;
+	}
+	const roots = await ensureProjectRoots();
+	return pickDeepestOwningRoot(roots, documentUri.fsPath);
+}
+
+/**
+ * Synchronous best-effort lookup against the current snapshot. Returns
+ * undefined when the snapshot is empty or the path is outside every
+ * root.
+ */
+export function findOwningProjectRootSync(documentFsPath: string): string | undefined {
+	return pickDeepestOwningRoot(currentRoots, documentFsPath);
+}
+
+function pickDeepestOwningRoot(roots: readonly QuartoProjectRoot[], fsPath: string): string | undefined {
+	let best: string | undefined;
+	let bestLength = -1;
+	for (const root of roots) {
+		if (!isInside(root.fsPath, fsPath)) {
+			continue;
+		}
+		if (root.fsPath.length > bestLength) {
+			best = root.fsPath;
+			bestLength = root.fsPath.length;
+		}
+	}
+	return best;
+}

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -262,7 +262,7 @@ async function directoryHasInstalledExtension(extensionsDir: vscode.Uri): Promis
 /**
  * True when `child` is `parent` or lives below it (resolved, normalised path comparison).
  */
-function isInside(parent: string, child: string): boolean {
+export function isInside(parent: string, child: string): boolean {
 	const relative = path.relative(parent, child);
 	if (relative === "") {
 		return true;


### PR DESCRIPTION
Schema-driven providers (YAML completion, hover, diagnostics, shortcode completion, element attribute completion, and snippet completion) previously scanned only the workspace folder root for `_extensions/`, so nested Quarto projects never surfaced their extensions for IntelliSense.

A shared project-roots registry now stays in lock-step with the Extensions tree view discovery flow. Providers resolve each document's nearest enclosing project root through the registry and feed that path to the existing per-project schema and extension caches. Registry invalidation runs only when the discovered root set can actually change (create or delete of `_quarto.yml` or `_extension.yml`), and the four collectors fetch installed extensions across roots in parallel.

A generation counter prevents a queued `ensureProjectRoots` continuation from clobbering state written by a later `setProjectRoots` or `invalidateProjectRoots` call.