### PR TITLE
feat: extend schema providers to metadata-files included YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: support a v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json`. v2 uses JSON Schema canonical names exclusively (`minimum`, `maximum`, `multipleOf`, `additionalProperties`, `propertyNames`, `dependentRequired`, `contentEncoding`, `contentMediaType`, `replaceWith`, ...), drops `pattern-exact` in favour of `^...$` anchors in the pattern itself, and lets shortcode entries declare a parent-level `required: [name1, ...]` array. v1 schemas keep working under the v1 URI; the runtime dispatches on the instance `$schema` URI.
 - feat: extend the v1 schema vocabulary with new optional field properties: `title`, `examples`, `format`, `null` type, `multiple-of`, `additional-properties`, `property-names`, `dependent-required`, `content-encoding`, `content-media-type`. `completion.type: directory` is now recognised alongside `file` / `color` / ... .
 - feat: `$schema:` completion in `_schema.yml` offers both the v1 and v2 URIs (v2 preferred).
+- feat: extend schema completion, diagnostics, and hover to YAML files included via `metadata-files:`. Secondary configuration files declared in `_quarto.yml`, `_metadata.yml`, or `.qmd` front-matter now receive the same IntelliSense as canonical Quarto config files.
 
 ### Bug Fixes
 

--- a/src/providers/registerYamlProviders.ts
+++ b/src/providers/registerYamlProviders.ts
@@ -8,7 +8,8 @@ import { SchemaDiagnosticsProvider } from "./schemaDiagnosticsProvider";
 import { SchemaDefinitionCompletionProvider, SCHEMA_DEFINITION_SELECTOR } from "./schemaDefinitionCompletionProvider";
 import { logMessage } from "../utils/log";
 import { invalidateWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
-import { findOwningProjectRootSync } from "../utils/projectRootsRegistry";
+import { findOwningProjectRoot, findOwningProjectRootSync } from "../utils/projectRootsRegistry";
+import { invalidateMetadataFiles, isQmdFile, refreshSource } from "../utils/metadataFilesRegistry";
 
 /**
  * Register YAML completion and diagnostics providers for Quarto
@@ -69,6 +70,84 @@ export function registerYamlProviders(context: vscode.ExtensionContext, schemaCa
 	context.subscriptions.push(schemaWatcher.onDidCreate(invalidateAndRevalidate));
 	context.subscriptions.push(schemaWatcher.onDidDelete(invalidateAndRevalidate));
 	context.subscriptions.push(schemaWatcher);
+
+	const applyMetadataChange = (owningRoot: string) => {
+		invalidateWorkspaceSchemaIndex(owningRoot);
+		diagnosticsProvider.revalidateAll();
+	};
+
+	// Watch Quarto config sources for changes in `metadata-files:` entries.
+	const metadataSourceWatcher = vscode.workspace.createFileSystemWatcher("**/_{quarto,metadata}.{yml,yaml}");
+	const refreshMetadataSource = async (uri: vscode.Uri) => {
+		if (uri.scheme !== "file") {
+			return;
+		}
+		const owningRoot = findOwningProjectRootSync(uri.fsPath);
+		if (!owningRoot) {
+			return;
+		}
+		const changed = await refreshSource(owningRoot, uri.fsPath);
+		if (!changed) {
+			return;
+		}
+		applyMetadataChange(owningRoot);
+		logMessage(`Metadata-files registry refreshed for ${uri.fsPath}.`, "debug");
+	};
+	context.subscriptions.push(metadataSourceWatcher.onDidChange(refreshMetadataSource));
+	context.subscriptions.push(metadataSourceWatcher.onDidCreate(refreshMetadataSource));
+	context.subscriptions.push(metadataSourceWatcher.onDidDelete(refreshMetadataSource));
+	context.subscriptions.push(metadataSourceWatcher);
+
+	// `.qmd` front-matter can also list metadata-files; refresh on save/open.
+	// Uses the async project-root lookup so first-open during activation succeeds
+	// before tree-view discovery has populated the sync snapshot.
+	const refreshQmdSource = async (document: vscode.TextDocument): Promise<string | undefined> => {
+		if (document.uri.scheme !== "file") {
+			return undefined;
+		}
+		if (document.languageId !== "quarto" && !isQmdFile(document.fileName)) {
+			return undefined;
+		}
+		const owningRoot = await findOwningProjectRoot(document.uri);
+		if (!owningRoot) {
+			return undefined;
+		}
+		const changed = await refreshSource(owningRoot, document.uri.fsPath);
+		return changed ? owningRoot : undefined;
+	};
+	const refreshQmdAndInvalidate = async (document: vscode.TextDocument) => {
+		const changedRoot = await refreshQmdSource(document);
+		if (changedRoot) {
+			applyMetadataChange(changedRoot);
+		}
+	};
+	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(refreshQmdAndInvalidate));
+	context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(refreshQmdAndInvalidate));
+
+	// Prime the registry from already-open .qmd documents in one batched pass:
+	// invalidate each affected root once instead of N times.
+	void (async () => {
+		const results = await Promise.all(vscode.workspace.textDocuments.map(refreshQmdSource));
+		const changedRoots = new Set<string>();
+		for (const root of results) {
+			if (root) {
+				changedRoots.add(root);
+			}
+		}
+		for (const root of changedRoots) {
+			invalidateWorkspaceSchemaIndex(root);
+		}
+		if (changedRoots.size > 0) {
+			diagnosticsProvider.revalidateAll();
+		}
+	})();
+
+	// Workspace folder changes can invalidate project-root identity; rebuild lazily.
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeWorkspaceFolders(() => {
+			invalidateMetadataFiles();
+		}),
+	);
 
 	logMessage("YAML completion, hover, and diagnostics providers registered.", "debug");
 }

--- a/src/providers/registerYamlProviders.ts
+++ b/src/providers/registerYamlProviders.ts
@@ -126,7 +126,7 @@ export function registerYamlProviders(context: vscode.ExtensionContext, schemaCa
 
 	// Prime the registry from already-open .qmd documents in one batched pass:
 	// invalidate each affected root once instead of N times.
-	void (async () => {
+	const primeOpenQmdDocuments = async () => {
 		const results = await Promise.all(vscode.workspace.textDocuments.map(refreshQmdSource));
 		const changedRoots = new Set<string>();
 		for (const root of results) {
@@ -140,7 +140,10 @@ export function registerYamlProviders(context: vscode.ExtensionContext, schemaCa
 		if (changedRoots.size > 0) {
 			diagnosticsProvider.revalidateAll();
 		}
-	})();
+	};
+	primeOpenQmdDocuments().catch((error) =>
+		logMessage(`Failed to prime metadata-files registry: ${String(error)}.`, "warn"),
+	);
 
 	// Workspace folder changes can invalidate project-root identity; rebuild lazily.
 	context.subscriptions.push(

--- a/src/providers/yamlCompletionProvider.ts
+++ b/src/providers/yamlCompletionProvider.ts
@@ -7,6 +7,7 @@ import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePat
 import { hasCompletableValues } from "../utils/schemaDocumentation";
 import { getWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
 import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
+import { isRelevantYaml } from "../utils/metadataFilesRegistry";
 import { logMessage } from "../utils/log";
 
 /**
@@ -21,6 +22,10 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 		position: vscode.Position,
 	): Promise<vscode.CompletionItem[] | undefined> {
 		try {
+			if (!isRelevantYaml(document)) {
+				return undefined;
+			}
+
 			const lines = document.getText().split("\n");
 			const languageId = document.languageId;
 
@@ -409,10 +414,12 @@ export class YamlCompletionProvider implements vscode.CompletionItemProvider {
 }
 
 /**
- * File patterns for YAML documents that may contain Quarto configuration.
+ * Document selector for schema-driven YAML providers.  Targets `.qmd` files
+ * and any YAML file; per-document relevance (canonical `_quarto.*`/
+ * `_metadata.*` filenames or `metadata-files:` registered paths) is enforced
+ * inside each provider via {@link isRelevantYaml}.
  */
 export const YAML_DOCUMENT_SELECTOR: vscode.DocumentSelector = [
-	{ language: "yaml", pattern: "**/_quarto.{yml,yaml}" },
-	{ language: "yaml", pattern: "**/_metadata.{yml,yaml}" },
+	{ language: "yaml", scheme: "file" },
 	{ language: "quarto", pattern: "**/*.qmd" },
 ];

--- a/src/providers/yamlDiagnosticsProvider.ts
+++ b/src/providers/yamlDiagnosticsProvider.ts
@@ -8,6 +8,7 @@ import { logMessage } from "../utils/log";
 import { debounce } from "../utils/debounce";
 import { getWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
 import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
+import { isRelevantYaml } from "../utils/metadataFilesRegistry";
 
 /**
  * Validate a single value against a field descriptor, returning error messages.
@@ -180,19 +181,7 @@ export class YamlDiagnosticsProvider implements vscode.Disposable {
 	}
 
 	private isRelevantDocument(document: vscode.TextDocument): boolean {
-		const fileName = document.fileName;
-		if (document.languageId === "quarto" || fileName.endsWith(".qmd")) {
-			return true;
-		}
-		if (document.languageId === "yaml") {
-			return (
-				fileName.endsWith("_quarto.yml") ||
-				fileName.endsWith("_quarto.yaml") ||
-				fileName.endsWith("_metadata.yml") ||
-				fileName.endsWith("_metadata.yaml")
-			);
-		}
-		return false;
+		return isRelevantYaml(document);
 	}
 
 	private async validateDocument(document: vscode.TextDocument): Promise<void> {

--- a/src/providers/yamlHoverProvider.ts
+++ b/src/providers/yamlHoverProvider.ts
@@ -6,6 +6,7 @@ import { getYamlKeyPath, isInYamlRegion } from "../utils/yamlPosition";
 import { logMessage } from "../utils/log";
 import { getWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
 import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
+import { isRelevantYaml } from "../utils/metadataFilesRegistry";
 
 /**
  * Provides hover information for Quarto extension options
@@ -16,6 +17,10 @@ export class YamlHoverProvider implements vscode.HoverProvider {
 
 	async provideHover(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover | null> {
 		try {
+			if (!isRelevantYaml(document)) {
+				return null;
+			}
+
 			const lines = document.getText().split("\n");
 			const languageId = document.languageId;
 

--- a/src/test/suite/metadataFilesRegistry.test.ts
+++ b/src/test/suite/metadataFilesRegistry.test.ts
@@ -1,0 +1,202 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+	getMetadataFiles,
+	invalidateMetadataFiles,
+	isRegisteredMetadataFile,
+	isRelevantYaml,
+	refreshSource,
+} from "../../utils/metadataFilesRegistry";
+
+const QUARTO_AND_METADATA_FILENAMES = new Set(["_quarto.yml", "_quarto.yaml", "_metadata.yml", "_metadata.yaml"]);
+
+suite("Metadata Files Registry Test Suite", () => {
+	let tempDir: string;
+	let originalFindFiles: typeof vscode.workspace.findFiles;
+	let originalTextDocumentsDescriptor: PropertyDescriptor | undefined;
+	let mockedTextDocuments: readonly vscode.TextDocument[];
+
+	function scan(base: string, filenames: ReadonlySet<string>): vscode.Uri[] {
+		const matches: vscode.Uri[] = [];
+		const walk = (current: string) => {
+			let entries: fs.Dirent[];
+			try {
+				entries = fs.readdirSync(current, { withFileTypes: true });
+			} catch {
+				return;
+			}
+			for (const entry of entries) {
+				const fullPath = path.join(current, entry.name);
+				if (entry.isDirectory()) {
+					walk(fullPath);
+				} else if (entry.isFile() && filenames.has(entry.name)) {
+					matches.push(vscode.Uri.file(fullPath));
+				}
+			}
+		};
+		walk(base);
+		return matches;
+	}
+
+	setup(() => {
+		tempDir = vscode.Uri.file(fs.mkdtempSync(path.join(os.tmpdir(), "quarto-wizard-metadata-"))).fsPath;
+
+		mockedTextDocuments = [];
+		originalFindFiles = vscode.workspace.findFiles;
+		vscode.workspace.findFiles = ((include: vscode.GlobPattern) => {
+			if (typeof include === "object" && "baseUri" in include) {
+				const rel = include as vscode.RelativePattern;
+				if (rel.pattern === "**/_{quarto,metadata}.{yml,yaml}") {
+					return Promise.resolve(scan(rel.baseUri.fsPath, QUARTO_AND_METADATA_FILENAMES));
+				}
+			}
+			return Promise.resolve([]);
+		}) as typeof vscode.workspace.findFiles;
+
+		originalTextDocumentsDescriptor = Object.getOwnPropertyDescriptor(vscode.workspace, "textDocuments");
+		Object.defineProperty(vscode.workspace, "textDocuments", {
+			get: () => mockedTextDocuments,
+			configurable: true,
+		});
+
+		invalidateMetadataFiles();
+	});
+
+	teardown(() => {
+		invalidateMetadataFiles();
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+		vscode.workspace.findFiles = originalFindFiles;
+		if (originalTextDocumentsDescriptor) {
+			Object.defineProperty(vscode.workspace, "textDocuments", originalTextDocumentsDescriptor);
+		}
+	});
+
+	function writeFile(filePath: string, content: string): void {
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, content, "utf8");
+	}
+
+	function makeDocument(filePath: string, text: string, languageId = "quarto"): vscode.TextDocument {
+		const lineCount = text.split("\n").length;
+		return {
+			uri: vscode.Uri.file(filePath),
+			fileName: filePath,
+			isUntitled: false,
+			isClosed: false,
+			languageId,
+			lineCount,
+			getText: () => text,
+		} as unknown as vscode.TextDocument;
+	}
+
+	test("collects metadata-files from _quarto.yml", async () => {
+		writeFile(
+			path.join(tempDir, "_quarto.yml"),
+			["project:", "  type: website", "metadata-files:", "  - _sidebar.yml", "  - sub/_extra.yml", ""].join("\n"),
+		);
+
+		const files = await getMetadataFiles(tempDir);
+		assert.strictEqual(files.size, 2);
+		assert.ok(files.has(path.normalize(path.join(tempDir, "_sidebar.yml"))));
+		assert.ok(files.has(path.normalize(path.join(tempDir, "sub/_extra.yml"))));
+	});
+
+	test("isRegisteredMetadataFile returns the owning project root", async () => {
+		writeFile(path.join(tempDir, "_quarto.yml"), "metadata-files:\n  - _sidebar.yml\n");
+
+		await getMetadataFiles(tempDir);
+		const owning = isRegisteredMetadataFile(path.join(tempDir, "_sidebar.yml"));
+		assert.strictEqual(owning, path.normalize(tempDir));
+	});
+
+	test("collects from _metadata.yml in subdirectory", async () => {
+		writeFile(path.join(tempDir, "chapter", "_metadata.yml"), "metadata-files:\n  - shared.yml\n  - ../top.yml\n");
+
+		const files = await getMetadataFiles(tempDir);
+		assert.strictEqual(files.size, 2);
+		assert.ok(files.has(path.normalize(path.join(tempDir, "chapter", "shared.yml"))));
+		assert.ok(files.has(path.normalize(path.join(tempDir, "top.yml"))));
+	});
+
+	test("collects from .qmd front-matter via open document", async () => {
+		const qmdPath = path.join(tempDir, "doc.qmd");
+		const text = ["---", "title: Doc", "metadata-files:", "  - _sidebar.yml", "---", "", "Body."].join("\n");
+		writeFile(qmdPath, text);
+		mockedTextDocuments = [makeDocument(qmdPath, text)];
+
+		const files = await getMetadataFiles(tempDir);
+		assert.ok(files.has(path.normalize(path.join(tempDir, "_sidebar.yml"))));
+	});
+
+	test("refreshSource drops removed entries", async () => {
+		const sourcePath = path.join(tempDir, "_quarto.yml");
+		writeFile(sourcePath, "metadata-files:\n  - _a.yml\n  - _b.yml\n");
+
+		const before = await getMetadataFiles(tempDir);
+		assert.strictEqual(before.size, 2);
+
+		writeFile(sourcePath, "metadata-files:\n  - _a.yml\n");
+		const changed = await refreshSource(tempDir, sourcePath);
+		assert.strictEqual(changed, true);
+
+		const after = await getMetadataFiles(tempDir);
+		assert.strictEqual(after.size, 1);
+		assert.ok(after.has(path.normalize(path.join(tempDir, "_a.yml"))));
+		assert.strictEqual(isRegisteredMetadataFile(path.join(tempDir, "_b.yml")), undefined);
+	});
+
+	test("refreshSource returns false when contributions are unchanged", async () => {
+		const sourcePath = path.join(tempDir, "_quarto.yml");
+		writeFile(sourcePath, "metadata-files:\n  - _a.yml\n");
+
+		await getMetadataFiles(tempDir);
+		const changedAgain = await refreshSource(tempDir, sourcePath);
+		assert.strictEqual(changedAgain, false);
+	});
+
+	test("refreshSource removes all entries when source is deleted", async () => {
+		const sourcePath = path.join(tempDir, "_quarto.yml");
+		writeFile(sourcePath, "metadata-files:\n  - _a.yml\n");
+
+		await getMetadataFiles(tempDir);
+		fs.rmSync(sourcePath);
+		await refreshSource(tempDir, sourcePath);
+
+		const after = await getMetadataFiles(tempDir);
+		assert.strictEqual(after.size, 0);
+	});
+
+	test("invalid YAML is tolerated silently", async () => {
+		writeFile(path.join(tempDir, "_quarto.yml"), "metadata-files:\n  - _ok.yml\n: : not valid\n");
+		const files = await getMetadataFiles(tempDir);
+		assert.strictEqual(files.size, 0);
+	});
+
+	test("missing metadata-files key yields empty set", async () => {
+		writeFile(path.join(tempDir, "_quarto.yml"), "project:\n  type: website\n");
+		const files = await getMetadataFiles(tempDir);
+		assert.strictEqual(files.size, 0);
+	});
+
+	test("isRelevantYaml accepts canonical files and registered metadata files", async () => {
+		writeFile(path.join(tempDir, "_quarto.yml"), "metadata-files:\n  - _sidebar.yml\n");
+		await getMetadataFiles(tempDir);
+
+		const qmdDoc = makeDocument(path.join(tempDir, "doc.qmd"), "", "quarto");
+		const quartoYml = makeDocument(path.join(tempDir, "_quarto.yml"), "", "yaml");
+		const metadataYml = makeDocument(path.join(tempDir, "sub", "_metadata.yml"), "", "yaml");
+		const includedYml = makeDocument(path.join(tempDir, "_sidebar.yml"), "", "yaml");
+		const unrelatedYml = makeDocument(path.join(tempDir, "other.yml"), "", "yaml");
+
+		assert.strictEqual(isRelevantYaml(qmdDoc), true);
+		assert.strictEqual(isRelevantYaml(quartoYml), true);
+		assert.strictEqual(isRelevantYaml(metadataYml), true);
+		assert.strictEqual(isRelevantYaml(includedYml), true);
+		assert.strictEqual(isRelevantYaml(unrelatedYml), false);
+	});
+});

--- a/src/test/suite/metadataFilesRegistry.test.ts
+++ b/src/test/suite/metadataFilesRegistry.test.ts
@@ -183,6 +183,37 @@ suite("Metadata Files Registry Test Suite", () => {
 		assert.strictEqual(files.size, 0);
 	});
 
+	test("refreshSource awaits in-flight build before mutating", async () => {
+		const sourcePath = path.join(tempDir, "_quarto.yml");
+		writeFile(sourcePath, "metadata-files:\n  - _a.yml\n  - _b.yml\n");
+
+		// Hold findFiles open until both calls have begun, so the lazy build is
+		// guaranteed to overlap the targeted refresh.  Without the in-flight
+		// await in refreshSource, the two mutations interleave on
+		// state.contributions for the same source.
+		let releaseFindFiles!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseFindFiles = resolve;
+		});
+		const baseline = vscode.workspace.findFiles;
+		vscode.workspace.findFiles = (async (...args: Parameters<typeof vscode.workspace.findFiles>) => {
+			await gate;
+			return baseline(...args);
+		}) as typeof vscode.workspace.findFiles;
+
+		const lazyBuild = getMetadataFiles(tempDir);
+		// Kick the targeted refresh while the build is still pending.
+		const refresh = refreshSource(tempDir, sourcePath);
+		releaseFindFiles();
+
+		await Promise.all([lazyBuild, refresh]);
+
+		const finalFiles = await getMetadataFiles(tempDir);
+		assert.strictEqual(finalFiles.size, 2);
+		assert.ok(finalFiles.has(path.normalize(path.join(tempDir, "_a.yml"))));
+		assert.ok(finalFiles.has(path.normalize(path.join(tempDir, "_b.yml"))));
+	});
+
 	test("isRelevantYaml accepts canonical files and registered metadata files", async () => {
 		writeFile(path.join(tempDir, "_quarto.yml"), "metadata-files:\n  - _sidebar.yml\n");
 		await getMetadataFiles(tempDir);

--- a/src/utils/metadataFilesRegistry.ts
+++ b/src/utils/metadataFilesRegistry.ts
@@ -1,0 +1,346 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import * as yaml from "js-yaml";
+import { getErrorMessage } from "@quarto-wizard/core";
+import { isInside } from "./quartoProjectDiscovery";
+import { logMessage } from "./log";
+
+/**
+ * Per-project-root index of YAML files included via Quarto's `metadata-files:`
+ * key.  Sources scanned are `_quarto.{yml,yaml}`, `_metadata.{yml,yaml}`, and
+ * `.qmd` front-matter.  Inclusion is non-recursive: `metadata-files:` entries
+ * inside an already-included file are not followed.
+ */
+
+const QUARTO_AND_METADATA_PATTERN = "**/_{quarto,metadata}.{yml,yaml}";
+
+const QUARTO_AND_METADATA_FILENAMES: ReadonlySet<string> = new Set([
+	"_quarto.yml",
+	"_quarto.yaml",
+	"_metadata.yml",
+	"_metadata.yaml",
+]);
+
+interface RootState {
+	/** sourceFsPath -> absolute paths it contributes. */
+	contributions: Map<string, Set<string>>;
+	initialised: boolean;
+	inFlight?: Promise<void>;
+}
+
+const rootStates = new Map<string, RootState>();
+
+/** Reverse lookup: included absolute path -> project root that includes it. */
+const reverseIndex = new Map<string, string>();
+
+function getOrCreateState(projectRoot: string): RootState {
+	let state = rootStates.get(projectRoot);
+	if (!state) {
+		state = { contributions: new Map(), initialised: false };
+		rootStates.set(projectRoot, state);
+	}
+	return state;
+}
+
+function normalisePath(fsPath: string): string {
+	return path.normalize(fsPath);
+}
+
+function extractMetadataFiles(parsed: unknown, sourceDir: string): string[] {
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return [];
+	}
+	const value = (parsed as Record<string, unknown>)["metadata-files"];
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	const result: string[] = [];
+	for (const entry of value) {
+		if (typeof entry !== "string" || entry.length === 0) {
+			continue;
+		}
+		const resolved = path.isAbsolute(entry) ? entry : path.resolve(sourceDir, entry);
+		result.push(normalisePath(resolved));
+	}
+	return result;
+}
+
+function parseYamlText(text: string): unknown {
+	try {
+		return yaml.load(text);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Extract the YAML front-matter from a `.qmd` document text.  Returns null
+ * when no front-matter block is present.
+ */
+function extractFrontMatter(text: string): string | null {
+	const lines = text.split("\n");
+	if (lines.length === 0 || lines[0].trim() !== "---") {
+		return null;
+	}
+	for (let i = 1; i < lines.length; i++) {
+		if (lines[i].trim() === "---") {
+			return lines.slice(1, i).join("\n");
+		}
+	}
+	return null;
+}
+
+async function readSourceText(sourceFsPath: string): Promise<string | undefined> {
+	// Prefer the in-memory document so unsaved edits drive the registry.
+	for (const doc of vscode.workspace.textDocuments) {
+		if (doc.uri.scheme === "file" && normalisePath(doc.uri.fsPath) === normalisePath(sourceFsPath)) {
+			return doc.getText();
+		}
+	}
+	try {
+		const buffer = await vscode.workspace.fs.readFile(vscode.Uri.file(sourceFsPath));
+		return Buffer.from(buffer).toString("utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+function isQuartoOrMetadataYaml(fsPath: string): boolean {
+	return QUARTO_AND_METADATA_FILENAMES.has(path.basename(fsPath));
+}
+
+export function isQmdFile(fsPath: string): boolean {
+	return fsPath.toLowerCase().endsWith(".qmd");
+}
+
+function setsEqual(a: ReadonlySet<string> | undefined, b: ReadonlySet<string>): boolean {
+	if (a === undefined) {
+		return b.size === 0;
+	}
+	if (a.size !== b.size) {
+		return false;
+	}
+	for (const value of a) {
+		if (!b.has(value)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Returns true when the source's contributions changed.  Callers use the
+ * return value to skip downstream invalidations on no-op updates.
+ */
+function updateContributions(projectRoot: string, sourceFsPath: string, included: string[]): boolean {
+	const state = getOrCreateState(projectRoot);
+	const normalisedSource = normalisePath(sourceFsPath);
+	const previous = state.contributions.get(normalisedSource);
+	const next = new Set<string>(included);
+
+	if (setsEqual(previous, next)) {
+		return false;
+	}
+
+	if (previous) {
+		for (const prev of previous) {
+			if (reverseIndex.get(prev) !== projectRoot) {
+				continue;
+			}
+			// Only clear when no other source in the same root still includes it.
+			let stillIncluded = false;
+			for (const [otherSource, set] of state.contributions) {
+				if (otherSource !== normalisedSource && set.has(prev)) {
+					stillIncluded = true;
+					break;
+				}
+			}
+			if (!stillIncluded) {
+				reverseIndex.delete(prev);
+			}
+		}
+	}
+
+	if (next.size === 0) {
+		state.contributions.delete(normalisedSource);
+		return true;
+	}
+
+	state.contributions.set(normalisedSource, next);
+	for (const inc of next) {
+		// First writer wins; mixing roots is unusual but harmless.
+		if (!reverseIndex.has(inc)) {
+			reverseIndex.set(inc, projectRoot);
+		}
+	}
+	return true;
+}
+
+async function parseAndUpdateSource(projectRoot: string, sourceFsPath: string): Promise<boolean> {
+	const text = await readSourceText(sourceFsPath);
+	if (text === undefined) {
+		return updateContributions(projectRoot, sourceFsPath, []);
+	}
+
+	let parsed: unknown;
+	if (isQmdFile(sourceFsPath)) {
+		const front = extractFrontMatter(text);
+		if (!front) {
+			return updateContributions(projectRoot, sourceFsPath, []);
+		}
+		parsed = parseYamlText(front);
+	} else {
+		parsed = parseYamlText(text);
+	}
+
+	const included = extractMetadataFiles(parsed, path.dirname(sourceFsPath));
+	return updateContributions(projectRoot, sourceFsPath, included);
+}
+
+async function buildForRoot(projectRoot: string): Promise<void> {
+	const folderUri = vscode.Uri.file(projectRoot);
+	try {
+		const uris = await vscode.workspace.findFiles(
+			new vscode.RelativePattern(folderUri, QUARTO_AND_METADATA_PATTERN),
+			null,
+		);
+
+		const sources = new Set<string>();
+		for (const uri of uris) {
+			if (uri.scheme !== "file") {
+				continue;
+			}
+			sources.add(normalisePath(uri.fsPath));
+		}
+
+		// Pick up open .qmd docs inside this root.
+		for (const doc of vscode.workspace.textDocuments) {
+			if (doc.uri.scheme !== "file" || doc.isUntitled) {
+				continue;
+			}
+			if (!isQmdFile(doc.uri.fsPath)) {
+				continue;
+			}
+			if (!isInside(projectRoot, doc.uri.fsPath)) {
+				continue;
+			}
+			sources.add(normalisePath(doc.uri.fsPath));
+		}
+
+		await Promise.all([...sources].map((source) => parseAndUpdateSource(projectRoot, source)));
+	} catch (error) {
+		logMessage(`Failed to build metadata-files registry for ${projectRoot}: ${getErrorMessage(error)}.`, "warn");
+	}
+}
+
+/**
+ * Returns the absolute paths of all YAML files included via `metadata-files:`
+ * from sources within `projectRoot`.  Builds the registry lazily on first
+ * access and shares the in-flight promise across concurrent callers.
+ */
+export async function getMetadataFiles(projectRoot: string): Promise<Set<string>> {
+	const normalisedRoot = normalisePath(projectRoot);
+	const state = getOrCreateState(normalisedRoot);
+	if (state.initialised) {
+		return collectIncluded(state);
+	}
+	if (!state.inFlight) {
+		state.inFlight = buildForRoot(normalisedRoot)
+			.then(() => {
+				state.initialised = true;
+			})
+			.finally(() => {
+				state.inFlight = undefined;
+			});
+	}
+	await state.inFlight;
+	return collectIncluded(state);
+}
+
+function collectIncluded(state: RootState): Set<string> {
+	const result = new Set<string>();
+	for (const set of state.contributions.values()) {
+		for (const inc of set) {
+			result.add(inc);
+		}
+	}
+	return result;
+}
+
+/**
+ * Refresh the registry for a single source file.  Call on file system
+ * watcher events or `.qmd` saves.  When `sourceFsPath` no longer exists or
+ * no longer contains `metadata-files:`, its contributions are removed.
+ * Returns true when contributions changed so callers can skip downstream
+ * invalidations on no-op refreshes.
+ */
+export async function refreshSource(projectRoot: string, sourceFsPath: string): Promise<boolean> {
+	const normalisedRoot = normalisePath(projectRoot);
+	const state = getOrCreateState(normalisedRoot);
+	// Mark as initialised: subsequent getMetadataFiles must not trigger a full rebuild
+	// that would race against this targeted refresh.
+	state.initialised = true;
+	return parseAndUpdateSource(normalisedRoot, sourceFsPath);
+}
+
+/**
+ * Drop the registry for `projectRoot`, or for all roots when omitted.
+ */
+export function invalidateMetadataFiles(projectRoot?: string): void {
+	if (projectRoot === undefined) {
+		for (const [root, state] of rootStates) {
+			for (const set of state.contributions.values()) {
+				for (const inc of set) {
+					if (reverseIndex.get(inc) === root) {
+						reverseIndex.delete(inc);
+					}
+				}
+			}
+		}
+		rootStates.clear();
+		return;
+	}
+	const normalisedRoot = normalisePath(projectRoot);
+	const state = rootStates.get(normalisedRoot);
+	if (!state) {
+		return;
+	}
+	for (const set of state.contributions.values()) {
+		for (const inc of set) {
+			if (reverseIndex.get(inc) === normalisedRoot) {
+				reverseIndex.delete(inc);
+			}
+		}
+	}
+	rootStates.delete(normalisedRoot);
+}
+
+/**
+ * Synchronous lookup: returns the owning project root when `fsPath` has been
+ * registered as a metadata-files target, undefined otherwise.
+ */
+export function isRegisteredMetadataFile(fsPath: string): string | undefined {
+	return reverseIndex.get(normalisePath(fsPath));
+}
+
+/**
+ * Whether `document` is a Quarto YAML target eligible for schema-driven
+ * completion, diagnostics, and hover.  Returns true for `.qmd` documents,
+ * canonical `_quarto.*`/`_metadata.*` files, and any YAML registered as a
+ * `metadata-files:` target.
+ */
+export function isRelevantYaml(document: vscode.TextDocument): boolean {
+	if (document.languageId === "quarto" || document.fileName.toLowerCase().endsWith(".qmd")) {
+		return true;
+	}
+	if (document.languageId !== "yaml") {
+		return false;
+	}
+	if (isQuartoOrMetadataYaml(document.fileName)) {
+		return true;
+	}
+	if (document.uri.scheme !== "file") {
+		return false;
+	}
+	return isRegisteredMetadataFile(document.uri.fsPath) !== undefined;
+}

--- a/src/utils/metadataFilesRegistry.ts
+++ b/src/utils/metadataFilesRegistry.ts
@@ -277,6 +277,12 @@ function collectIncluded(state: RootState): Set<string> {
 export async function refreshSource(projectRoot: string, sourceFsPath: string): Promise<boolean> {
 	const normalisedRoot = normalisePath(projectRoot);
 	const state = getOrCreateState(normalisedRoot);
+	// Wait for any in-flight lazy build so its parsed contributions land first;
+	// otherwise this targeted refresh and the build can interleave mutations on
+	// `state.contributions` for the same source.
+	if (state.inFlight) {
+		await state.inFlight;
+	}
 	// Mark as initialised: subsequent getMetadataFiles must not trigger a full rebuild
 	// that would race against this targeted refresh.
 	state.initialised = true;


### PR DESCRIPTION
Quarto's `metadata-files:` key splits configuration across secondary YAML files declared in `_quarto.yml`, `_metadata.yml`, or `.qmd` front-matter. Those files previously received no key/value completion, schema validation, or hover docs because the YAML providers targeted hard-coded filenames only.

A per-project-root registry now parses `metadata-files:` from those three source kinds and exposes the resolved absolute paths. The YAML completion, diagnostics, and hover providers activate on any registered metadata-files target in addition to `_quarto.*`, `_metadata.*`, and `.qmd`. File system watchers and `.qmd` save/open listeners keep the registry in sync. Workspace-folder changes drop the cache for a lazy rebuild. Snippets remain scoped to `.qmd` documents.

The targeted refresh path waits for any in-flight lazy build of the same root before mutating contributions, and the activation-time prime logs registry init failures instead of swallowing them.