### PR TITLE
fix: Exempt math braces from inline attribute linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: do not flag spaces around `=` inside math such as `\text{X = Y}` as needing whitespace removal. Braces in LaTeX math are no longer treated as Pandoc attribute blocks, so inline attribute diagnostics only run in genuine attribute contexts (spans, links/images, code, divs, headers).
+
 ## 3.1.0 (2026-05-17)
 
 ### New Features

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import type { SchemaCache, FieldDescriptor, DeprecatedSpec, ShortcodeSchema } from "@quarto-wizard/schema";
 import { typeIncludes, formatType } from "@quarto-wizard/schema";
-import { parseAttributeAtPosition } from "../utils/elementAttributeParser";
+import { parseAttributeAtPosition, isPandocAttributeContext } from "../utils/elementAttributeParser";
 import { parseShortcodeAtPosition } from "../utils/shortcodeParser";
 import {
 	type ElementAttributeSchemas,
@@ -296,6 +296,13 @@ export function extractBlocks(text: string, codeBlockRanges?: TextRange[]): Bloc
 
 	for (const match of text.matchAll(ELEMENT_ATTRIBUTE_RE)) {
 		if (match.index === undefined) {
+			continue;
+		}
+		// Only treat the brace as an attribute block when it opens a genuine
+		// Pandoc attribute context (span, link/image, code, div, header).
+		// This excludes braces in math such as `\text{X = Y}` and discards
+		// most non-attribute braces before the costlier range overlap check.
+		if (isPandocAttributeContext(text, match.index) === null) {
 			continue;
 		}
 		if (overlapsExclusionRanges(fencedRanges, inlineRanges, match.index, match.index + match[0].length - 1)) {

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -762,6 +762,54 @@ suite("Inline Attribute Diagnostics", () => {
 		});
 	});
 
+	suite("extractBlocks (math)", () => {
+		test("should not extract a block from \\text{} in display math", () => {
+			const text = ["$$", "\\text{X = Y}", "$$"].join("\n");
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+
+		test("should not produce spaces-around-equals findings inside display math", () => {
+			const text = ["$$", "\\text{X = Y}", "$$"].join("\n");
+			const blocks = extractBlocks(text);
+			for (const block of blocks) {
+				assert.strictEqual(findSpacesAroundEquals(block.content).length, 0);
+			}
+		});
+
+		test("should not extract a block from \\frac{a = b}{c} in inline math", () => {
+			const text = "value $\\frac{a = b}{c}$ here";
+			const blocks = extractBlocks(text);
+			assert.strictEqual(blocks.length, 0);
+		});
+	});
+
+	suite("extractBlocks (attribute contexts)", () => {
+		test("should extract a span attribute block", () => {
+			const blocks = extractBlocks('[text]{.cls key = "v"}');
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, '.cls key = "v"');
+		});
+
+		test("should extract a div attribute block and flag spaces around =", () => {
+			const blocks = extractBlocks('::: {.panel key = "v"}\n\ncontent\n\n:::');
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(findSpacesAroundEquals(blocks[0].content).length, 1);
+		});
+
+		test("should extract a header attribute block", () => {
+			const blocks = extractBlocks('# Title {#id key = "v"}');
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(findSpacesAroundEquals(blocks[0].content).length, 1);
+		});
+
+		test("should extract a link attribute block", () => {
+			const blocks = extractBlocks("[text](url){.cls}");
+			assert.strictEqual(blocks.length, 1);
+			assert.strictEqual(blocks[0].content, ".cls");
+		});
+	});
+
 	suite("extractBareWords", () => {
 		test("should extract bare word from element content", () => {
 			const results = extractBareWords(".class myword");

--- a/src/utils/elementAttributeParser.ts
+++ b/src/utils/elementAttributeParser.ts
@@ -148,7 +148,7 @@ export function getAttributeBounds(
  *
  * @returns The element type, or null if the brace is not in a Pandoc attribute context.
  */
-function isPandocAttributeContext(text: string, bracePos: number): PandocElementType | null {
+export function isPandocAttributeContext(text: string, bracePos: number): PandocElementType | null {
 	if (bracePos === 0) {
 		return null;
 	}


### PR DESCRIPTION
The inline attribute diagnostics treated any `{...}` brace as a Pandoc attribute block, so LaTeX math such as `\text{X = Y}` triggered a false "Remove spaces around =" warning.

Element brace matches are now gated with `isPandocAttributeContext`, so the diagnostics only run when the brace opens a genuine attribute context (span, link/image, code, div, header). Braces in math and other non-attribute positions are skipped.

Closes #353