### PR TITLE
fix: make unknown attribute diagnostic opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: stop reporting valid attributes such as `width` on `.column` as `Unknown attribute` by default. The `schema-unknown-attribute` diagnostic is now opt-in via the new `quartoWizard.lint.unknownAttributes` setting (default `false`), since Quarto Wizard has no built-in schema for Quarto/Pandoc internals ([#356](https://github.com/mcanouil/quarto-wizard/issues/356)).
+
 ## 3.1.1 (2026-06-14)
 
 ### Bug Fixes

--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -81,6 +81,27 @@ URL to the Quarto extensions registry JSON file. Change this to use a custom reg
 }
 ```
 
+## Linting
+
+### Report Unknown Attributes
+
+**Setting**: `quartoWizard.lint.unknownAttributes`
+
+Report inline attributes not declared by any installed extension schema as `Unknown attribute`.
+Disabled by default: Quarto Wizard has no built-in schema for Quarto/Pandoc/revealjs internals (for example `width` on `.column`), so this would flag many valid attributes.
+Enable only when authoring against extensions whose `_schema.yml` declares a complete attribute set.
+
+| Property | Value   |
+| -------- | ------- |
+| Type     | Boolean |
+| Default  | `false` |
+
+```json
+{
+  "quartoWizard.lint.unknownAttributes": false
+}
+```
+
 ## Workspace vs User Settings
 
 All Quarto Wizard settings are scoped to "resource", meaning they can be configured at:
@@ -102,6 +123,7 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.update.crossSource": false,
   "quartoWizard.autoProjectDetection": subFolders,
   "quartoWizard.cache.ttlMinutes": 30,
-  "quartoWizard.registry.url": "https://m.canouil.dev/quarto-extensions/extensions.json"
+  "quartoWizard.registry.url": "https://m.canouil.dev/quarto-extensions/extensions.json",
+  "quartoWizard.lint.unknownAttributes": false
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,33 +15,33 @@
 				"@quarto-wizard/core": "*",
 				"@quarto-wizard/schema": "*",
 				"@quarto-wizard/snippets": "*",
-				"js-yaml": "^4.1.1",
-				"semver": "^7.8.0"
+				"js-yaml": "^4.2.0",
+				"semver": "^7.8.4"
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
 				"@types/js-yaml": "^4.0.9",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^25.8.0",
+				"@types/node": "^25.9.3",
 				"@types/semver": "^7.7.1",
 				"@types/vscode": "^1.96.0",
 				"@vscode/test-cli": "^0.0.12",
-				"@vscode/test-electron": "^2.5.2",
-				"@vscode/vsce": "^3.9.1",
-				"eslint": "^10.4.0",
+				"@vscode/test-electron": "^3.0.0",
+				"@vscode/vsce": "^3.9.2",
+				"eslint": "^10.5.0",
 				"eslint-formatter-unix": "^9.0.1",
 				"eslint-plugin-tsdoc": "^0.5.2",
 				"glob": "^13.0.6",
-				"lru-cache": "^11.3.6",
-				"mocha": "^11.7.5",
-				"prettier": "^3.8.3",
-				"ts-loader": "^9.5.7",
+				"lru-cache": "^11.5.1",
+				"mocha": "^11.7.6",
+				"prettier": "^3.8.4",
+				"ts-loader": "^9.6.0",
 				"typedoc": "^0.28.19",
-				"typedoc-plugin-markdown": "^4.11.0",
+				"typedoc-plugin-markdown": "^4.12.0",
 				"typescript": "^6.0.3",
-				"typescript-eslint": "^8.59.3",
-				"webpack": "^5.106.2",
-				"webpack-cli": "^7.0.2"
+				"typescript-eslint": "^8.61.1",
+				"webpack": "^5.107.2",
+				"webpack-cli": "^7.0.3"
 			},
 			"engines": {
 				"vscode": "^1.96.0"
@@ -316,9 +316,9 @@
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
-			"integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+			"integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -513,9 +513,9 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -694,14 +694,14 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
@@ -751,9 +751,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -784,9 +784,9 @@
 			"link": true
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
 			"cpu": [
 				"arm64"
 			],
@@ -801,9 +801,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -818,9 +818,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
 			"cpu": [
 				"x64"
 			],
@@ -835,9 +835,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
 			"cpu": [
 				"x64"
 			],
@@ -852,9 +852,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
 			"cpu": [
 				"arm"
 			],
@@ -869,13 +869,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -886,13 +889,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -903,13 +909,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -920,13 +929,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -937,13 +949,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -954,13 +969,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -971,9 +989,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -988,9 +1006,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1007,9 +1025,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1024,9 +1042,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
 			"cpu": [
 				"x64"
 			],
@@ -1385,16 +1403,6 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@types/archiver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
-			"integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/readdir-glob": "*"
-			}
-		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1412,28 +1420,6 @@
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/eslint": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*",
-				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
-			}
 		},
 		"node_modules/@types/esrecurse": {
 			"version": "4.3.1",
@@ -1488,9 +1474,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.8.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-			"integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+			"version": "25.9.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+			"integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1553,17 +1539,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-			"integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+			"integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/type-utils": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/type-utils": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1576,20 +1562,20 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.59.3",
+				"@typescript-eslint/parser": "^8.61.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1600,9 +1586,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1614,13 +1600,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1642,16 +1628,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1667,14 +1653,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1685,9 +1671,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1699,13 +1685,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1717,14 +1703,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+			"integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.59.3",
-				"@typescript-eslint/types": "^8.59.3",
+				"@typescript-eslint/tsconfig-utils": "^8.61.1",
+				"@typescript-eslint/types": "^8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1739,9 +1725,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1771,9 +1757,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+			"integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1788,15 +1774,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-			"integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+			"integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1813,9 +1799,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1841,16 +1827,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+			"integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.59.3",
-				"@typescript-eslint/tsconfig-utils": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3",
+				"@typescript-eslint/project-service": "8.61.1",
+				"@typescript-eslint/tsconfig-utils": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1869,9 +1855,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1883,13 +1869,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1940,16 +1926,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-			"integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+			"integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.59.3",
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3"
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1964,14 +1950,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
-				"@typescript-eslint/visitor-keys": "8.59.3"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1982,9 +1968,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1996,13 +1982,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -2047,14 +2033,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-			"integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.9",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -2068,8 +2054,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.6",
-				"vitest": "4.1.6"
+				"@vitest/browser": "4.1.9",
+				"vitest": "4.1.9"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -2078,16 +2064,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2096,13 +2082,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.6",
+				"@vitest/spy": "4.1.9",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -2123,9 +2109,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2136,13 +2122,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.9",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -2150,14 +2136,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -2166,9 +2152,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2176,13 +2162,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
+				"@vitest/pretty-format": "4.1.9",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2351,9 +2337,9 @@
 			}
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-			"integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
+			"integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2364,13 +2350,13 @@
 				"semver": "^7.6.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
-			"integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+			"integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2386,13 +2372,13 @@
 				"cockatiel": "^3.1.2",
 				"commander": "^12.1.0",
 				"form-data": "^4.0.0",
-				"glob": "^11.0.0",
+				"glob": "^13.0.6",
 				"hosted-git-info": "^4.0.2",
 				"jsonc-parser": "^3.2.0",
 				"leven": "^3.1.0",
 				"markdown-it": "^14.1.0",
 				"mime": "^1.3.4",
-				"minimatch": "^3.0.3",
+				"minimatch": "^10.2.2",
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
 				"secretlint": "^10.1.2",
@@ -2559,59 +2545,20 @@
 				"win32"
 			]
 		},
+		"node_modules/@vscode/vsce/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-			"integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@vscode/vsce/node_modules/glob": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"foreground-child": "^3.3.1",
-				"jackspeak": "^4.1.1",
-				"minimatch": "^10.1.1",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^2.0.0"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-			"integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jackspeak": "^4.2.3"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2621,33 +2568,20 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
-		"node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+		"node_modules/@vscode/vsce/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@vscode/vsce/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -3885,13 +3819,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4289,14 +4216,14 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+			"integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.3.0"
+				"tapable": "^2.3.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -4421,18 +4348,21 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+			"integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
 			"dev": true,
 			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
 				"@eslint/config-array": "^0.23.5",
 				"@eslint/config-helpers": "^0.6.0",
 				"@eslint/core": "^1.2.1",
-				"@eslint/plugin-kit": "^0.7.1",
+				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -4937,16 +4867,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/fastest-levenshtein": {
-			"version": "1.0.16",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.9.1"
-			}
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
@@ -5926,9 +5846,19 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -6338,6 +6268,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -6359,6 +6292,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -6380,6 +6316,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -6401,6 +6340,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -6467,9 +6409,9 @@
 			}
 		},
 		"node_modules/loader-runner": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-			"integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+			"integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6577,9 +6519,9 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -6816,9 +6758,9 @@
 			"optional": true
 		},
 		"node_modules/mocha": {
-			"version": "11.7.5",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-			"integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+			"version": "11.7.6",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+			"integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7210,15 +7152,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -7719,9 +7664,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -7739,7 +7684,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -7786,9 +7731,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -8119,13 +8064,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.130.0",
+				"@oxc-project/types": "=0.133.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -8135,21 +8080,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.1",
-				"@rolldown/binding-darwin-arm64": "1.0.1",
-				"@rolldown/binding-darwin-x64": "1.0.1",
-				"@rolldown/binding-freebsd-x64": "1.0.1",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
-				"@rolldown/binding-linux-arm64-musl": "1.0.1",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-musl": "1.0.1",
-				"@rolldown/binding-openharmony-arm64": "1.0.1",
-				"@rolldown/binding-wasm32-wasi": "1.0.1",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
-				"@rolldown/binding-win32-x64-msvc": "1.0.1"
+				"@rolldown/binding-android-arm64": "1.0.3",
+				"@rolldown/binding-darwin-arm64": "1.0.3",
+				"@rolldown/binding-darwin-x64": "1.0.3",
+				"@rolldown/binding-freebsd-x64": "1.0.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
+				"@rolldown/binding-linux-arm64-musl": "1.0.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-musl": "1.0.3",
+				"@rolldown/binding-openharmony-arm64": "1.0.3",
+				"@rolldown/binding-wasm32-wasi": "1.0.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
+				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
 		"node_modules/run-applescript": {
@@ -8270,9 +8215,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -8873,9 +8818,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8884,22 +8829,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/tar": {
-			"version": "7.5.15",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/tar-fs": {
@@ -9007,9 +8936,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-			"integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9029,10 +8958,37 @@
 				"webpack": "^5.1.0"
 			},
 			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
 				"@swc/core": {
 					"optional": true
 				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
 				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
 					"optional": true
 				},
 				"uglify-js": {
@@ -9294,9 +9250,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9304,9 +9260,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9398,9 +9354,9 @@
 			}
 		},
 		"node_modules/ts-loader": {
-			"version": "9.5.7",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
-			"integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.6.0.tgz",
+			"integrity": "sha512-dsJO0S+T7grTDWTc4a0nTygXGjKncVUpx8Y+af8EvI/D5WgTJby5UEk5eoMCB9EcLQmnvitqh99MqtjtHgAwFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9414,8 +9370,14 @@
 				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
+				"loader-utils": "*",
 				"typescript": "*",
-				"webpack": "^5.0.0"
+				"webpack": "^4.0.0 || ^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"loader-utils": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tslib": {
@@ -9512,9 +9474,9 @@
 			}
 		},
 		"node_modules/typedoc-plugin-markdown": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz",
-			"integrity": "sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.12.0.tgz",
+			"integrity": "sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9578,16 +9540,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.59.3",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-			"integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+			"integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.59.3",
-				"@typescript-eslint/parser": "8.59.3",
-				"@typescript-eslint/typescript-estree": "8.59.3",
-				"@typescript-eslint/utils": "8.59.3"
+				"@typescript-eslint/eslint-plugin": "8.61.1",
+				"@typescript-eslint/parser": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9771,17 +9733,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.13",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+			"version": "8.0.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.14",
-				"rolldown": "1.0.1",
-				"tinyglobby": "^0.2.16"
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.3",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -9862,19 +9824,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.6",
-				"@vitest/mocker": "4.1.6",
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/runner": "4.1.6",
-				"@vitest/snapshot": "4.1.6",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -9902,12 +9864,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.6",
-				"@vitest/browser-preview": "4.1.6",
-				"@vitest/browser-webdriverio": "4.1.6",
-				"@vitest/coverage-istanbul": "4.1.6",
-				"@vitest/coverage-v8": "4.1.6",
-				"@vitest/ui": "4.1.6",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9979,13 +9941,12 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.106.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-			"integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+			"version": "5.107.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+			"integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
@@ -9995,20 +9956,20 @@
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.20.0",
-				"es-module-lexer": "^2.0.0",
+				"enhanced-resolve": "^5.22.0",
+				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"loader-runner": "^4.3.1",
+				"loader-runner": "^4.3.2",
 				"mime-db": "^1.54.0",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.17",
+				"terser-webpack-plugin": "^5.5.0",
 				"watchpack": "^2.5.1",
-				"webpack-sources": "^3.3.4"
+				"webpack-sources": "^3.5.0"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -10027,17 +9988,16 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
-			"integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.3.tgz",
+			"integrity": "sha512-2E2C6A1e2El7791zQgTH7LPIuwLjRliow9OHS/qlJc9pwhZlCoL/uiwqd/1WSlXT83wJfmfDbkcqHXuXoPJZ3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@discoveryjs/json-ext": "^1.0.0",
+				"@discoveryjs/json-ext": "^1.1.0",
 				"commander": "^14.0.3",
 				"cross-spawn": "^7.0.6",
 				"envinfo": "^7.14.0",
-				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
 				"interpret": "^3.1.1",
 				"rechoir": "^0.8.0",
@@ -10093,9 +10053,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+			"integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10487,30 +10447,40 @@
 		},
 		"packages/core": {
 			"name": "@quarto-wizard/core",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"glob": "^13.0.6",
-				"js-yaml": "^4.1.1",
+				"js-yaml": "^4.2.0",
 				"minimatch": "^10.2.5",
-				"semver": "^7.8.0",
-				"tar": "^7.5.15",
-				"undici": "^8.3.0",
+				"semver": "^7.8.4",
+				"tar": "7.5.15",
+				"undici": "^8.5.0",
 				"unzipper": "^0.12.3"
 			},
 			"devDependencies": {
 				"@types/archiver": "^7.0.0",
 				"@types/js-yaml": "^4.0.9",
-				"@types/node": "^25.8.0",
+				"@types/node": "^25.9.3",
 				"@types/semver": "^7.7.1",
 				"@types/unzipper": "^0.10.11",
-				"@vitest/coverage-v8": "^4.1.6",
+				"@vitest/coverage-v8": "^4.1.9",
 				"archiver": "^7.0.1",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.6"
+				"vitest": "^4.1.9"
 			},
 			"engines": {
 				"node": ">=25.0.0"
+			}
+		},
+		"packages/core/node_modules/@types/archiver": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+			"integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/readdir-glob": "*"
 			}
 		},
 		"packages/core/node_modules/archiver": {
@@ -10655,10 +10625,26 @@
 				"node": ">=10"
 			}
 		},
+		"packages/core/node_modules/tar": {
+			"version": "7.5.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+			"integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"packages/core/node_modules/undici": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-			"integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"
@@ -10681,17 +10667,17 @@
 		},
 		"packages/schema": {
 			"name": "@quarto-wizard/schema",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"license": "MIT",
 			"dependencies": {
-				"js-yaml": "^4.1.1"
+				"js-yaml": "^4.2.0"
 			},
 			"devDependencies": {
 				"@types/js-yaml": "^4.0.9",
-				"@types/node": "^25.8.0",
-				"@vitest/coverage-v8": "^4.1.6",
+				"@types/node": "^25.9.3",
+				"@vitest/coverage-v8": "^4.1.9",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.6"
+				"vitest": "^4.1.9"
 			},
 			"engines": {
 				"node": ">=25.0.0"
@@ -10699,13 +10685,13 @@
 		},
 		"packages/snippets": {
 			"name": "@quarto-wizard/snippets",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"license": "MIT",
 			"devDependencies": {
-				"@types/node": "^25.8.0",
-				"@vitest/coverage-v8": "^4.1.6",
+				"@types/node": "^25.9.3",
+				"@vitest/coverage-v8": "^4.1.9",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.6"
+				"vitest": "^4.1.9"
 			},
 			"engines": {
 				"node": ">=25.0.0"

--- a/package.json
+++ b/package.json
@@ -83,39 +83,39 @@
 		"docs:preview": "npm run docs:api && cd docs && quarto preview",
 		"docs:clean": "rm -rf docs/api docs/_site",
 		"docs:format": "prettier --write \"docs/**/*.{qmd,yml}\"",
-		"update:deps": "npx npm-check-updates -u --reject @types/vscode,archiver --workspaces --root && npm install"
+		"update:deps": "npx npm-check-updates -u --reject @types/vscode,archiver,@types/archiver,tar --workspaces --root && npm install"
 	},
 	"dependencies": {
 		"@quarto-wizard/core": "*",
 		"@quarto-wizard/schema": "*",
 		"@quarto-wizard/snippets": "*",
-		"js-yaml": "^4.1.1",
-		"semver": "^7.8.0"
+		"js-yaml": "^4.2.0",
+		"semver": "^7.8.4"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
 		"@types/mocha": "^10.0.10",
 		"@types/js-yaml": "^4.0.9",
-		"@types/node": "^25.8.0",
+		"@types/node": "^25.9.3",
 		"@types/semver": "^7.7.1",
 		"@types/vscode": "^1.96.0",
 		"@vscode/test-cli": "^0.0.12",
-		"@vscode/test-electron": "^2.5.2",
-		"@vscode/vsce": "^3.9.1",
-		"eslint": "^10.4.0",
+		"@vscode/test-electron": "^3.0.0",
+		"@vscode/vsce": "^3.9.2",
+		"eslint": "^10.5.0",
 		"eslint-formatter-unix": "^9.0.1",
 		"eslint-plugin-tsdoc": "^0.5.2",
 		"glob": "^13.0.6",
-		"lru-cache": "^11.3.6",
-		"mocha": "^11.7.5",
-		"prettier": "^3.8.3",
-		"ts-loader": "^9.5.7",
+		"lru-cache": "^11.5.1",
+		"mocha": "^11.7.6",
+		"prettier": "^3.8.4",
+		"ts-loader": "^9.6.0",
 		"typedoc": "^0.28.19",
-		"typedoc-plugin-markdown": "^4.11.0",
+		"typedoc-plugin-markdown": "^4.12.0",
 		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.59.3",
-		"webpack": "^5.106.2",
-		"webpack-cli": "^7.0.2"
+		"typescript-eslint": "^8.61.1",
+		"webpack": "^5.107.2",
+		"webpack-cli": "^7.0.3"
 	},
 	"contributes": {
 		"commands": [

--- a/package.json
+++ b/package.json
@@ -713,6 +713,15 @@
 					"markdownDescription": "URL to the Quarto extensions registry JSON file. Change this to use a custom registry. See [`RawRegistryEntry`](https://m.canouil.dev/quarto-wizard/api/core/types.html#rawregistryentry) in the API reference for the expected JSON schema.",
 					"title": "Registry URL",
 					"description": "Custom registry URL."
+				},
+				"quartoWizard.lint.unknownAttributes": {
+					"order": 12,
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Report inline attributes not declared by any installed extension schema as `Unknown attribute`. Disabled by default: Quarto Wizard has no built-in schema for Quarto/Pandoc/revealjs internals (for example `width` on `.column`), so this would flag many valid attributes. Enable only when authoring against extensions whose `_schema.yml` declares a complete attribute set.",
+					"title": "Report Unknown Attributes",
+					"description": "Flag inline attributes absent from extension schemas."
 				}
 			}
 		}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,23 +33,23 @@
 	},
 	"dependencies": {
 		"glob": "^13.0.6",
-		"js-yaml": "^4.1.1",
+		"js-yaml": "^4.2.0",
 		"minimatch": "^10.2.5",
-		"semver": "^7.8.0",
-		"tar": "^7.5.15",
-		"undici": "^8.3.0",
+		"semver": "^7.8.4",
+		"tar": "7.5.15",
+		"undici": "^8.5.0",
 		"unzipper": "^0.12.3"
 	},
 	"devDependencies": {
 		"@types/archiver": "^7.0.0",
 		"@types/js-yaml": "^4.0.9",
-		"@types/node": "^25.8.0",
+		"@types/node": "^25.9.3",
 		"@types/semver": "^7.7.1",
 		"@types/unzipper": "^0.10.11",
-		"@vitest/coverage-v8": "^4.1.6",
+		"@vitest/coverage-v8": "^4.1.9",
 		"archiver": "^7.0.1",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.6"
+		"vitest": "^4.1.9"
 	},
 	"engines": {
 		"node": ">=25.0.0"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -32,14 +32,14 @@
 		"directory": "packages/schema"
 	},
 	"dependencies": {
-		"js-yaml": "^4.1.1"
+		"js-yaml": "^4.2.0"
 	},
 	"devDependencies": {
 		"@types/js-yaml": "^4.0.9",
-		"@types/node": "^25.8.0",
-		"@vitest/coverage-v8": "^4.1.6",
+		"@types/node": "^25.9.3",
+		"@vitest/coverage-v8": "^4.1.9",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.6"
+		"vitest": "^4.1.9"
 	},
 	"engines": {
 		"node": ">=25.0.0"

--- a/packages/snippets/package.json
+++ b/packages/snippets/package.json
@@ -32,10 +32,10 @@
 		"directory": "packages/snippets"
 	},
 	"devDependencies": {
-		"@types/node": "^25.8.0",
-		"@vitest/coverage-v8": "^4.1.6",
+		"@types/node": "^25.9.3",
+		"@vitest/coverage-v8": "^4.1.9",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.6"
+		"vitest": "^4.1.9"
 	},
 	"engines": {
 		"node": ">=25.0.0"

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -918,7 +918,20 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 			}),
 		);
 
+		// Re-validate open documents when a lint setting is toggled.
+		this.disposables.push(
+			vscode.workspace.onDidChangeConfiguration((event) => {
+				if (event.affectsConfiguration("quartoWizard.lint")) {
+					this.revalidateOpenDocuments();
+				}
+			}),
+		);
+
 		// Validate all open relevant documents on activation.
+		this.revalidateOpenDocuments();
+	}
+
+	private revalidateOpenDocuments(): void {
 		for (const document of vscode.workspace.textDocuments) {
 			if (this.isRelevantDocument(document)) {
 				this.validateDocument(document);
@@ -996,9 +1009,20 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 			const hasShortcodeSchemas = shortcodeSchemas.size > 0;
 
 			if (hasElementSchemas || hasShortcodeSchemas) {
+				const reportUnknown = vscode.workspace
+					.getConfiguration("quartoWizard.lint", document.uri)
+					.get<boolean>("unknownAttributes", false);
 				for (const block of blocks) {
 					if (block.type === "element" && hasElementSchemas) {
-						this.validateElementBlock(block, text, elementSchemas, document, diagnostics, codeBlockRanges);
+						this.validateElementBlock(
+							block,
+							text,
+							elementSchemas,
+							document,
+							diagnostics,
+							codeBlockRanges,
+							reportUnknown,
+						);
 					} else if (block.type === "shortcode" && hasShortcodeSchemas) {
 						this.validateShortcodeBlock(block, text, shortcodeSchemas, document, diagnostics, codeBlockRanges);
 					}
@@ -1026,6 +1050,7 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 		document: vscode.TextDocument,
 		diagnostics: vscode.Diagnostic[],
 		codeBlockRanges: TextRange[],
+		reportUnknown: boolean,
 	): void {
 		// Use the parser as a context filter: the offset just inside the closing `}`.
 		const blockEndOffset = block.contentOffset + block.content.length;
@@ -1064,7 +1089,10 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 		for (const [key, value] of Object.entries(parsed.attributes)) {
 			const entry = resolveElementAttribute(applicable, key);
 			if (!entry) {
-				// Unknown attribute.
+				if (!reportUnknown) {
+					continue;
+				}
+				// Unknown attribute (opt-in via quartoWizard.lint.unknownAttributes).
 				const kv = findKeyValueOffset(block.content, key);
 				if (kv) {
 					const absStart = block.contentOffset + kv.keyStart;


### PR DESCRIPTION
The inline attribute linter validated attributes against an allow-list built only from installed extension `_schema.yml` files. Quarto Wizard ships no schema for Quarto, Pandoc, or revealjs internals, so valid attributes such as `width` on `.column` were reported as `Unknown attribute` whenever an installed extension contributed an `attributes._any` block.

The `schema-unknown-attribute` diagnostic is now gated behind a new `quartoWizard.lint.unknownAttributes` setting, disabled by default. With the default, unknown attributes are ignored; enabling the setting restores the diagnostic for authors working against extensions that declare a complete attribute set. Open documents re-validate when the setting changes.

Also updates dependencies to their latest compatible versions. `tar` is held at 7.5.15 because 7.5.16 emits an unhandled `Z_STREAM_ERROR` when an extraction is aborted mid-stream, and `@types/archiver` is held at v7 to match the v7 `archiver` runtime; both are added to the `update:deps` reject list.

Closes #356