### PR TITLE
fix: abort URI-triggered install when dialog is dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- fix: stop installing the extension when the confirmation dialog opened by a `vscode://mcanouil.quarto-wizard/install` or `/use` link is dismissed. Cancelling the dialog, or pressing <kbd>Esc</kbd>, now aborts the operation as intended. The dialog no longer shows a redundant "No" button alongside the built-in Cancel.
+- fix: stop installing the extension when the confirmation dialog opened by a `vscode://mcanouil.quarto-wizard/install` or `/use` link is dismissed. Cancelling the dialog, or pressing <kbd>Esc</kbd>, now aborts the operation as intended. The dialog no longer shows a redundant "No" button alongside the built-in Cancel, and it now states the destination folder so the target of the install is visible before confirming.
 
 ## 3.1.2 (2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: stop installing the extension when the confirmation dialog opened by a `vscode://mcanouil.quarto-wizard/install` or `/use` link is dismissed. Cancelling the dialog, or pressing <kbd>Esc</kbd>, now aborts the operation as intended. The dialog no longer shows a redundant "No" button alongside the built-in Cancel.
+
 ## 3.1.2 (2026-06-16)
 
 ### Bug Fixes

--- a/src/test/suite/handleUri.test.ts
+++ b/src/test/suite/handleUri.test.ts
@@ -3,18 +3,18 @@ import * as vscode from "vscode";
 import { confirmUriAction } from "../../utils/handleUri";
 
 suite("Handle URI Test Suite", () => {
-	let originalShowInformationMessage: typeof vscode.window.showInformationMessage;
+	let originalShowWarningMessage: typeof vscode.window.showWarningMessage;
 
 	let dialogResult: string | undefined;
 	let dialogCalls: { message: string; options: vscode.MessageOptions; items: string[] }[];
 
 	setup(() => {
-		originalShowInformationMessage = vscode.window.showInformationMessage;
+		originalShowWarningMessage = vscode.window.showWarningMessage;
 
 		dialogResult = undefined;
 		dialogCalls = [];
 
-		Object.defineProperty(vscode.window, "showInformationMessage", {
+		Object.defineProperty(vscode.window, "showWarningMessage", {
 			value: async (message: string, options: vscode.MessageOptions, ...items: string[]) => {
 				dialogCalls.push({ message, options, items });
 				return dialogResult;
@@ -25,8 +25,8 @@ suite("Handle URI Test Suite", () => {
 	});
 
 	teardown(() => {
-		Object.defineProperty(vscode.window, "showInformationMessage", {
-			value: originalShowInformationMessage,
+		Object.defineProperty(vscode.window, "showWarningMessage", {
+			value: originalShowWarningMessage,
 			writable: true,
 			configurable: true,
 		});
@@ -36,7 +36,7 @@ suite("Handle URI Test Suite", () => {
 		test("Should return true when the user selects 'Yes'", async () => {
 			dialogResult = "Yes";
 
-			const result = await confirmUriAction("Do you confirm?");
+			const result = await confirmUriAction("Do you confirm?", "/workspace");
 
 			assert.strictEqual(result, true);
 		});
@@ -44,7 +44,7 @@ suite("Handle URI Test Suite", () => {
 		test("Should return false when the user dismisses the dialog with Cancel or Esc", async () => {
 			dialogResult = undefined;
 
-			const result = await confirmUriAction("Do you confirm?");
+			const result = await confirmUriAction("Do you confirm?", "/workspace");
 
 			assert.strictEqual(result, false);
 		});
@@ -52,7 +52,7 @@ suite("Handle URI Test Suite", () => {
 		test("Should return false for any other response", async () => {
 			dialogResult = "No";
 
-			const result = await confirmUriAction("Do you confirm?");
+			const result = await confirmUriAction("Do you confirm?", "/workspace");
 
 			assert.strictEqual(result, false);
 		});
@@ -60,12 +60,20 @@ suite("Handle URI Test Suite", () => {
 		test("Should show a modal dialog with a single 'Yes' item", async () => {
 			dialogResult = "Yes";
 
-			await confirmUriAction("Do you confirm?");
+			await confirmUriAction("Do you confirm?", "/workspace");
 
 			assert.strictEqual(dialogCalls.length, 1);
 			assert.strictEqual(dialogCalls[0].message, "Do you confirm?");
 			assert.strictEqual(dialogCalls[0].options.modal, true);
 			assert.deepStrictEqual(dialogCalls[0].items, ["Yes"]);
+		});
+
+		test("Should show the destination folder in the dialog detail", async () => {
+			dialogResult = "Yes";
+
+			await confirmUriAction("Do you confirm?", "/home/user/my-project");
+
+			assert.strictEqual(dialogCalls[0].options.detail, "Destination: /home/user/my-project");
 		});
 	});
 });

--- a/src/test/suite/handleUri.test.ts
+++ b/src/test/suite/handleUri.test.ts
@@ -1,0 +1,71 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { confirmUriAction } from "../../utils/handleUri";
+
+suite("Handle URI Test Suite", () => {
+	let originalShowInformationMessage: typeof vscode.window.showInformationMessage;
+
+	let dialogResult: string | undefined;
+	let dialogCalls: { message: string; options: vscode.MessageOptions; items: string[] }[];
+
+	setup(() => {
+		originalShowInformationMessage = vscode.window.showInformationMessage;
+
+		dialogResult = undefined;
+		dialogCalls = [];
+
+		Object.defineProperty(vscode.window, "showInformationMessage", {
+			value: async (message: string, options: vscode.MessageOptions, ...items: string[]) => {
+				dialogCalls.push({ message, options, items });
+				return dialogResult;
+			},
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	teardown(() => {
+		Object.defineProperty(vscode.window, "showInformationMessage", {
+			value: originalShowInformationMessage,
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	suite("confirmUriAction", () => {
+		test("Should return true when the user selects 'Yes'", async () => {
+			dialogResult = "Yes";
+
+			const result = await confirmUriAction("Do you confirm?");
+
+			assert.strictEqual(result, true);
+		});
+
+		test("Should return false when the user dismisses the dialog with Cancel or Esc", async () => {
+			dialogResult = undefined;
+
+			const result = await confirmUriAction("Do you confirm?");
+
+			assert.strictEqual(result, false);
+		});
+
+		test("Should return false for any other response", async () => {
+			dialogResult = "No";
+
+			const result = await confirmUriAction("Do you confirm?");
+
+			assert.strictEqual(result, false);
+		});
+
+		test("Should show a modal dialog with a single 'Yes' item", async () => {
+			dialogResult = "Yes";
+
+			await confirmUriAction("Do you confirm?");
+
+			assert.strictEqual(dialogCalls.length, 1);
+			assert.strictEqual(dialogCalls[0].message, "Do you confirm?");
+			assert.strictEqual(dialogCalls[0].options.modal, true);
+			assert.deepStrictEqual(dialogCalls[0].items, ["Yes"]);
+		});
+	});
+});

--- a/src/utils/handleUri.ts
+++ b/src/utils/handleUri.ts
@@ -26,6 +26,20 @@ interface UriActionConfig {
 }
 
 /**
+ * Prompts the user with a modal confirmation for a URI-triggered action.
+ *
+ * VS Code adds its own Cancel button to modal dialogs, so only an explicit
+ * "Yes" confirms; Cancel and Esc both resolve to `undefined` and abort.
+ *
+ * @param message - The confirmation message to display.
+ * @returns A Promise that resolves to true only when the user confirms.
+ */
+export async function confirmUriAction(message: string): Promise<boolean> {
+	const response = await vscode.window.showInformationMessage(message, { modal: true }, "Yes");
+	return response === "Yes";
+}
+
+/**
  * Common handler for URI-based actions.
  * Extracts repo from URI, prompts for workspace folder, confirms action, and executes.
  *
@@ -51,14 +65,7 @@ async function handleUriAction(
 		return;
 	}
 
-	const confirmed = await vscode.window.showInformationMessage(
-		config.confirmMessage(repo),
-		{ modal: true },
-		"Yes",
-		"No",
-	);
-
-	if (confirmed === "No") {
+	if (!(await confirmUriAction(config.confirmMessage(repo)))) {
 		const message = "Operation cancelled by the user.";
 		logMessage(message, "info");
 		showMessageWithLogs(message, "info");

--- a/src/utils/handleUri.ts
+++ b/src/utils/handleUri.ts
@@ -28,14 +28,21 @@ interface UriActionConfig {
 /**
  * Prompts the user with a modal confirmation for a URI-triggered action.
  *
- * VS Code adds its own Cancel button to modal dialogs, so only an explicit
- * "Yes" confirms; Cancel and Esc both resolve to `undefined` and abort.
+ * A URI can be triggered from any web page, so this dialog is the only consent
+ * gate before an extension is downloaded into the workspace. VS Code adds its
+ * own Cancel button to modal dialogs, so only an explicit "Yes" confirms;
+ * Cancel and Esc both resolve to `undefined` and abort.
  *
  * @param message - The confirmation message to display.
+ * @param workspaceFolder - The folder the action would write to.
  * @returns A Promise that resolves to true only when the user confirms.
  */
-export async function confirmUriAction(message: string): Promise<boolean> {
-	const response = await vscode.window.showInformationMessage(message, { modal: true }, "Yes");
+export async function confirmUriAction(message: string, workspaceFolder: string): Promise<boolean> {
+	const response = await vscode.window.showWarningMessage(
+		message,
+		{ modal: true, detail: `Destination: ${workspaceFolder}` },
+		"Yes",
+	);
 	return response === "Yes";
 }
 
@@ -65,7 +72,7 @@ async function handleUriAction(
 		return;
 	}
 
-	if (!(await confirmUriAction(config.confirmMessage(repo)))) {
+	if (!(await confirmUriAction(config.confirmMessage(repo), workspaceFolder))) {
 		const message = "Operation cancelled by the user.";
 		logMessage(message, "info");
 		showMessageWithLogs(message, "info");


### PR DESCRIPTION
The modal confirmation shown for `vscode://mcanouil.quarto-wizard/install?repo=owner/name` and `vscode://mcanouil.quarto-wizard/use?repo=owner/name` links tested for its "No" button only. VS Code adds its own Cancel button to modal dialogs, so the dialog actually rendered Yes, No and Cancel, and both Cancel and Esc resolved to `undefined`. That fell through the check and installed the extension anyway. Only the explicit "No" button aborted.

The confirmation is now affirmative: `confirmUriAction` returns true only for an explicit "Yes", so every dismissal path aborts, logs `Operation cancelled by the user.` and notifies the user. The redundant "No" button is gone, leaving "Yes" and the built-in Cancel, matching the other modals in the extension.

Since a URI can be triggered from any web page, this dialog is the only consent gate before an extension is downloaded into the workspace. It now uses a warning dialog like the other consequential modals, and states the destination folder the extension would be written to.

Both `handleUriInstall` and `handleUriUse` are covered, as they share `handleUriAction`.

New tests in `src/test/suite/handleUri.test.ts` cover the confirming, dismissed and other-response cases, the dialog shape, and the destination detail. The dismissed case fails against the previous logic.