### PR TITLE
fix: treat the root _extensions directory as the primary host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: treat the workspace folder's `_extensions/` as the primary host. When the folder itself holds at least one installed extension, it is now the only install, update, template and brand target, and the only entry in the Extensions Installed view. Subfolders are no longer offered, so an extension development repository can no longer install into a copy such as `docs/_extensions/`. This already happened by accident for `quartoWizard.autoProjectDetection` set to `true` or `subFolders`; it now also holds for `openEditors`, and for workspaces that exclude `_extensions` through `files.exclude` or `search.exclude`.
+- fix: skip paths matched by the workspace folder's `.quartoignore` when detecting Quarto project roots. Listing `docs` there keeps a documentation website out of the Extensions Installed view and out of the folder pickers.
+- fix: apply the same two rules to the source side of an installation. When a downloaded repository has extensions in its own `_extensions/`, copies found elsewhere in the archive, typically the vendored `docs/_extensions/` of a documentation site, are no longer offered. Installing such a repository no longer opens a "This repository contains multiple extensions" picker when the repository ships a single extension. Paths matched by the repository's `.quartoignore` are dropped as well. Neither rule can empty the list, so an archive that only ships extensions in ignored locations still installs.
+
+### Dependency Updates
+
+- chore(deps): upgrade `@vscode/test-electron` from 3.0.0 to 3.1.0. VS Code 1.131 dropped the `Contents/MacOS/Electron` alias from its macOS bundle, which made the test suite fail with `spawn .../Contents/MacOS/Electron ENOENT`.
+
 ## 3.1.3 (2026-07-24)
 
 ### Dependency Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - fix: skip paths matched by the workspace folder's `.quartoignore` when detecting Quarto project roots. Listing `docs` there keeps a documentation website out of the Extensions Installed view and out of the folder pickers.
 - fix: apply the same two rules to the source side of an installation. When a downloaded repository has extensions in its own `_extensions/`, copies found elsewhere in the archive, typically the vendored `docs/_extensions/` of a documentation site, are no longer offered. Installing such a repository no longer opens a "This repository contains multiple extensions" picker when the repository ships a single extension. Paths matched by the repository's `.quartoignore` are dropped as well. Neither rule can empty the list, so an archive that only ships extensions in ignored locations still installs.
 
+### Internal
+
+- test: build the link-rejection tar fixtures byte by byte instead of archiving a real link with node-tar, whose writer emits a late unhandled stream error when it walks a hard link. That error failed the suite intermittently (6 of 15 local runs, and the macOS CI job). The fixtures no longer skip themselves on platforms without link support.
+
 ### Dependency Updates
 
 - chore(deps): upgrade `@vscode/test-electron` from 3.0.0 to 3.1.0. VS Code 1.131 dropped the `Contents/MacOS/Electron` alias from its macOS bundle, which made the test suite fail with `spawn .../Contents/MacOS/Electron ENOENT`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: start files and directories matched by a template repository's `.quartoignore` unselected in the file picker shown by **Use Template**. They stay in the list and can be ticked back on; the ignore file states an intent, not a prohibition. When no picker is involved, they are excluded outright, matching `quarto use template`.
+
 ### Bug Fixes
 
 - fix: treat the workspace folder's `_extensions/` as the primary host. When the folder itself holds at least one installed extension, it is now the only install, update, template and brand target, and the only entry in the Extensions Installed view. Subfolders are no longer offered, so an extension development repository can no longer install into a copy such as `docs/_extensions/`. This already happened by accident for `quartoWizard.autoProjectDetection` set to `true` or `subFolders`; it now also holds for `openEditors`, and for workspaces that exclude `_extensions` through `files.exclude` or `search.exclude`.

--- a/docs/getting-started/using-templates.qmd
+++ b/docs/getting-started/using-templates.qmd
@@ -135,6 +135,7 @@ Templates typically include:
 ::: {.callout-note}
 The "Use Template" command retrieves all files from the template repository and allows you to select which ones to copy.
 Common repository files (such as README, LICENSE, and Git configuration) are excluded by default, but you can include them if needed.
+Anything listed in the template repository's `.quartoignore` starts unselected as well, so a documentation website or a scratch directory is not copied unless you tick it back on.
 :::
 
 ## Recently Used Templates

--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -41,6 +41,34 @@ Ask for confirmation before installing an extension. `ask` to ask for confirmati
 }
 ```
 
+## Project Detection
+
+### Auto Project Detection
+
+**Setting**: `quartoWizard.autoProjectDetection`
+
+When to look for Quarto project roots inside a workspace folder.
+A folder qualifies as a root when it contains `_quarto.yml`/`_quarto.yaml`, or an `_extensions/` directory holding at least one installed extension.
+Detected roots feed the Extensions Installed view and every command that needs a target folder.
+
+| Value         | Description                                               |
+| ------------- | --------------------------------------------------------- |
+| `subFolders`  | Scan direct subfolders of the workspace folder (default). |
+| `true`        | Scan recursively through all nested subfolders.           |
+| `openEditors` | Scan the parent folders of open files.                    |
+| `false`       | Disable scanning; the workspace folder is the only root.  |
+
+Two rules apply whatever the value:
+
+- **The root `_extensions/` wins.** When the workspace folder itself has an `_extensions/` directory with at least one installed extension, that folder is the only root, and no subfolder is offered as a separate target. Quarto resolves extensions by walking up from the document being rendered, so a populated `_extensions/` at the root already serves every document below it. This keeps installs and updates out of places such as the `docs/_extensions/` copy in an extension development repository.
+- **`.quartoignore` is honoured.** Paths matched by the workspace folder's `.quartoignore` are never detected as roots. Listing `docs` there keeps a documentation website out of the picture even when it ships its own `_quarto.yml` and `_extensions/`.
+
+```json
+{
+  "quartoWizard.autoProjectDetection": "subFolders"
+}
+```
+
 ## Cache Settings
 
 ### Cache Duration
@@ -100,7 +128,7 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.ask.trustAuthors": "ask",
   "quartoWizard.ask.confirmInstall": "ask",
   "quartoWizard.update.crossSource": false,
-  "quartoWizard.autoProjectDetection": subFolders,
+  "quartoWizard.autoProjectDetection": "subFolders",
   "quartoWizard.cache.ttlMinutes": 30,
   "quartoWizard.registry.url": "https://m.canouil.dev/quarto-extensions/extensions.json",
   "quartoWizard.lint.unknownAttributes": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@types/semver": "^7.7.1",
 				"@types/vscode": "^1.96.0",
 				"@vscode/test-cli": "^0.0.15",
-				"@vscode/test-electron": "^3.0.0",
+				"@vscode/test-electron": "^3.1.0",
 				"@vscode/vsce": "^3.9.2",
 				"eslint": "^10.7.0",
 				"eslint-formatter-unix": "^9.0.1",
@@ -2346,9 +2346,9 @@
 			}
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
-			"integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+			"integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10274,7 +10274,7 @@
 		},
 		"packages/core": {
 			"name": "@quarto-wizard/core",
-			"version": "3.1.2",
+			"version": "3.1.3",
 			"license": "MIT",
 			"dependencies": {
 				"glob": "^13.0.6",
@@ -10349,7 +10349,7 @@
 		},
 		"packages/schema": {
 			"name": "@quarto-wizard/schema",
-			"version": "3.1.2",
+			"version": "3.1.3",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^5.2.2"
@@ -10366,7 +10366,7 @@
 		},
 		"packages/snippets": {
 			"name": "@quarto-wizard/snippets",
-			"version": "3.1.2",
+			"version": "3.1.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"@types/semver": "^7.7.1",
 		"@types/vscode": "^1.96.0",
 		"@vscode/test-cli": "^0.0.15",
-		"@vscode/test-electron": "^3.0.0",
+		"@vscode/test-electron": "^3.1.0",
 		"@vscode/vsce": "^3.9.2",
 		"eslint": "^10.7.0",
 		"eslint-formatter-unix": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -692,7 +692,7 @@
 						"Scan parent folders of open files."
 					],
 					"default": "subFolders",
-					"markdownDescription": "Configures when Quarto project roots should be automatically detected. A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, **or** an `_extensions/` directory with at least one installed extension. Detected roots are used by the Extensions Installed view and by every command that needs a target folder (Install, Use Template, Use Brand, ...). The default `subFolders` only inspects direct children of the workspace folder; set the value to `true` for a recursive scan, or `openEditors` to walk up from the parent folders of open files.",
+					"markdownDescription": "Configures when Quarto project roots should be automatically detected. A folder qualifies when it contains `_quarto.yml`/`_quarto.yaml`, **or** an `_extensions/` directory with at least one installed extension. Detected roots are used by the Extensions Installed view and by every command that needs a target folder (Install, Use Template, Use Brand, ...). The default `subFolders` only inspects direct children of the workspace folder; set the value to `true` for a recursive scan, or `openEditors` to walk up from the parent folders of open files. Two rules apply whatever the value: when the workspace folder itself has a populated `_extensions/` directory, it is the only root and no sub-folder is detected; and paths matched by the workspace folder's `.quartoignore` are never detected.",
 					"title": "Auto Project Detection",
 					"description": "When to auto-detect Quarto projects."
 				},

--- a/packages/core/src/archive/extract.ts
+++ b/packages/core/src/archive/extract.ts
@@ -12,6 +12,8 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { ExtensionError } from "../errors.js";
 import { MANIFEST_FILENAMES } from "../filesystem/manifest.js";
+import { EXTENSIONS_DIR } from "../filesystem/discovery.js";
+import { isQuartoIgnored, readQuartoIgnore } from "../filesystem/quartoignore.js";
 import { extractZip } from "./zip.js";
 import { extractTar } from "./tar.js";
 
@@ -192,11 +194,55 @@ function deriveExtensionIdFromPath(extensionPath: string, extractDir: string): {
 }
 
 /**
+ * Resolve the repository root inside an extraction directory.
+ *
+ * GitHub archives wrap everything in a single top-level directory such as `repo-tag/`.
+ * That wrapper is stripped so `.quartoignore` and `_extensions/` are looked up where the
+ * repository actually declares them. A sole `_extensions/` entry is not a wrapper, and
+ * neither is a directory that is itself an extension.
+ *
+ * @param extractDir - Extraction directory
+ * @returns Path to the repository root
+ */
+async function resolveArchiveRoot(extractDir: string): Promise<string> {
+	let current = extractDir;
+
+	for (let depth = 0; depth <= MAX_FIND_DEPTH; depth++) {
+		for (const name of MANIFEST_FILENAMES) {
+			if (await fileExists(path.join(current, name))) {
+				return current;
+			}
+		}
+
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(current, { withFileTypes: true });
+		} catch {
+			return current;
+		}
+
+		if (entries.length !== 1 || !entries[0].isDirectory() || entries[0].name === EXTENSIONS_DIR) {
+			return current;
+		}
+
+		current = path.join(current, entries[0].name);
+	}
+
+	return current;
+}
+
+/**
  * Find all extension roots in an extracted archive.
  *
  * Unlike findExtensionRoot which returns the first match, this function
  * finds all extensions in the archive, useful for repositories that
  * contain multiple extensions.
+ *
+ * The repository's own `_extensions/` is the primary host: when it holds at least one
+ * extension, extensions found elsewhere in the archive are ignored, so a vendored copy
+ * under `docs/_extensions/` is not offered for installation. Paths matched by the
+ * repository's `.quartoignore` are dropped as well. Neither rule is allowed to empty the
+ * result, so an archive that only ships extensions in ignored locations still installs.
  *
  * @param extractDir - Extraction directory
  * @returns Array of discovered extensions
@@ -232,7 +278,38 @@ export async function findAllExtensionRoots(extractDir: string): Promise<Discove
 	}
 
 	await searchDirectory(extractDir);
-	return results;
+
+	if (results.length === 0) {
+		return results;
+	}
+
+	const archiveRoot = await resolveArchiveRoot(extractDir);
+
+	const ignorePatterns = readQuartoIgnore(archiveRoot);
+	const kept = results.filter((ext) => !isQuartoIgnored(ignorePatterns, toRelativePosixPath(archiveRoot, ext.path)));
+
+	const hostDir = path.join(archiveRoot, EXTENSIONS_DIR);
+	const hosted = (kept.length > 0 ? kept : results).filter((ext) => isInside(hostDir, ext.path));
+
+	if (hosted.length > 0) {
+		return hosted;
+	}
+	return kept.length > 0 ? kept : results;
+}
+
+/**
+ * Express `fsPath` relative to `basePath` with POSIX separators.
+ */
+function toRelativePosixPath(basePath: string, fsPath: string): string {
+	return path.relative(basePath, fsPath).split(path.sep).join(path.posix.sep);
+}
+
+/**
+ * True when `child` lives below `parent`.
+ */
+function isInside(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
 /**

--- a/packages/core/src/archive/extract.ts
+++ b/packages/core/src/archive/extract.ts
@@ -12,8 +12,9 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { ExtensionError } from "../errors.js";
 import { MANIFEST_FILENAMES } from "../filesystem/manifest.js";
-import { EXTENSIONS_DIR } from "../filesystem/discovery.js";
+import { EXTENSIONS_DIR, getExtensionsDir } from "../filesystem/discovery.js";
 import { isQuartoIgnored, readQuartoIgnore } from "../filesystem/quartoignore.js";
+import { isInside, toRelativePosixPath } from "../filesystem/walk.js";
 import { extractZip } from "./zip.js";
 import { extractTar } from "./tar.js";
 
@@ -110,6 +111,18 @@ async function fileExists(filePath: string): Promise<boolean> {
 const MAX_FIND_DEPTH = 5;
 
 /**
+ * Check whether a directory holds an extension manifest.
+ */
+async function hasManifestFile(directory: string): Promise<boolean> {
+	for (const name of MANIFEST_FILENAMES) {
+		if (await fileExists(path.join(directory, name))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Find the extension root in an extracted archive.
  *
  * GitHub archives typically have a top-level directory like "repo-tag/".
@@ -124,11 +137,8 @@ export async function findExtensionRoot(extractDir: string, depth = 0): Promise<
 		return null;
 	}
 
-	for (const name of MANIFEST_FILENAMES) {
-		const directPath = path.join(extractDir, name);
-		if (await fileExists(directPath)) {
-			return extractDir;
-		}
+	if (await hasManifestFile(extractDir)) {
+		return extractDir;
 	}
 
 	const entries = await fs.promises.readdir(extractDir, { withFileTypes: true });
@@ -136,12 +146,8 @@ export async function findExtensionRoot(extractDir: string, depth = 0): Promise<
 
 	for (const dir of directories) {
 		const dirPath = path.join(extractDir, dir.name);
-
-		for (const name of MANIFEST_FILENAMES) {
-			const manifestPath = path.join(dirPath, name);
-			if (await fileExists(manifestPath)) {
-				return dirPath;
-			}
+		if (await hasManifestFile(dirPath)) {
+			return dirPath;
 		}
 	}
 
@@ -177,7 +183,7 @@ export interface DiscoveredExtension {
 function deriveExtensionIdFromPath(extensionPath: string, extractDir: string): { owner: string | null; name: string } {
 	const relativePath = path.relative(extractDir, extensionPath);
 	const parts = relativePath.split(path.sep);
-	const extensionsIndex = parts.lastIndexOf("_extensions");
+	const extensionsIndex = parts.lastIndexOf(EXTENSIONS_DIR);
 
 	if (extensionsIndex >= 0 && parts.length > extensionsIndex + 1) {
 		const afterExtensions = parts.slice(extensionsIndex + 1);
@@ -205,30 +211,34 @@ function deriveExtensionIdFromPath(extensionPath: string, extractDir: string): {
  * @returns Path to the repository root
  */
 async function resolveArchiveRoot(extractDir: string): Promise<string> {
-	let current = extractDir;
-
-	for (let depth = 0; depth <= MAX_FIND_DEPTH; depth++) {
-		for (const name of MANIFEST_FILENAMES) {
-			if (await fileExists(path.join(current, name))) {
-				return current;
-			}
-		}
-
-		let entries: fs.Dirent[];
-		try {
-			entries = await fs.promises.readdir(current, { withFileTypes: true });
-		} catch {
-			return current;
-		}
-
-		if (entries.length !== 1 || !entries[0].isDirectory() || entries[0].name === EXTENSIONS_DIR) {
-			return current;
-		}
-
-		current = path.join(current, entries[0].name);
+	if (await hasManifestFile(extractDir)) {
+		return extractDir;
 	}
 
-	return current;
+	let entries: fs.Dirent[];
+	try {
+		entries = await fs.promises.readdir(extractDir, { withFileTypes: true });
+	} catch {
+		return extractDir;
+	}
+
+	if (entries.length !== 1 || !entries[0].isDirectory() || entries[0].name === EXTENSIONS_DIR) {
+		return extractDir;
+	}
+
+	return path.join(extractDir, entries[0].name);
+}
+
+/**
+ * Narrow a list, but never to nothing.
+ *
+ * The primary-host and `.quartoignore` rules both express a preference rather than a hard
+ * requirement: a repository that keeps its only extension in an ignored location must still
+ * be installable.
+ */
+function narrowKeepingNonEmpty<T>(items: T[], keep: (item: T) => boolean): T[] {
+	const narrowed = items.filter(keep);
+	return narrowed.length > 0 ? narrowed : items;
 }
 
 /**
@@ -256,16 +266,13 @@ export async function findAllExtensionRoots(extractDir: string): Promise<Discove
 		}
 
 		// Check for manifest in current directory
-		for (const name of MANIFEST_FILENAMES) {
-			const manifestPath = path.join(dir, name);
-			if (await fileExists(manifestPath)) {
-				// Found an extension, derive its ID from path
-				const id = deriveExtensionIdFromPath(dir, extractDir);
-				const relativePath = path.relative(extractDir, dir);
-				results.push({ path: dir, relativePath, id });
-				// Don't search subdirectories of an extension
-				return;
-			}
+		if (await hasManifestFile(dir)) {
+			// Found an extension, derive its ID from path
+			const id = deriveExtensionIdFromPath(dir, extractDir);
+			const relativePath = path.relative(extractDir, dir);
+			results.push({ path: dir, relativePath, id });
+			// Don't search subdirectories of an extension
+			return;
 		}
 
 		// Search subdirectories
@@ -284,32 +291,14 @@ export async function findAllExtensionRoots(extractDir: string): Promise<Discove
 	}
 
 	const archiveRoot = await resolveArchiveRoot(extractDir);
-
 	const ignorePatterns = readQuartoIgnore(archiveRoot);
-	const kept = results.filter((ext) => !isQuartoIgnored(ignorePatterns, toRelativePosixPath(archiveRoot, ext.path)));
+	const hostDir = getExtensionsDir(archiveRoot);
 
-	const hostDir = path.join(archiveRoot, EXTENSIONS_DIR);
-	const hosted = (kept.length > 0 ? kept : results).filter((ext) => isInside(hostDir, ext.path));
-
-	if (hosted.length > 0) {
-		return hosted;
-	}
-	return kept.length > 0 ? kept : results;
-}
-
-/**
- * Express `fsPath` relative to `basePath` with POSIX separators.
- */
-function toRelativePosixPath(basePath: string, fsPath: string): string {
-	return path.relative(basePath, fsPath).split(path.sep).join(path.posix.sep);
-}
-
-/**
- * True when `child` lives below `parent`.
- */
-function isInside(parent: string, child: string): boolean {
-	const relative = path.relative(parent, child);
-	return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+	const kept = narrowKeepingNonEmpty(
+		results,
+		(ext) => !isQuartoIgnored(ignorePatterns, toRelativePosixPath(archiveRoot, ext.path)),
+	);
+	return narrowKeepingNonEmpty(kept, (ext) => isInside(hostDir, ext.path));
 }
 
 /**

--- a/packages/core/src/filesystem/index.ts
+++ b/packages/core/src/filesystem/index.ts
@@ -26,6 +26,15 @@ export {
 	getExtensionInstallPath,
 } from "./discovery.js";
 
-export { type WalkEntry, type WalkCallback, walkDirectory, collectFiles, copyDirectory, pathExists } from "./walk.js";
+export {
+	type WalkEntry,
+	type WalkCallback,
+	walkDirectory,
+	collectFiles,
+	copyDirectory,
+	pathExists,
+	toRelativePosixPath,
+	isInside,
+} from "./walk.js";
 
-export { QUARTOIGNORE_FILENAME, readQuartoIgnore, isQuartoIgnored } from "./quartoignore.js";
+export { QUARTOIGNORE_FILENAME, readQuartoIgnore, isQuartoIgnored, quartoIgnoreGlobs } from "./quartoignore.js";

--- a/packages/core/src/filesystem/index.ts
+++ b/packages/core/src/filesystem/index.ts
@@ -27,3 +27,5 @@ export {
 } from "./discovery.js";
 
 export { type WalkEntry, type WalkCallback, walkDirectory, collectFiles, copyDirectory, pathExists } from "./walk.js";
+
+export { QUARTOIGNORE_FILENAME, readQuartoIgnore, isQuartoIgnored } from "./quartoignore.js";

--- a/packages/core/src/filesystem/quartoignore.ts
+++ b/packages/core/src/filesystem/quartoignore.ts
@@ -1,0 +1,100 @@
+/**
+ * @title Quarto Ignore Module
+ * @description Reading and matching `.quartoignore` patterns.
+ *
+ * `.quartoignore` lists paths a repository keeps out of Quarto's view, most commonly a
+ * documentation website that ships its own `_quarto.yml` and `_extensions/`. Tooling that
+ * scans a repository for Quarto projects should skip those paths.
+ *
+ * @module filesystem
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { minimatch } from "minimatch";
+
+/** Name of the ignore file. */
+export const QUARTOIGNORE_FILENAME = ".quartoignore";
+
+/**
+ * Read and normalise the patterns declared in a directory's `.quartoignore`.
+ *
+ * Comments (`#`), blank lines, and surrounding whitespace are stripped, as are leading
+ * `./` and `/` and trailing `/`, so `docs/`, `/docs` and `docs` are equivalent.
+ * Negation (`!`) is not part of Quarto's format and such lines are dropped.
+ *
+ * @param dir - Directory holding the `.quartoignore` file
+ * @returns Normalised patterns, or an empty array when the file is absent or unreadable
+ *
+ * @example
+ * ```typescript
+ * const patterns = readQuartoIgnore("./my-extension");
+ * // [".scratch", "docs"]
+ * ```
+ */
+export function readQuartoIgnore(dir: string): string[] {
+	let content: string;
+	try {
+		content = fs.readFileSync(path.join(dir, QUARTOIGNORE_FILENAME), "utf8");
+	} catch {
+		// Missing or unreadable ignore file: nothing is ignored.
+		return [];
+	}
+
+	const patterns: string[] = [];
+	for (const line of content.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith("!")) {
+			continue;
+		}
+		const normalised = trimmed.replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "");
+		if (normalised !== "") {
+			patterns.push(normalised);
+		}
+	}
+	return patterns;
+}
+
+/**
+ * Check whether a path is covered by `.quartoignore` patterns.
+ *
+ * Every ancestor of `relativePath` is tested, so an ignored directory also hides everything
+ * below it. Patterns containing no separator are additionally matched against each individual
+ * segment, so `_site` matches at any depth; patterns containing a separator stay anchored to
+ * the directory holding the `.quartoignore`.
+ *
+ * @param patterns - Normalised patterns from {@link readQuartoIgnore}
+ * @param relativePath - POSIX-separated path relative to the directory holding the ignore file
+ * @returns True when the path is ignored
+ *
+ * @example
+ * ```typescript
+ * isQuartoIgnored(["docs"], "docs/_extensions/mcanouil/gitlink"); // true
+ * ```
+ */
+export function isQuartoIgnored(patterns: readonly string[], relativePath: string): boolean {
+	if (patterns.length === 0) {
+		return false;
+	}
+
+	const segments = relativePath.split("/").filter((segment) => segment !== "" && segment !== ".");
+	if (segments.length === 0) {
+		// The directory holding the ignore file cannot ignore itself.
+		return false;
+	}
+
+	for (const pattern of patterns) {
+		const anchored = pattern.includes("/");
+		for (let depth = 1; depth <= segments.length; depth++) {
+			const prefix = segments.slice(0, depth).join("/");
+			if (minimatch(prefix, pattern, { dot: true })) {
+				return true;
+			}
+			if (!anchored && minimatch(segments[depth - 1], pattern, { dot: true })) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/packages/core/src/filesystem/quartoignore.ts
+++ b/packages/core/src/filesystem/quartoignore.ts
@@ -47,7 +47,7 @@ export function readQuartoIgnore(dir: string): string[] {
 		if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith("!")) {
 			continue;
 		}
-		const normalised = trimmed.replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "");
+		const normalised = trimmed.replace(/^\.?\/+/, "").replace(/\/+$/, "");
 		if (normalised !== "") {
 			patterns.push(normalised);
 		}
@@ -73,28 +73,43 @@ export function readQuartoIgnore(dir: string): string[] {
  * ```
  */
 export function isQuartoIgnored(patterns: readonly string[], relativePath: string): boolean {
-	if (patterns.length === 0) {
-		return false;
-	}
-
+	// An empty path is the directory holding the ignore file, which cannot ignore itself.
 	const segments = relativePath.split("/").filter((segment) => segment !== "" && segment !== ".");
-	if (segments.length === 0) {
-		// The directory holding the ignore file cannot ignore itself.
-		return false;
-	}
+	const prefixes = segments.map((_, index) => segments.slice(0, index + 1).join("/"));
 
+	return patterns.some((pattern) => {
+		// An anchored pattern is matched against whole prefixes only; an unanchored one is
+		// matched against each segment, which is what makes it apply at any depth.
+		const candidates = pattern.includes("/") ? prefixes : segments;
+		return candidates.some((candidate) => minimatch(candidate, pattern, { dot: true }));
+	});
+}
+
+/**
+ * Convert `.quartoignore` patterns into globs matching the ignored paths and their contents.
+ *
+ * {@link isQuartoIgnored} is a predicate over one path; consumers that hand patterns to a
+ * glob matcher need the same semantics expressed as globs instead. Each pattern yields the
+ * path itself and everything below it, plus depth-independent variants for unanchored
+ * patterns.
+ *
+ * @param patterns - Normalised patterns from {@link readQuartoIgnore}
+ * @returns Glob patterns covering the ignored paths and their descendants
+ *
+ * @example
+ * ```typescript
+ * quartoIgnoreGlobs(["docs"]); // ["docs", "docs/**", "**\/docs", "**\/docs/**"]
+ * ```
+ */
+export function quartoIgnoreGlobs(patterns: readonly string[]): string[] {
+	const globs = new Set<string>();
 	for (const pattern of patterns) {
-		const anchored = pattern.includes("/");
-		for (let depth = 1; depth <= segments.length; depth++) {
-			const prefix = segments.slice(0, depth).join("/");
-			if (minimatch(prefix, pattern, { dot: true })) {
-				return true;
-			}
-			if (!anchored && minimatch(segments[depth - 1], pattern, { dot: true })) {
-				return true;
-			}
+		globs.add(pattern);
+		globs.add(`${pattern}/**`);
+		if (!pattern.includes("/")) {
+			globs.add(`**/${pattern}`);
+			globs.add(`**/${pattern}/**`);
 		}
 	}
-
-	return false;
+	return [...globs];
 }

--- a/packages/core/src/filesystem/walk.ts
+++ b/packages/core/src/filesystem/walk.ts
@@ -115,3 +115,32 @@ export async function copyDirectory(sourceDir: string, targetDir: string): Promi
 
 	return filesCreated;
 }
+
+/**
+ * Express `fsPath` relative to `basePath` using POSIX separators.
+ *
+ * Path comparison and pattern matching both work on forward slashes, so callers on Windows
+ * need this normalisation before handing a path to a matcher or to a display label.
+ *
+ * @param basePath - Directory the result is relative to
+ * @param fsPath - Path to express relatively
+ * @returns POSIX-separated relative path, empty when the two paths are equal
+ */
+export function toRelativePosixPath(basePath: string, fsPath: string): string {
+	return path.relative(basePath, fsPath).split(path.sep).join(path.posix.sep);
+}
+
+/**
+ * Check whether a path is `parent` itself or lives below it.
+ *
+ * @param parent - Ancestor directory
+ * @param child - Path to test
+ * @returns True when `child` is `parent` or is contained by it
+ */
+export function isInside(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	if (relative === "") {
+		return true;
+	}
+	return !relative.startsWith("..") && !path.isAbsolute(relative);
+}

--- a/packages/core/src/operations/use.ts
+++ b/packages/core/src/operations/use.ts
@@ -28,6 +28,7 @@ import {
 } from "./install.js";
 import { cleanupExtraction, findAllExtensionRoots, type DiscoveredExtension } from "../archive/extract.js";
 import { getExtensionInstallPath } from "../filesystem/discovery.js";
+import { quartoIgnoreGlobs, readQuartoIgnore } from "../filesystem/quartoignore.js";
 
 /**
  * Options for globbing files.
@@ -128,6 +129,25 @@ const DEFAULT_EXCLUDE_PATTERNS = [
 	// LLM
 	".claude/**",
 ];
+
+/**
+ * Patterns the file-selection UI starts with unticked.
+ *
+ * `_extensions/**` is dropped from the defaults because the extension itself is installed
+ * separately and its files are offered on purpose. On top of the defaults, the repository's
+ * own `.quartoignore` declares what a project created from this template should not receive,
+ * so those paths start unselected too. They stay selectable: the ignore file states an
+ * intent, not a prohibition.
+ *
+ * @param sourceRoot - Root of the extracted template source
+ * @returns Glob patterns to leave unselected
+ */
+function defaultUnselectedPatterns(sourceRoot: string): string[] {
+	return [
+		...DEFAULT_EXCLUDE_PATTERNS.filter((pattern) => pattern !== "_extensions/**"),
+		...quartoIgnoreGlobs(readQuartoIgnore(sourceRoot)),
+	];
+}
 
 /**
  * Callback for confirming file overwrites (per-file).
@@ -369,11 +389,7 @@ async function twoPhaseUse(source: InstallSource, options: UseOptions): Promise<
 
 		onProgress?.({ phase: "selecting", message: "Awaiting file selection..." });
 
-		const selectionResult = await selectFiles(
-			allFiles,
-			existingFiles,
-			DEFAULT_EXCLUDE_PATTERNS.filter((p) => p !== "_extensions/**"),
-		);
+		const selectionResult = await selectFiles(allFiles, existingFiles, defaultUnselectedPatterns(sourceRoot));
 
 		if (!selectionResult) {
 			// User cancelled file selection. Cleanup is handled by the finally block.
@@ -620,11 +636,7 @@ export async function use(source: string | InstallSource, options: UseOptions): 
 			}
 
 			// Call the selection callback
-			const selectionResult = await selectFiles(
-				allFiles,
-				existingFiles,
-				DEFAULT_EXCLUDE_PATTERNS.filter((p) => p !== "_extensions/**"),
-			);
+			const selectionResult = await selectFiles(allFiles, existingFiles, defaultUnselectedPatterns(sourceRoot));
 
 			if (!selectionResult) {
 				// User cancelled
@@ -639,8 +651,10 @@ export async function use(source: string | InstallSource, options: UseOptions): 
 			overwriteAll = selectionResult.overwriteExisting;
 		} else {
 			// Legacy mode: use include/exclude patterns
+			// No UI to unselect in, so the repository's `.quartoignore` excludes outright here,
+			// matching what `quarto use template` does.
 			filesToCopy = await globFiles(sourceRoot, {
-				ignore: [...DEFAULT_EXCLUDE_PATTERNS, ...exclude],
+				ignore: [...DEFAULT_EXCLUDE_PATTERNS, ...quartoIgnoreGlobs(readQuartoIgnore(sourceRoot)), ...exclude],
 			});
 
 			if (include && include.length > 0) {

--- a/packages/core/tests/archive.test.ts
+++ b/packages/core/tests/archive.test.ts
@@ -48,6 +48,91 @@ async function createTarArchive(sourceDir: string, tarPath: string): Promise<voi
 	);
 }
 
+/** Byte offsets and widths of the ustar header fields this helper writes. */
+const USTAR_CHECKSUM_OFFSET = 148;
+const USTAR_CHECKSUM_WIDTH = 8;
+const USTAR_BLOCK_SIZE = 512;
+
+/**
+ * Build a single ustar header block.
+ *
+ * @param name - Entry name
+ * @param typeflag - ustar type flag ("0" file, "1" hard link, "2" symbolic link)
+ * @param linkname - Link target, for link entries
+ */
+function createUstarHeader(name: string, typeflag: string, linkname: string): Buffer {
+	const header = Buffer.alloc(USTAR_BLOCK_SIZE);
+	const write = (value: string, offset: number, length: number) => {
+		header.write(value.slice(0, length), offset, length, "utf8");
+	};
+
+	write(name, 0, 100);
+	write("0000644\0", 100, 8); // mode
+	write("0000000\0", 108, 8); // uid
+	write("0000000\0", 116, 8); // gid
+	write("00000000000\0", 124, 12); // size: link entries carry no data
+	write("00000000000\0", 136, 12); // mtime
+	header.fill(" ", USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_WIDTH);
+	write(typeflag, 156, 1);
+	write(linkname, 157, 100);
+	write("ustar\0", 257, 6);
+	write("00", 263, 2);
+
+	let checksum = 0;
+	for (const byte of header) {
+		checksum += byte;
+	}
+	write(`${checksum.toString(8).padStart(6, "0")}\0 `, USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_WIDTH);
+
+	return header;
+}
+
+/**
+ * Write an uncompressed tar containing one regular file and one link entry.
+ *
+ * The header is assembled by hand rather than by archiving a real link with `tar.create`:
+ * node-tar's writer emits a late, unhandled stream error when it walks a hard link, which
+ * made this suite fail intermittently. Building the bytes directly also makes the fixture
+ * independent of what the host filesystem permits, so the tests no longer skip themselves
+ * on platforms without link support.
+ *
+ * @param tarPath - Destination archive path
+ * @param typeflag - "1" for a hard link, "2" for a symbolic link
+ * @param linkName - Name of the link entry
+ * @param targetName - Name of the file the link points at
+ */
+async function createTarWithLinkEntry(
+	tarPath: string,
+	typeflag: "1" | "2",
+	linkName: string,
+	targetName: string,
+): Promise<void> {
+	const content = Buffer.from("link-target\n", "utf8");
+	const paddedContent = Buffer.alloc(Math.ceil(content.length / USTAR_BLOCK_SIZE) * USTAR_BLOCK_SIZE);
+	content.copy(paddedContent);
+
+	const fileHeader = createUstarHeader(targetName, "0", "");
+	fileHeader.write(`${content.length.toString(8).padStart(11, "0")}\0`, 124, 12, "utf8");
+	// Rewriting the size invalidates the checksum computed for a zero-length entry.
+	fileHeader.fill(" ", USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_OFFSET + USTAR_CHECKSUM_WIDTH);
+	let checksum = 0;
+	for (const byte of fileHeader) {
+		checksum += byte;
+	}
+	fileHeader.write(`${checksum.toString(8).padStart(6, "0")}\0 `, USTAR_CHECKSUM_OFFSET, USTAR_CHECKSUM_WIDTH, "utf8");
+
+	await fs.promises.writeFile(
+		tarPath,
+		Buffer.concat([
+			fileHeader,
+			paddedContent,
+			createUstarHeader(linkName, typeflag, targetName),
+			// Two zero blocks mark the end of the archive.
+			Buffer.alloc(USTAR_BLOCK_SIZE * 2),
+		]),
+	);
+}
+
 describe("detectArchiveFormat", () => {
 	it("detects zip format", () => {
 		expect(detectArchiveFormat("file.zip")).toBe("zip");
@@ -296,21 +381,11 @@ describe("ZIP extraction", () => {
 	});
 
 	it("rejects hard links in tar archives", async () => {
-		const sourceWithHardLink = path.join(tempDir, "source-hardlink");
-		await fs.promises.mkdir(sourceWithHardLink);
-		const originalFile = path.join(sourceWithHardLink, "original.txt");
-		const hardLinkFile = path.join(sourceWithHardLink, "hardlink.txt");
-		await fs.promises.writeFile(originalFile, "hard-link-target");
-		try {
-			fs.linkSync(originalFile, hardLinkFile);
-		} catch {
-			// Some filesystems/environments may disallow hard links.
-			return;
-		}
+		const hardLinkTarPath = path.join(tempDir, "hardlink.tar");
+		await createTarWithLinkEntry(hardLinkTarPath, "1", "hardlink.txt", "original.txt");
 
-		const hardLinkTarPath = path.join(tempDir, "hardlink.tar.gz");
-		await createTarArchive(sourceWithHardLink, hardLinkTarPath);
 		const destDir = path.join(tempDir, "dest-hardlink");
+
 		await expect(extractTar(hardLinkTarPath, destDir)).rejects.toThrow(SecurityError);
 	});
 });
@@ -356,20 +431,11 @@ describe("TAR extraction", () => {
 	});
 
 	it("rejects symbolic links in tar archives", async () => {
-		const sourceWithSymlink = path.join(tempDir, "source-symlink");
-		await fs.promises.mkdir(sourceWithSymlink);
-		const targetFile = path.join(sourceWithSymlink, "target.txt");
-		await fs.promises.writeFile(targetFile, "symlink-target");
-		try {
-			fs.symlinkSync(targetFile, path.join(sourceWithSymlink, "link.txt"));
-		} catch {
-			// Some filesystems/environments may disallow symbolic links.
-			return;
-		}
+		const symlinkTarPath = path.join(tempDir, "symlink.tar");
+		await createTarWithLinkEntry(symlinkTarPath, "2", "link.txt", "target.txt");
 
-		const symlinkTarPath = path.join(tempDir, "symlink.tar.gz");
-		await createTarArchive(sourceWithSymlink, symlinkTarPath);
 		const destDir = path.join(tempDir, "dest-symlink");
+
 		await expect(extractTar(symlinkTarPath, destDir)).rejects.toThrow(SecurityError);
 	});
 

--- a/packages/core/tests/archive.test.ts
+++ b/packages/core/tests/archive.test.ts
@@ -4,7 +4,13 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { ZipArchive } from "archiver";
 import * as tar from "tar";
-import { detectArchiveFormat, extractArchive, findExtensionRoot, cleanupExtraction } from "../src/archive/extract.js";
+import {
+	detectArchiveFormat,
+	extractArchive,
+	findAllExtensionRoots,
+	findExtensionRoot,
+	cleanupExtraction,
+} from "../src/archive/extract.js";
 import { extractZip } from "../src/archive/zip.js";
 import { extractTar } from "../src/archive/tar.js";
 import { SecurityError } from "../src/errors.js";
@@ -129,6 +135,108 @@ describe("findExtensionRoot", () => {
 		const root = await findExtensionRoot(tempDir);
 
 		expect(root).toBe(current);
+	});
+});
+
+describe("findAllExtensionRoots", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ext-roots-test-"));
+	});
+
+	afterEach(async () => {
+		await fs.promises.rm(tempDir, { recursive: true, force: true });
+	});
+
+	async function writeExtension(dir: string, title: string): Promise<void> {
+		await fs.promises.mkdir(dir, { recursive: true });
+		await fs.promises.writeFile(path.join(dir, "_extension.yml"), `title: ${title}`);
+	}
+
+	function names(extensions: { id: { name: string } }[]): string[] {
+		return extensions.map((ext) => ext.id.name).sort();
+	}
+
+	it("returns every extension when the repository root has no _extensions/", async () => {
+		const repo = path.join(tempDir, "owner-repo-main");
+		await writeExtension(path.join(repo, "docs", "_extensions", "mcanouil", "iconify"), "iconify");
+		await writeExtension(path.join(repo, "pkg", "_extensions", "mcanouil", "pastel"), "pastel");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["iconify", "pastel"]);
+	});
+
+	it("keeps only the repository root _extensions/ when it is populated", async () => {
+		// Mirrors a GitHub archive of an extension repository that also builds a docs site.
+		const repo = path.join(tempDir, "mcanouil-quarto-code-window-8a3af22");
+		await writeExtension(path.join(repo, "_extensions", "code-window"), "code-window");
+		await writeExtension(path.join(repo, "docs", "_extensions", "mcanouil", "atelier"), "atelier");
+		await writeExtension(path.join(repo, "docs", "_extensions", "mcanouil", "gitlink"), "gitlink");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["code-window"]);
+	});
+
+	it("keeps every extension in the repository root _extensions/", async () => {
+		const repo = path.join(tempDir, "owner-repo-main");
+		await writeExtension(path.join(repo, "_extensions", "mcanouil", "first"), "first");
+		await writeExtension(path.join(repo, "_extensions", "mcanouil", "second"), "second");
+		await writeExtension(path.join(repo, "docs", "_extensions", "mcanouil", "vendored"), "vendored");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["first", "second"]);
+	});
+
+	it("applies the repository root _extensions/ rule without a wrapper directory", async () => {
+		await writeExtension(path.join(tempDir, "_extensions", "code-window"), "code-window");
+		await writeExtension(path.join(tempDir, "docs", "_extensions", "mcanouil", "atelier"), "atelier");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["code-window"]);
+	});
+
+	it("drops extensions matched by the repository .quartoignore", async () => {
+		const repo = path.join(tempDir, "owner-repo-main");
+		await fs.promises.mkdir(repo, { recursive: true });
+		await fs.promises.writeFile(path.join(repo, ".quartoignore"), "# the docs site\ndocs\n");
+		await writeExtension(path.join(repo, "pkg", "_extensions", "mcanouil", "pastel"), "pastel");
+		await writeExtension(path.join(repo, "docs", "_extensions", "mcanouil", "iconify"), "iconify");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["pastel"]);
+	});
+
+	it("keeps the unfiltered set when .quartoignore would discard everything", async () => {
+		const repo = path.join(tempDir, "owner-repo-main");
+		await fs.promises.mkdir(repo, { recursive: true });
+		await fs.promises.writeFile(path.join(repo, ".quartoignore"), "docs\n");
+		await writeExtension(path.join(repo, "docs", "_extensions", "mcanouil", "iconify"), "iconify");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["iconify"]);
+	});
+
+	it("does not mistake a lone _extensions/ directory for an archive wrapper", async () => {
+		await writeExtension(path.join(tempDir, "_extensions", "mcanouil", "only"), "only");
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(names(found)).toEqual(["only"]);
+	});
+
+	it("returns an empty array when the archive holds no extension", async () => {
+		await fs.promises.mkdir(path.join(tempDir, "owner-repo-main", "docs"), { recursive: true });
+
+		const found = await findAllExtensionRoots(tempDir);
+
+		expect(found).toEqual([]);
 	});
 });
 

--- a/packages/core/tests/operations/use.test.ts
+++ b/packages/core/tests/operations/use.test.ts
@@ -247,3 +247,101 @@ describe("use with targetSubdir", () => {
 		expect(fs.existsSync(path.join(projectDir, "template.qmd"))).toBe(true);
 	});
 });
+
+describe("use honouring .quartoignore", () => {
+	let sourceDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "qw-use-ignore-source-"));
+		projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "qw-use-ignore-project-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(sourceDir, { recursive: true, force: true });
+		fs.rmSync(projectDir, { recursive: true, force: true });
+	});
+
+	function createSourceFile(relativePath: string, content = ""): void {
+		const fullPath = path.join(sourceDir, relativePath);
+		fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+		fs.writeFileSync(fullPath, content);
+	}
+
+	function createTemplateSource(): void {
+		createSourceFile(
+			"_extensions/owner/my-ext/_extension.yml",
+			"title: Test\ncontributes:\n  shortcodes:\n    - test.lua",
+		);
+		createSourceFile("_extensions/owner/my-ext/test.lua", "-- test");
+		createSourceFile("template.qmd", "---\ntitle: Template\n---");
+		createSourceFile("scratch/notes.md", "notes");
+		createSourceFile("scratch/nested/deep.md", "deep");
+	}
+
+	it("leaves .quartoignore matches unselected but still offered", async () => {
+		createTemplateSource();
+		createSourceFile(".quartoignore", "# working notes\nscratch\n");
+
+		let offeredFiles: string[] = [];
+		let unselectedPatterns: string[] = [];
+
+		const result = await use(
+			{ type: "local", path: sourceDir },
+			{
+				projectDir,
+				selectFiles: async (availableFiles, _existingFiles, defaultExcludePatterns) => {
+					offeredFiles = availableFiles;
+					unselectedPatterns = defaultExcludePatterns;
+					// The UI would drop the unselected ones; copy everything to prove they are
+					// still selectable rather than removed from the list.
+					return { selectedFiles: availableFiles, overwriteExisting: false };
+				},
+			},
+		);
+
+		expect(result.install.success).toBe(true);
+		// Still offered, so the user can tick them back on.
+		expect(offeredFiles).toContain("scratch/notes.md");
+		expect(offeredFiles).toContain("template.qmd");
+		// And they start unticked.
+		expect(unselectedPatterns).toContain("scratch");
+		expect(unselectedPatterns).toContain("scratch/**");
+		// Selecting them anyway copies them.
+		expect(fs.existsSync(path.join(projectDir, "scratch", "notes.md"))).toBe(true);
+	});
+
+	it("does not add unselected patterns when there is no .quartoignore", async () => {
+		createTemplateSource();
+
+		let unselectedPatterns: string[] = [];
+
+		await use(
+			{ type: "local", path: sourceDir },
+			{
+				projectDir,
+				selectFiles: async (availableFiles, _existingFiles, defaultExcludePatterns) => {
+					unselectedPatterns = defaultExcludePatterns;
+					return { selectedFiles: availableFiles, overwriteExisting: false };
+				},
+			},
+		);
+
+		expect(unselectedPatterns).not.toContain("scratch");
+		// The built-in defaults are still there, minus the extension directory.
+		expect(unselectedPatterns).toContain("README.md");
+		expect(unselectedPatterns).not.toContain("_extensions/**");
+	});
+
+	it("excludes .quartoignore matches outright when there is no selection UI", async () => {
+		createTemplateSource();
+		createSourceFile(".quartoignore", "scratch\n");
+
+		const result = await use({ type: "local", path: sourceDir }, { projectDir });
+
+		expect(result.install.success).toBe(true);
+		expect(result.templateFiles).toContain("template.qmd");
+		expect(result.templateFiles.some((file) => file.startsWith("scratch/"))).toBe(false);
+		expect(fs.existsSync(path.join(projectDir, "scratch"))).toBe(false);
+	});
+});

--- a/packages/core/tests/quartoignore.test.ts
+++ b/packages/core/tests/quartoignore.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { QUARTOIGNORE_FILENAME, readQuartoIgnore, isQuartoIgnored } from "../src/filesystem/quartoignore.js";
+
+describe("quartoignore.ts", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quartoignore-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function writeIgnore(content: string): void {
+		fs.writeFileSync(path.join(tempDir, QUARTOIGNORE_FILENAME), content, "utf8");
+	}
+
+	describe("readQuartoIgnore", () => {
+		it("returns an empty array when the file is absent", () => {
+			expect(readQuartoIgnore(tempDir)).toEqual([]);
+		});
+
+		it("returns an empty array when the directory does not exist", () => {
+			expect(readQuartoIgnore(path.join(tempDir, "missing"))).toEqual([]);
+		});
+
+		it("skips comments and blank lines and trims whitespace", () => {
+			writeIgnore("# a comment\n\n  docs  \n\t\n#another\n_site\n");
+
+			expect(readQuartoIgnore(tempDir)).toEqual(["docs", "_site"]);
+		});
+
+		it("normalises leading and trailing separators", () => {
+			writeIgnore("docs/\n/build\n./scratch\n");
+
+			expect(readQuartoIgnore(tempDir)).toEqual(["docs", "build", "scratch"]);
+		});
+
+		it("drops negation lines, which Quarto does not support", () => {
+			writeIgnore("docs\n!docs/keep\n");
+
+			expect(readQuartoIgnore(tempDir)).toEqual(["docs"]);
+		});
+
+		it("drops lines that normalise to nothing", () => {
+			writeIgnore("/\n./\n   \n");
+
+			expect(readQuartoIgnore(tempDir)).toEqual([]);
+		});
+	});
+
+	describe("isQuartoIgnored", () => {
+		it("returns false when there are no patterns", () => {
+			expect(isQuartoIgnored([], "docs")).toBe(false);
+		});
+
+		it("returns false for an empty path", () => {
+			expect(isQuartoIgnored(["docs"], "")).toBe(false);
+		});
+
+		it("matches an exact path", () => {
+			expect(isQuartoIgnored(["docs"], "docs")).toBe(true);
+		});
+
+		it("matches a descendant of an ignored directory", () => {
+			expect(isQuartoIgnored(["docs"], "docs/site/nested")).toBe(true);
+		});
+
+		it("does not match a sibling with a shared prefix", () => {
+			expect(isQuartoIgnored(["docs"], "docs-site")).toBe(false);
+		});
+
+		it("matches a separator-free pattern at any depth", () => {
+			expect(isQuartoIgnored(["_site"], "docs/_site")).toBe(true);
+		});
+
+		it("anchors a pattern containing a separator to the root", () => {
+			expect(isQuartoIgnored(["docs/_site"], "docs/_site")).toBe(true);
+			expect(isQuartoIgnored(["docs/_site"], "nested/docs/_site")).toBe(false);
+		});
+
+		it("supports glob patterns", () => {
+			expect(isQuartoIgnored(["site-*"], "site-a")).toBe(true);
+			expect(isQuartoIgnored(["site-*"], "site")).toBe(false);
+		});
+
+		it("matches dot directories", () => {
+			expect(isQuartoIgnored([".scratch"], ".scratch/project")).toBe(true);
+		});
+
+		it("returns false when nothing matches", () => {
+			expect(isQuartoIgnored(["docs", "_site"], "paper")).toBe(false);
+		});
+	});
+});

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -108,6 +108,13 @@ suite("Quarto Project Discovery Test Suite", () => {
 		return file;
 	}
 
+	function writeQuartoIgnore(dir: string, content: string): string {
+		fs.mkdirSync(dir, { recursive: true });
+		const file = path.join(dir, ".quartoignore");
+		fs.writeFileSync(file, content, "utf8");
+		return file;
+	}
+
 	function writeExtensionManifest(projectDir: string, owner: string, name: string): string {
 		const dir = path.join(projectDir, "_extensions", owner, name);
 		fs.mkdirSync(dir, { recursive: true });
@@ -430,6 +437,97 @@ suite("Quarto Project Discovery Test Suite", () => {
 		assert.strictEqual(roots.length, 1);
 		assert.strictEqual(roots[0].fsPath, projectDir);
 		assert.strictEqual(roots[0].label, "workspace/nested/ext-only");
+	});
+
+	// Mirrors an extension development repository: the extension lives in the root
+	// `_extensions/`, and `docs/` is a documentation website with its own project files.
+	function writeExtensionRepoFixture(): string {
+		writeExtensionManifest(tempDir, "mcanouil", "gitlink");
+		const docs = path.join(tempDir, "docs");
+		writeQuartoYml(docs);
+		writeExtensionManifest(docs, "mcanouil", "gitlink");
+		const docPath = path.join(docs, "index.qmd");
+		fs.writeFileSync(docPath, "", "utf8");
+		return docPath;
+	}
+
+	for (const setting of [true, "subFolders", "openEditors"] as const) {
+		test(`setting=${setting}: populated root _extensions/ hides every sub-root`, async () => {
+			const docPath = writeExtensionRepoFixture();
+			mockedConfig.autoProjectDetection = setting;
+			mockedTextDocuments = [makeDocument(docPath)];
+
+			const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+			assert.strictEqual(roots.length, 1);
+			assert.strictEqual(roots[0].fsPath, tempDir);
+			assert.strictEqual(roots[0].label, "workspace");
+		});
+	}
+
+	test("populated root _extensions/ short-circuits before any scan", async () => {
+		writeExtensionRepoFixture();
+		let findFilesCalled = false;
+		vscode.workspace.findFiles = (() => {
+			findFilesCalled = true;
+			return Promise.resolve([]);
+		}) as typeof vscode.workspace.findFiles;
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(findFilesCalled, false);
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+	});
+
+	test("empty root _extensions/ does not hide sub-roots", async () => {
+		fs.mkdirSync(path.join(tempDir, EXTENSIONS_DIR), { recursive: true });
+		const site = path.join(tempDir, "site");
+		writeQuartoYml(site);
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, site);
+	});
+
+	test(".quartoignore removes matching sub-roots", async () => {
+		writeQuartoIgnore(tempDir, "# the documentation website\ndocs\n");
+		writeQuartoYml(path.join(tempDir, "docs"));
+		const paper = path.join(tempDir, "paper");
+		writeQuartoYml(paper);
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, paper);
+	});
+
+	test(".quartoignore removes sub-roots detected via _extensions/", async () => {
+		writeQuartoIgnore(tempDir, "docs\n");
+		writeExtensionManifest(path.join(tempDir, "docs"), "mcanouil", "gitlink");
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		// Nothing survives the filter, so the workspace folder fallback applies.
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
+	});
+
+	test(".quartoignore removes sub-roots found by the open-editor walk-up", async () => {
+		writeQuartoIgnore(tempDir, "docs\n");
+		const docs = path.join(tempDir, "docs");
+		writeQuartoYml(docs);
+		const docPath = path.join(docs, "index.qmd");
+		fs.writeFileSync(docPath, "", "utf8");
+
+		mockedConfig.autoProjectDetection = "openEditors";
+		mockedTextDocuments = [makeDocument(docPath)];
+
+		const roots = await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)]);
+
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].fsPath, tempDir);
 	});
 
 	test("setting=openEditors: symlink loops in _extensions/ do not cause infinite recursion", async function () {

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -5,9 +5,14 @@ import {
 	MANIFEST_FILENAMES,
 	QUARTOIGNORE_FILENAME,
 	getErrorMessage,
+	getExtensionsDir,
+	isInside,
 	isQuartoIgnored,
 	readQuartoIgnore,
+	toRelativePosixPath,
 } from "@quarto-wizard/core";
+
+export { isInside } from "@quarto-wizard/core";
 import { getAutoProjectDetection } from "./extensionDetails";
 import { logMessage } from "./log";
 
@@ -94,29 +99,26 @@ export async function discoverQuartoProjectRoots(
 		// Quarto resolves `_extensions/` by walking up from the input file, so a populated
 		// `_extensions/` at the folder root already serves every document below it. It is the
 		// primary host: no sub-folder is offered as a separate install or update target.
-		if (await directoryHasInstalledExtension(vscode.Uri.file(path.join(folderPath, EXTENSIONS_DIR)))) {
+		// The `true` and `subFolders` scans reach the same conclusion on their own; probing
+		// here makes the rule hold for `openEditors` too, and skips the scan entirely.
+		if (await directoryHasInstalledExtension(vscode.Uri.file(getExtensionsDir(folderPath)))) {
 			results.push(buildRoot(folder, folderPath));
 			continue;
 		}
 
 		const ignorePatterns = readQuartoIgnore(folderPath);
+		const discovered =
+			setting === "openEditors"
+				? await findOpenEditorProjectDirs(folder)
+				: await findSubFolderProjectDirs(folder, setting === true);
+
 		const candidates = new Set<string>();
-
-		if (setting === true || setting === "subFolders") {
-			for (const dir of await findSubFolderProjectDirs(folder, setting === true)) {
-				candidates.add(dir);
-			}
-		} else if (setting === "openEditors") {
-			for (const dir of await findOpenEditorProjectDirs(folder)) {
-				candidates.add(dir);
-			}
-		}
-
-		for (const dir of candidates) {
+		for (const dir of discovered) {
 			if (isQuartoIgnored(ignorePatterns, toRelativePosixPath(folderPath, dir))) {
-				candidates.delete(dir);
 				logMessage(`Skipping ${dir}: matched by ${QUARTOIGNORE_FILENAME} in ${folderPath}.`, "debug");
+				continue;
 			}
+			candidates.add(dir);
 		}
 
 		if (candidates.has(folderPath) || candidates.size === 0) {
@@ -140,14 +142,6 @@ function buildRoot(folder: vscode.WorkspaceFolder, fsPath: string): QuartoProjec
 		return { fsPath, workspaceFolder: folder, label: folder.name };
 	}
 	return { fsPath, workspaceFolder: folder, label: `${folder.name}/${toRelativePosixPath(folder.uri.fsPath, fsPath)}` };
-}
-
-/**
- * Expresses `fsPath` relative to `basePath` with POSIX separators, as expected by
- * `.quartoignore` matching and by the project root labels.
- */
-function toRelativePosixPath(basePath: string, fsPath: string): string {
-	return path.relative(basePath, fsPath).split(path.sep).join(path.posix.sep);
 }
 
 async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder, recursive: boolean): Promise<string[]> {
@@ -289,15 +283,4 @@ async function directoryHasInstalledExtension(extensionsDir: vscode.Uri): Promis
 		}
 	}
 	return false;
-}
-
-/**
- * True when `child` is `parent` or lives below it (resolved, normalised path comparison).
- */
-export function isInside(parent: string, child: string): boolean {
-	const relative = path.relative(parent, child);
-	if (relative === "") {
-		return true;
-	}
-	return !relative.startsWith("..") && !path.isAbsolute(relative);
 }

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -1,6 +1,13 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { EXTENSIONS_DIR, MANIFEST_FILENAMES, getErrorMessage } from "@quarto-wizard/core";
+import {
+	EXTENSIONS_DIR,
+	MANIFEST_FILENAMES,
+	QUARTOIGNORE_FILENAME,
+	getErrorMessage,
+	isQuartoIgnored,
+	readQuartoIgnore,
+} from "@quarto-wizard/core";
 import { getAutoProjectDetection } from "./extensionDetails";
 import { logMessage } from "./log";
 
@@ -59,6 +66,8 @@ export interface QuartoProjectRoot {
  * `quartoWizard.autoProjectDetection` setting.
  *
  * Smart merge per workspace folder:
+ *  - if the folder root has a populated `_extensions/`, only that root is returned;
+ *  - else, paths matched by the folder's `.quartoignore` are discarded;
  *  - if the folder root itself contains `_quarto.{yml,yaml}`, only that root is returned;
  *  - else, all detected sub-roots are returned;
  *  - if nothing is detected, the folder root is returned as a fallback so the tree view
@@ -82,6 +91,15 @@ export async function discoverQuartoProjectRoots(
 			continue;
 		}
 
+		// Quarto resolves `_extensions/` by walking up from the input file, so a populated
+		// `_extensions/` at the folder root already serves every document below it. It is the
+		// primary host: no sub-folder is offered as a separate install or update target.
+		if (await directoryHasInstalledExtension(vscode.Uri.file(path.join(folderPath, EXTENSIONS_DIR)))) {
+			results.push(buildRoot(folder, folderPath));
+			continue;
+		}
+
+		const ignorePatterns = readQuartoIgnore(folderPath);
 		const candidates = new Set<string>();
 
 		if (setting === true || setting === "subFolders") {
@@ -91,6 +109,13 @@ export async function discoverQuartoProjectRoots(
 		} else if (setting === "openEditors") {
 			for (const dir of await findOpenEditorProjectDirs(folder)) {
 				candidates.add(dir);
+			}
+		}
+
+		for (const dir of candidates) {
+			if (isQuartoIgnored(ignorePatterns, toRelativePosixPath(folderPath, dir))) {
+				candidates.delete(dir);
+				logMessage(`Skipping ${dir}: matched by ${QUARTOIGNORE_FILENAME} in ${folderPath}.`, "debug");
 			}
 		}
 
@@ -114,8 +139,15 @@ function buildRoot(folder: vscode.WorkspaceFolder, fsPath: string): QuartoProjec
 	if (fsPath === folder.uri.fsPath) {
 		return { fsPath, workspaceFolder: folder, label: folder.name };
 	}
-	const relative = path.relative(folder.uri.fsPath, fsPath).split(path.sep).join(path.posix.sep);
-	return { fsPath, workspaceFolder: folder, label: `${folder.name}/${relative}` };
+	return { fsPath, workspaceFolder: folder, label: `${folder.name}/${toRelativePosixPath(folder.uri.fsPath, fsPath)}` };
+}
+
+/**
+ * Expresses `fsPath` relative to `basePath` with POSIX separators, as expected by
+ * `.quartoignore` matching and by the project root labels.
+ */
+function toRelativePosixPath(basePath: string, fsPath: string): string {
+	return path.relative(basePath, fsPath).split(path.sep).join(path.posix.sep);
 }
 
 async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder, recursive: boolean): Promise<string[]> {


### PR DESCRIPTION
Quarto resolves `_extensions/` by walking up from the document being rendered, so a populated `_extensions/` at the root of a workspace folder already serves every document below it. Project detection now stops there: no sub-folder is offered as a separate install, update, template or brand target, and the Extensions Installed view shows a single entry for that folder. This already held by accident when `quartoWizard.autoProjectDetection` is `true` or `subFolders`, because the folder ended up in the candidate set and the smart merge collapsed to it. It now also holds for `openEditors`, and for workspaces that exclude `_extensions` through `files.exclude` or `search.exclude`, which the recursive scan honours through `findFiles`. The check runs before any scan, so the common case does no globbing at all.

The same rule applies to the source side of an installation. `findAllExtensionRoots` returned every `_extension.yml` in a downloaded archive, including the vendored copies a documentation site keeps under `docs/_extensions/`. Installing `mcanouil/quarto-code-window` therefore opened a "This repository contains multiple extensions" picker listing one real extension and four copies. The archive's repository root is now resolved by stripping the wrapper directory a GitHub archive adds, and when that root has its own `_extensions/`, only the extensions below it are candidates.

Both sides honour the repository's `.quartoignore` through a new `quartoignore` module in `@quarto-wizard/core`, which reads the patterns and matches a path and its ancestors against them. Listing `docs` there keeps a documentation website out of the folder pickers and out of the extension list. Neither rule may empty the candidate list: an archive that only ships extensions in ignored locations still installs rather than failing with "No _extension.yml found in archive".

The `@vscode/test-electron` bump is unrelated to the behaviour change. VS Code 1.131 dropped the `Contents/MacOS/Electron` alias from its macOS bundle, which made the test suite fail to launch.