### PR TITLE
fix: patch manifest source fields without rewriting the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- fix: record `source` and `source-type` without rewriting the rest of an extension's `_extension.yml`. Installing, updating or using a template re-serialised the whole manifest from a fixed set of known keys, which dropped comments and any other top-level key the author had added, coerced `version: 1.0` to `'1'`, flipped quoting style, and reordered keys. The two fields are now patched line by line, so everything else stays byte for byte identical.
 - fix: stop **Use Template** from deleting a local template folder. The command removed whatever directory it had read the template from, and for a local source that directory is the user's own folder rather than a temporary copy. Only the temporary directory extracted from a downloaded archive is removed now.
 - fix: copy template files from the template's own folder when the repository is itself an extension, that is when `_extension.yml` sits at the top level rather than under `_extensions/`. The folder above the template was used instead, so **Use Template** pulled in that folder's unrelated contents.
 - fix: remove the whole temporary directory extracted from an archive. The wrapper directory that a downloaded archive unpacks into was left behind in the system temporary folder after every template use.

--- a/packages/core/src/filesystem/index.ts
+++ b/packages/core/src/filesystem/index.ts
@@ -10,7 +10,6 @@ export {
 	parseManifestContent,
 	readManifest,
 	hasManifest,
-	writeManifest,
 	updateManifestSource,
 } from "./manifest.js";
 

--- a/packages/core/src/filesystem/manifest.ts
+++ b/packages/core/src/filesystem/manifest.ts
@@ -129,77 +129,182 @@ export function hasManifest(directory: string): boolean {
 	return findManifestFile(directory) !== null;
 }
 
-/**
- * Write a manifest to a file.
- *
- * @param manifestPath - Path to write the manifest
- * @param manifest - Manifest data to write
- */
-export function writeManifest(manifestPath: string, manifest: ExtensionManifest): void {
-	const raw: RawManifest = {
-		title: manifest.title,
-		author: manifest.author,
-		version: manifest.version,
-	};
-
-	if (manifest.quartoRequired) {
-		raw["quarto-required"] = manifest.quartoRequired;
-	}
-
-	if (manifest.source) {
-		raw.source = manifest.source;
-	}
-
-	if (manifest.sourceType) {
-		raw["source-type"] = manifest.sourceType;
-	}
-
-	const contributes: RawManifest["contributes"] = {};
-	if (manifest.contributes.filter?.length) {
-		contributes.filters = manifest.contributes.filter;
-	}
-	if (manifest.contributes.shortcode?.length) {
-		contributes.shortcodes = manifest.contributes.shortcode;
-	}
-	if (manifest.contributes.format && Object.keys(manifest.contributes.format).length) {
-		contributes.formats = manifest.contributes.format;
-	}
-	if (manifest.contributes.project) {
-		contributes.project = manifest.contributes.project;
-	}
-	if (manifest.contributes.revealjsPlugin?.length) {
-		contributes["revealjs-plugins"] = manifest.contributes.revealjsPlugin;
-	}
-	if (manifest.contributes.metadata) {
-		contributes.metadata = manifest.contributes.metadata;
-	}
-
-	if (Object.keys(contributes).length > 0) {
-		raw.contributes = contributes;
-	}
-
-	const content = yaml.dump(raw, {
-		indent: 2,
-		lineWidth: 120,
-		noRefs: true,
-		sortKeys: false,
-	});
-
-	fs.writeFileSync(manifestPath, content, "utf-8");
+/** A manifest line together with the line terminator that followed it. */
+interface ManifestLine {
+	/** Line content without its terminator. */
+	text: string;
+	/** Line terminator, empty for a final line with no trailing newline. */
+	eol: string;
 }
 
 /**
- * Update the source field in an existing manifest file.
+ * Split content into lines, keeping each line's own terminator so that mixed
+ * or non-native line endings survive a round trip.
+ */
+function splitLines(content: string): ManifestLine[] {
+	return content.split(/(?<=\n)/).map((part) => {
+		const match = /\r?\n$/.exec(part);
+		return match ? { text: part.slice(0, match.index), eol: match[0] } : { text: part, eol: "" };
+	});
+}
+
+function joinLines(lines: ManifestLine[]): string {
+	return lines.map((line) => line.text + line.eol).join("");
+}
+
+/** Blank lines, comments, and directives carry no mapping content. */
+function isIgnorableLine(text: string): boolean {
+	const trimmed = text.trim();
+	return trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith("%");
+}
+
+function isDocumentStart(text: string): boolean {
+	return text === "---" || text.startsWith("--- ") || text.startsWith("---\t");
+}
+
+function isDocumentEnd(text: string): boolean {
+	return text === "..." || text.startsWith("... ") || text.startsWith("...\t");
+}
+
+/**
+ * Serialise a scalar with js-yaml so that values needing quotes get them,
+ * and plain values such as `owner/repo@v1.2.3` stay unquoted.
+ */
+function formatScalar(value: string): string {
+	return yaml.dump(value, { lineWidth: -1 }).replace(/\n$/, "");
+}
+
+/**
+ * Index of the first line of the first document's root mapping.
+ * Skips leading comments, directives, and an opening document separator.
+ */
+function findRootStart(lines: ManifestLine[]): number {
+	let index = 0;
+	while (index < lines.length && isIgnorableLine(lines[index].text)) {
+		index++;
+	}
+	if (index < lines.length && isDocumentStart(lines[index].text)) {
+		index++;
+		while (index < lines.length && isIgnorableLine(lines[index].text)) {
+			index++;
+		}
+	}
+	return index;
+}
+
+/**
+ * Exclusive index of the end of the first document, so that a second document
+ * in the same file is never patched.
+ */
+function findRootEnd(lines: ManifestLine[], start: number): number {
+	for (let index = start; index < lines.length; index++) {
+		const { text } = lines[index];
+		if (isDocumentStart(text) || isDocumentEnd(text)) {
+			return index;
+		}
+	}
+	return lines.length;
+}
+
+/**
+ * Exclusive index of the last line belonging to the value that starts at
+ * `from`, covering block scalars and multi-line plain scalars.
+ */
+function findValueEnd(lines: ManifestLine[], from: number, end: number): number {
+	let last = from;
+	for (let index = from; index < end; index++) {
+		const { text } = lines[index];
+		if (text.trim() === "") {
+			continue;
+		}
+		if (/^\s/.test(text)) {
+			last = index + 1;
+			continue;
+		}
+		break;
+	}
+	return last;
+}
+
+/**
+ * Upsert a top-level scalar key, leaving every other byte of the document
+ * untouched. A missing key is appended at the end of the first document; an
+ * existing one is replaced where it stands.
+ *
+ * Zero indentation is a safe anchor for the key: nested mappings and block
+ * scalar bodies must be indented past their parent, so a `source:` under
+ * `contributes:` is never mistaken for the root key.
+ *
+ * @param content - Current manifest content
+ * @param key - Top-level key to set
+ * @param value - Scalar value to record
+ * @param manifestPath - Manifest path, used for error reporting
+ * @returns Updated manifest content
+ * @throws ManifestError if the document root is a flow collection
+ */
+function setTopLevelScalar(content: string, key: string, value: string, manifestPath: string): string {
+	const lines = splitLines(content);
+	const start = findRootStart(lines);
+
+	if (start < lines.length && /^[{[]/.test(lines[start].text)) {
+		throw new ManifestError(
+			`Cannot record "${key}": the manifest root is a flow collection, which requires a block mapping with one key per line.`,
+			{ manifestPath },
+		);
+	}
+
+	const end = findRootEnd(lines, start);
+	const defaultEol = lines.find((line) => line.eol !== "")?.eol ?? "\n";
+	const newText = `${key}: ${formatScalar(value)}`;
+	const keyPattern = new RegExp(`^${key}\\s*:(\\s|$)`);
+	const keyIndex = lines.findIndex((line, index) => index >= start && index < end && keyPattern.test(line.text));
+
+	if (keyIndex !== -1) {
+		const valueEnd = findValueEnd(lines, keyIndex + 1, end);
+		lines.splice(keyIndex, valueEnd - keyIndex, { text: newText, eol: lines[keyIndex].eol || defaultEol });
+		return joinLines(lines);
+	}
+
+	const previous = end > 0 ? lines[end - 1] : undefined;
+	if (previous && previous.text === "" && previous.eol === "") {
+		lines.splice(end - 1, 1, { text: newText, eol: defaultEol });
+		return joinLines(lines);
+	}
+	if (previous && previous.eol === "") {
+		previous.eol = defaultEol;
+	}
+	lines.splice(end, 0, { text: newText, eol: defaultEol });
+	return joinLines(lines);
+}
+
+/**
+ * Record the source of an installed extension in its manifest.
+ *
+ * Patches the `source` and `source-type` lines in place instead of
+ * re-serialising the document, so comments, key order, quoting style, and any
+ * keys the extension author added are preserved. A file without a trailing
+ * newline gains one when a key is appended.
  *
  * @param manifestPath - Path to the manifest file
  * @param source - New source value
  * @param sourceType - Type of source (github, url, local, registry)
+ * @throws ManifestError if the manifest cannot be read or patched
  */
 export function updateManifestSource(manifestPath: string, source: string, sourceType?: SourceType): void {
-	const manifest = parseManifestFile(manifestPath);
-	manifest.source = source;
-	if (sourceType) {
-		manifest.sourceType = sourceType;
+	let content: string;
+	try {
+		content = fs.readFileSync(manifestPath, "utf-8");
+	} catch (error) {
+		throw new ManifestError(`Failed to read manifest file: ${getErrorMessage(error)}`, {
+			manifestPath,
+			cause: error,
+		});
 	}
-	writeManifest(manifestPath, manifest);
+
+	let updated = setTopLevelScalar(content, "source", source, manifestPath);
+	if (sourceType) {
+		updated = setTopLevelScalar(updated, "source-type", sourceType, manifestPath);
+	}
+
+	fs.writeFileSync(manifestPath, updated, "utf-8");
 }

--- a/packages/core/src/filesystem/manifest.ts
+++ b/packages/core/src/filesystem/manifest.ts
@@ -46,6 +46,24 @@ export function findManifestFile(directory: string): string | null {
 }
 
 /**
+ * Read a manifest file as text.
+ *
+ * @param manifestPath - Full path to the manifest file
+ * @returns File content
+ * @throws ManifestError if the file cannot be read
+ */
+function readManifestContent(manifestPath: string): string {
+	try {
+		return fs.readFileSync(manifestPath, "utf-8");
+	} catch (error) {
+		throw new ManifestError(`Failed to read manifest file: ${getErrorMessage(error)}`, {
+			manifestPath,
+			cause: error,
+		});
+	}
+}
+
+/**
  * Parse a manifest file from a path.
  *
  * @param manifestPath - Full path to the manifest file
@@ -53,18 +71,7 @@ export function findManifestFile(directory: string): string | null {
  * @throws ManifestError if parsing fails
  */
 export function parseManifestFile(manifestPath: string): ExtensionManifest {
-	try {
-		const content = fs.readFileSync(manifestPath, "utf-8");
-		return parseManifestContent(content, manifestPath);
-	} catch (error) {
-		if (error instanceof ManifestError) {
-			throw error;
-		}
-		throw new ManifestError(`Failed to read manifest file: ${getErrorMessage(error)}`, {
-			manifestPath,
-			cause: error,
-		});
-	}
+	return parseManifestContent(readManifestContent(manifestPath), manifestPath);
 }
 
 /**
@@ -158,12 +165,12 @@ function isIgnorableLine(text: string): boolean {
 	return trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith("%");
 }
 
-function isDocumentStart(text: string): boolean {
-	return text === "---" || text.startsWith("--- ") || text.startsWith("---\t");
-}
-
-function isDocumentEnd(text: string): boolean {
-	return text === "..." || text.startsWith("... ") || text.startsWith("...\t");
+/**
+ * Whether a line is the given document marker, `---` or `...`, on its own or
+ * followed by a comment.
+ */
+function isDocumentMarker(text: string, marker: string): boolean {
+	return text === marker || text.startsWith(`${marker} `) || text.startsWith(`${marker}\t`);
 }
 
 /**
@@ -177,13 +184,15 @@ function formatScalar(value: string): string {
 /**
  * Index of the first line of the first document's root mapping.
  * Skips leading comments, directives, and an opening document separator.
+ * A Quarto manifest holds none of those, but this patcher edits a file it
+ * does not own, so they are read rather than assumed away.
  */
 function findRootStart(lines: ManifestLine[]): number {
 	let index = 0;
 	while (index < lines.length && isIgnorableLine(lines[index].text)) {
 		index++;
 	}
-	if (index < lines.length && isDocumentStart(lines[index].text)) {
+	if (index < lines.length && isDocumentMarker(lines[index].text, "---")) {
 		index++;
 		while (index < lines.length && isIgnorableLine(lines[index].text)) {
 			index++;
@@ -199,7 +208,7 @@ function findRootStart(lines: ManifestLine[]): number {
 function findRootEnd(lines: ManifestLine[], start: number): number {
 	for (let index = start; index < lines.length; index++) {
 		const { text } = lines[index];
-		if (isDocumentStart(text) || isDocumentEnd(text)) {
+		if (isDocumentMarker(text, "---") || isDocumentMarker(text, "...")) {
 			return index;
 		}
 	}
@@ -266,10 +275,6 @@ function setTopLevelScalar(content: string, key: string, value: string, manifest
 	}
 
 	const previous = end > 0 ? lines[end - 1] : undefined;
-	if (previous && previous.text === "" && previous.eol === "") {
-		lines.splice(end - 1, 1, { text: newText, eol: defaultEol });
-		return joinLines(lines);
-	}
 	if (previous && previous.eol === "") {
 		previous.eol = defaultEol;
 	}
@@ -291,17 +296,7 @@ function setTopLevelScalar(content: string, key: string, value: string, manifest
  * @throws ManifestError if the manifest cannot be read or patched
  */
 export function updateManifestSource(manifestPath: string, source: string, sourceType?: SourceType): void {
-	let content: string;
-	try {
-		content = fs.readFileSync(manifestPath, "utf-8");
-	} catch (error) {
-		throw new ManifestError(`Failed to read manifest file: ${getErrorMessage(error)}`, {
-			manifestPath,
-			cause: error,
-		});
-	}
-
-	let updated = setTopLevelScalar(content, "source", source, manifestPath);
+	let updated = setTopLevelScalar(readManifestContent(manifestPath), "source", source, manifestPath);
 	if (sourceType) {
 		updated = setTopLevelScalar(updated, "source-type", sourceType, manifestPath);
 	}

--- a/packages/core/tests/manifest.test.ts
+++ b/packages/core/tests/manifest.test.ts
@@ -520,6 +520,16 @@ describe("filesystem manifest functions", () => {
 			);
 		});
 
+		it("keeps both keys inside the first document", () => {
+			const manifestPath = writeFixture("title: Test\n---\ntitle: Other\n");
+
+			updateManifestSource(manifestPath, "owner/repo", "github");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe(
+				"title: Test\nsource: owner/repo\nsource-type: github\n---\ntitle: Other\n",
+			);
+		});
+
 		it("stops at an explicit document end marker", () => {
 			const manifestPath = writeFixture("title: Test\n...\n");
 

--- a/packages/core/tests/manifest.test.ts
+++ b/packages/core/tests/manifest.test.ts
@@ -9,7 +9,6 @@ import {
 	findManifestFile,
 	readManifest,
 	hasManifest,
-	writeManifest,
 	updateManifestSource,
 } from "../src/filesystem/manifest.js";
 import { ManifestError } from "../src/errors.js";
@@ -401,254 +400,138 @@ describe("filesystem manifest functions", () => {
 		});
 	});
 
-	describe("writeManifest", () => {
-		it("writes a basic manifest", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test Extension",
-				author: "Test Author",
-				version: "1.0.0",
-				contributes: {},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("title: Test Extension");
-			expect(content).toContain("author: Test Author");
-			expect(content).toContain("version: 1.0.0");
-		});
-
-		it("writes manifest with quarto-required", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				quartoRequired: ">=1.3.0",
-				contributes: {},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("quarto-required");
-		});
-
-		it("writes manifest with source", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				source: "owner/repo@v1.0.0",
-				contributes: {},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: owner/repo@v1.0.0");
-		});
-
-		it("writes manifest with filters", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {
-					filter: ["filter.lua"],
-				},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("filters:");
-			expect(content).toContain("filter.lua");
-		});
-
-		it("writes manifest with shortcodes", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {
-					shortcode: ["shortcode.lua"],
-				},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("shortcodes:");
-		});
-
-		it("writes manifest with formats", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {
-					format: { html: { toc: true } },
-				},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("formats:");
-		});
-
-		it("writes manifest with project", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {
-					project: { type: "book" },
-				},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("project:");
-		});
-
-		it("writes manifest with revealjs-plugins", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {
-					revealjsPlugin: ["plugin.js"],
-				},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("revealjs-plugins:");
-		});
-
-		it("writes manifest with metadata", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {
-					metadata: { key: "value" },
-				},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("metadata:");
-		});
-
-		it("omits empty contributes", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				contributes: {},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).not.toContain("contributes:");
-		});
-	});
-
 	describe("updateManifestSource", () => {
-		it("updates the source field in an existing manifest", () => {
+		const writeFixture = (content: string): string => {
 			const manifestPath = path.join(tempDir, "_extension.yml");
-			fs.writeFileSync(manifestPath, "title: Test\nversion: 1.0.0\n");
+			fs.writeFileSync(manifestPath, content);
+			return manifestPath;
+		};
 
-			updateManifestSource(manifestPath, "owner/repo@v2.0.0");
+		it("preserves comments, key order, formatting, and unknown keys", () => {
+			const original = [
+				"# My extension",
+				"title: Fancy Extension  # inline comment",
+				"version: 1.0",
+				'quarto-required: ">=1.4.0"',
+				"contributes:",
+				"  formats:",
+				"    html:",
+				"      theme: custom.scss",
+				"  shortcodes:",
+				"    - fancy.lua",
+				"custom-key: keep me",
+				"",
+			].join("\n");
+			const manifestPath = writeFixture(original);
 
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: owner/repo@v2.0.0");
+			updateManifestSource(manifestPath, "owner/repo@v1.2.3", "github");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe(
+				`${original}source: owner/repo@v1.2.3\nsource-type: github\n`,
+			);
 		});
 
-		it("overwrites existing source field", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			fs.writeFileSync(manifestPath, "title: Test\nversion: 1.0.0\nsource: old/source\n");
+		it("replaces an existing source in place", () => {
+			const manifestPath = writeFixture("title: Test\nsource: old/source\nversion: 1.0.0\n");
 
 			updateManifestSource(manifestPath, "new/source@v1.0.0");
 
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: new/source@v1.0.0");
-			expect(content).not.toContain("old/source");
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("title: Test\nsource: new/source@v1.0.0\nversion: 1.0.0\n");
 		});
 
-		it("writes source-type when provided", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			fs.writeFileSync(manifestPath, "title: Test\nversion: 1.0.0\n");
+		it("replaces an existing source-type in place", () => {
+			const manifestPath = writeFixture("title: Test\nsource: owner/repo\nsource-type: local\n");
 
 			updateManifestSource(manifestPath, "owner/repo", "github");
 
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: owner/repo");
-			expect(content).toContain("source-type: github");
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("title: Test\nsource: owner/repo\nsource-type: github\n");
+		});
+
+		it("appends source-type when provided", () => {
+			const manifestPath = writeFixture("title: Test\nversion: 1.0.0\n");
+
+			updateManifestSource(manifestPath, "owner/repo", "github");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe(
+				"title: Test\nversion: 1.0.0\nsource: owner/repo\nsource-type: github\n",
+			);
 		});
 
 		it("omits source-type when not provided", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			fs.writeFileSync(manifestPath, "title: Test\nversion: 1.0.0\n");
+			const manifestPath = writeFixture("title: Test\nversion: 1.0.0\n");
 
 			updateManifestSource(manifestPath, "owner/repo");
 
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: owner/repo");
-			expect(content).not.toContain("source-type");
-		});
-	});
-
-	describe("writeManifest with sourceType", () => {
-		it("writes source-type field", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				source: "owner/repo",
-				sourceType: "github" as const,
-				contributes: {},
-			};
-
-			writeManifest(manifestPath, manifest);
-
-			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: owner/repo");
-			expect(content).toContain("source-type: github");
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("title: Test\nversion: 1.0.0\nsource: owner/repo\n");
 		});
 
-		it("omits source-type when undefined", () => {
-			const manifestPath = path.join(tempDir, "_extension.yml");
-			const manifest = {
-				title: "Test",
-				author: "",
-				version: "1.0.0",
-				source: "owner/repo",
-				contributes: {},
-			};
+		it("leaves a nested source key untouched", () => {
+			const manifestPath = writeFixture("title: Test\ncontributes:\n  metadata:\n    source: nested\n");
 
-			writeManifest(manifestPath, manifest);
+			updateManifestSource(manifestPath, "owner/repo");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe(
+				"title: Test\ncontributes:\n  metadata:\n    source: nested\nsource: owner/repo\n",
+			);
+		});
+
+		it("terminates the appended key when the file lacks a trailing newline", () => {
+			const manifestPath = writeFixture("title: Test");
+
+			updateManifestSource(manifestPath, "owner/repo");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("title: Test\nsource: owner/repo\n");
+		});
+
+		it("preserves CRLF line endings", () => {
+			const manifestPath = writeFixture("title: Test\r\nversion: 1.0.0\r\n");
+
+			updateManifestSource(manifestPath, "owner/repo", "github");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe(
+				"title: Test\r\nversion: 1.0.0\r\nsource: owner/repo\r\nsource-type: github\r\n",
+			);
+		});
+
+		it("removes the continuation lines of a replaced block scalar", () => {
+			const manifestPath = writeFixture("title: Test\nsource: |\n  old\n\n  value\nversion: 1.0.0\n");
+
+			updateManifestSource(manifestPath, "owner/repo");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("title: Test\nsource: owner/repo\nversion: 1.0.0\n");
+		});
+
+		it("quotes values that require quoting", () => {
+			const manifestPath = writeFixture("title: Test\n");
+
+			updateManifestSource(manifestPath, "*needs: quoting");
 
 			const content = fs.readFileSync(manifestPath, "utf-8");
-			expect(content).toContain("source: owner/repo");
-			expect(content).not.toContain("source-type");
+			expect(parseManifestContent(content).source).toBe("*needs: quoting");
+		});
+
+		it("patches only the first document of a multi-document file", () => {
+			const manifestPath = writeFixture("title: Test\n---\ntitle: Other\nsource: untouched\n");
+
+			updateManifestSource(manifestPath, "owner/repo");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe(
+				"title: Test\nsource: owner/repo\n---\ntitle: Other\nsource: untouched\n",
+			);
+		});
+
+		it("skips a leading document separator when locating the root", () => {
+			const manifestPath = writeFixture("---\ntitle: Test\n");
+
+			updateManifestSource(manifestPath, "owner/repo");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("---\ntitle: Test\nsource: owner/repo\n");
+		});
+
+		it("throws when the manifest root is a flow mapping", () => {
+			const manifestPath = writeFixture("{title: Test, version: 1.0.0}\n");
+
+			expect(() => updateManifestSource(manifestPath, "owner/repo")).toThrow(ManifestError);
 		});
 	});
 });

--- a/packages/core/tests/manifest.test.ts
+++ b/packages/core/tests/manifest.test.ts
@@ -520,6 +520,14 @@ describe("filesystem manifest functions", () => {
 			);
 		});
 
+		it("stops at an explicit document end marker", () => {
+			const manifestPath = writeFixture("title: Test\n...\n");
+
+			updateManifestSource(manifestPath, "owner/repo");
+
+			expect(fs.readFileSync(manifestPath, "utf-8")).toBe("title: Test\nsource: owner/repo\n...\n");
+		});
+
 		it("skips a leading document separator when locating the root", () => {
 			const manifestPath = writeFixture("---\ntitle: Test\n");
 


### PR DESCRIPTION
Installing an extension, updating one, or using a template re-serialised the whole `_extension.yml` instead of touching the two fields Quarto Wizard records. `updateManifestSource` parsed the manifest into a fixed set of known keys and wrote it back with `yaml.dump`, so comments and any other top-level key the author had added were dropped, `version: 1.0` was coerced to `'1'`, quoting style flipped, keys were reordered, and anchors were expanded.

`source` and `source-type` are now patched line by line. A missing key is appended at the end of the first document, an existing one is replaced where it stands, and everything else is left byte for byte identical. Each line keeps its own terminator, so CRLF files stay CRLF. Zero indentation anchors the key, which is why a `source:` nested under `contributes:` is never touched. A manifest whose root is a flow collection cannot be patched this way and raises a `ManifestError`, which rolls the installation back.

`writeManifest` was only reachable through `updateManifestSource` and is removed, along with its export from `@quarto-wizard/core`. Reading is unchanged.

The tests compare the whole file rather than searching for a substring, so a reordered or dropped key fails them. They cover comment and unknown-key preservation, replacement in place, a nested `source` key, a missing trailing newline, CRLF, block scalar continuation lines, values that need quoting, document markers, and the flow collection error.