### PR TITLE
fix(schema): parse a block sequence at its key's column

### DIFF
--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1123,6 +1123,7 @@ local function _read_block_scalar(lines, start, parent_indent, style)
 end
 
 local _parse_block
+local _parse_sequence
 
 --- The order in which each parsed mapping declared its keys.
 --- Lua tables have no key order, but a schema is authored in a meaningful one,
@@ -1200,6 +1201,23 @@ local function _parse_map(lines, start, indent, depth)
           if err then
             return nil, next_index, err
           end
+
+          -- A block sequence may sit at the column of its own key, which
+          -- `_parse_block` declines because its guard wants a deeper line.
+          -- Nothing was consumed in that case, so read the sequence here.
+          if value == nil and next_index == index then
+            local peek = _skip_insignificant(lines, index)
+            if peek <= #lines and lines[peek].indent == indent then
+              local ahead = _content(lines[peek])
+              if ahead == '-' or ahead:sub(1, 2) == '- ' then
+                value, next_index, err = _parse_sequence(lines, peek, indent, depth + 1)
+                if err then
+                  return nil, next_index, err
+                end
+              end
+            end
+          end
+
           map[key] = value
           index = next_index
         elseif rest:sub(1, 1) == '[' or rest:sub(1, 1) == '{' then
@@ -1232,7 +1250,7 @@ end
 --- @return table|nil sequence
 --- @return number next_index
 --- @return string|nil err
-local function _parse_sequence(lines, start, indent, depth)
+_parse_sequence = function(lines, start, indent, depth)
   local sequence = {}
   local index = start
 

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1123,6 +1123,7 @@ local function _read_block_scalar(lines, start, parent_indent, style)
 end
 
 local _parse_block
+local _parse_sequence
 
 --- The order in which each parsed mapping declared its keys.
 --- Lua tables have no key order, but a schema is authored in a meaningful one,
@@ -1200,6 +1201,23 @@ local function _parse_map(lines, start, indent, depth)
           if err then
             return nil, next_index, err
           end
+
+          -- A block sequence may sit at the column of its own key, which
+          -- `_parse_block` declines because its guard wants a deeper line.
+          -- Nothing was consumed in that case, so read the sequence here.
+          if value == nil and next_index == index then
+            local peek = _skip_insignificant(lines, index)
+            if peek <= #lines and lines[peek].indent == indent then
+              local ahead = _content(lines[peek])
+              if ahead == '-' or ahead:sub(1, 2) == '- ' then
+                value, next_index, err = _parse_sequence(lines, peek, indent, depth + 1)
+                if err then
+                  return nil, next_index, err
+                end
+              end
+            end
+          end
+
           map[key] = value
           index = next_index
         elseif rest:sub(1, 1) == '[' or rest:sub(1, 1) == '{' then
@@ -1232,7 +1250,7 @@ end
 --- @return table|nil sequence
 --- @return number next_index
 --- @return string|nil err
-local function _parse_sequence(lines, start, indent, depth)
+_parse_sequence = function(lines, start, indent, depth)
   local sequence = {}
   local index = start
 

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -615,6 +615,31 @@ test('an empty sequence item is refused rather than shifting later items', funct
   assert_contains(tostring(err), 'empty')
 end)
 
+test('a block sequence may sit at the column of its key', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+    - color
+]])
+  local aliases = loaded.options.colour.aliases
+  assert_eq(type(aliases), 'table', 'aliases should parse to a table')
+  assert_eq(#aliases, 1, 'aliases should hold one entry')
+  assert_eq(aliases[1], 'color', 'the alias should be "color"')
+end)
+
+test('an indented block sequence still parses', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+      - color
+]])
+  assert_eq(loaded.options.colour.aliases[1], 'color', 'the alias should be "color"')
+end)
+
 -- ============================================================================
 -- STRUCTURE AND ENTRY POINTS
 -- ============================================================================


### PR DESCRIPTION
A block sequence written at the same column as its key is valid YAML, and the parser refused it. `aliases:` followed by a flush `- color` failed the whole schema file.

Bottom of the stack, so it lands before the tasks that read parsed values.