### PR TITLE
fix(schema): refuse patterns the compiler cannot express

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - feat: publish the Lua reference validator of the v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/schema.lua`. The vocabulary and the validator carry the same version, and extensions can now resolve the module by URL. (#374)
 
+### Bug Fixes
+
+- fix: report an error for every value of a field whose `pattern` the Lua reference validator cannot compile, instead of compiling that pattern to one that matches the wrong values. The refusal now covers an anchored alternation such as `^a|b$`, and the escapes `\b`, `\B`, `\0`, `\c`, `\u`, `\x`, `\p` and `\k`.
+
 ## 3.2.0 (2026-08-02)
 
 ### New Features

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -386,6 +386,7 @@ local function _compile_pattern(regex)
   local length = #regex
   local anchor_start = false
   local anchor_end = false
+  local has_top_level_alternation = false
   local parse_alternation
 
   --- Combine a set of prefixes with a set of continuations.
@@ -603,7 +604,9 @@ local function _compile_pattern(regex)
 
   parse_alternation = function(depth)
     local all = {}
+    local iterations = 0
     while true do
+      iterations = iterations + 1
       local branches, reason = parse_sequence(depth)
       if not branches then
         return nil, reason
@@ -620,6 +623,9 @@ local function _compile_pattern(regex)
         break
       end
     end
+    if depth == 0 and iterations > 1 then
+      has_top_level_alternation = true
+    end
     return all
   end
 
@@ -629,6 +635,12 @@ local function _compile_pattern(regex)
   end
   if position <= length then
     return nil, 'unbalanced ")" in pattern'
+  end
+
+  -- The anchors are collected for the expression as a whole, so applying them
+  -- to multiple top-level branches would anchor branches the author did not anchor.
+  if has_top_level_alternation and (anchor_start or anchor_end) then
+    return nil, 'unsupported anchor in a top-level alternation'
   end
 
   local prefix = anchor_start and '^' or ''

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -442,7 +442,7 @@ local function _compile_pattern(regex)
         local mapped = ESCAPE_INSIDE[next_char]
         if mapped then
           out[#out + 1] = mapped
-        elseif next_char:match('%d') then
+        elseif next_char:match('[1-9]') then
           return nil, 'unsupported backreference "\\' .. next_char .. '"'
         elseif next_char == '%' then
           out[#out + 1] = '%%'

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -361,6 +361,16 @@ local ESCAPE_INSIDE = {
   d = '%d', D = '%D', w = '%w_', s = '%s', S = '%S',
 }
 
+--- Escapes with a real Lua equivalent. Anything else alphanumeric is refused,
+--- because compiling it to the bare letter would accept the wrong values.
+local CONTROL_ESCAPES = {
+  n = '\n',
+  t = '\t',
+  r = '\r',
+  f = '\f',
+  v = '\v',
+}
+
 --- Characters Lua treats as magic outside a character class.
 local LUA_MAGIC = '^$()%.[]*+-?'
 
@@ -436,8 +446,10 @@ local function _compile_pattern(regex)
           return nil, 'unsupported backreference "\\' .. next_char .. '"'
         elseif next_char == '%' then
           out[#out + 1] = '%%'
+        elseif CONTROL_ESCAPES[next_char] then
+          out[#out + 1] = CONTROL_ESCAPES[next_char]
         elseif next_char:match('%w') then
-          out[#out + 1] = next_char
+          return nil, 'unsupported escape "\\' .. next_char .. '"'
         else
           out[#out + 1] = '%' .. next_char
         end
@@ -523,8 +535,10 @@ local function _compile_pattern(regex)
       local atom
       if mapped then
         atom = mapped
+      elseif CONTROL_ESCAPES[next_char] then
+        atom = CONTROL_ESCAPES[next_char]
       elseif next_char:match('%w') then
-        atom = next_char
+        return nil, 'unsupported escape "\\' .. next_char .. '"'
       else
         atom = _escape_literal(next_char)
       end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -386,6 +386,7 @@ local function _compile_pattern(regex)
   local length = #regex
   local anchor_start = false
   local anchor_end = false
+  local has_top_level_alternation = false
   local parse_alternation
 
   --- Combine a set of prefixes with a set of continuations.
@@ -603,7 +604,9 @@ local function _compile_pattern(regex)
 
   parse_alternation = function(depth)
     local all = {}
+    local iterations = 0
     while true do
+      iterations = iterations + 1
       local branches, reason = parse_sequence(depth)
       if not branches then
         return nil, reason
@@ -620,6 +623,9 @@ local function _compile_pattern(regex)
         break
       end
     end
+    if depth == 0 and iterations > 1 then
+      has_top_level_alternation = true
+    end
     return all
   end
 
@@ -629,6 +635,12 @@ local function _compile_pattern(regex)
   end
   if position <= length then
     return nil, 'unbalanced ")" in pattern'
+  end
+
+  -- The anchors are collected for the expression as a whole, so applying them
+  -- to multiple top-level branches would anchor branches the author did not anchor.
+  if has_top_level_alternation and (anchor_start or anchor_end) then
+    return nil, 'unsupported anchor in a top-level alternation'
   end
 
   local prefix = anchor_start and '^' or ''

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -442,7 +442,7 @@ local function _compile_pattern(regex)
         local mapped = ESCAPE_INSIDE[next_char]
         if mapped then
           out[#out + 1] = mapped
-        elseif next_char:match('%d') then
+        elseif next_char:match('[1-9]') then
           return nil, 'unsupported backreference "\\' .. next_char .. '"'
         elseif next_char == '%' then
           out[#out + 1] = '%%'

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -361,6 +361,16 @@ local ESCAPE_INSIDE = {
   d = '%d', D = '%D', w = '%w_', s = '%s', S = '%S',
 }
 
+--- Escapes with a real Lua equivalent. Anything else alphanumeric is refused,
+--- because compiling it to the bare letter would accept the wrong values.
+local CONTROL_ESCAPES = {
+  n = '\n',
+  t = '\t',
+  r = '\r',
+  f = '\f',
+  v = '\v',
+}
+
 --- Characters Lua treats as magic outside a character class.
 local LUA_MAGIC = '^$()%.[]*+-?'
 
@@ -436,8 +446,10 @@ local function _compile_pattern(regex)
           return nil, 'unsupported backreference "\\' .. next_char .. '"'
         elseif next_char == '%' then
           out[#out + 1] = '%%'
+        elseif CONTROL_ESCAPES[next_char] then
+          out[#out + 1] = CONTROL_ESCAPES[next_char]
         elseif next_char:match('%w') then
-          out[#out + 1] = next_char
+          return nil, 'unsupported escape "\\' .. next_char .. '"'
         else
           out[#out + 1] = '%' .. next_char
         end
@@ -523,8 +535,10 @@ local function _compile_pattern(regex)
       local atom
       if mapped then
         atom = mapped
+      elseif CONTROL_ESCAPES[next_char] then
+        atom = CONTROL_ESCAPES[next_char]
       elseif next_char:match('%w') then
-        atom = next_char
+        return nil, 'unsupported escape "\\' .. next_char .. '"'
       else
         atom = _escape_literal(next_char)
       end

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -347,6 +347,35 @@ test('an unanchored alternation still compiles', function()
   assert_true(pattern_matches('abc|def', 'def'), 'abc|def should match def')
 end)
 
+test('a control escape maps to its character', function()
+  assert_true(pattern_matches('a\\nb', 'a\nb'), '\\n should match a newline')
+  assert_true(pattern_matches('a\\tb', 'a\tb'), '\\t should match a tab')
+end)
+
+test('an escape this compiler cannot express is refused', function()
+  local branches, reason = schema._compile_pattern('a\\bc')
+  assert_eq(branches, nil, '\\b should not compile to the letter b')
+  assert_true(
+    reason ~= nil and reason:find('escape', 1, true) ~= nil,
+    'the reason should name the escape, got: ' .. tostring(reason)
+  )
+end)
+
+test('a refused escape inside a character class is reported too', function()
+  local branches, reason = schema._compile_pattern('[\\b]')
+  assert_eq(branches, nil, '\\b inside a class should not compile')
+  assert_true(reason ~= nil, 'a reason should be given')
+end)
+
+test('a control escape inside a character class matches its character', function()
+  assert_true(pattern_matches('[\\n]', '\n'), '[\\n] should match a newline')
+  assert_false(pattern_matches('[\\n]', 'n'), '[\\n] should not match the letter n')
+end)
+
+test('an ordinary pattern still compiles', function()
+  assert_true(pattern_matches('abc', 'abc'), 'abc should match abc')
+end)
+
 -- ============================================================================
 -- KEYWORD COVERAGE
 -- ============================================================================

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -329,6 +329,24 @@ test('the only pattern used in the corpus still works', function()
   assert_false(pattern_matches(regex, '3'))
 end)
 
+test('an anchor across an alternation is refused rather than misapplied', function()
+  local branches, reason = schema._compile_pattern('^abc|def$')
+  assert_eq(branches, nil, 'an anchored alternation should not compile')
+  assert_true(
+    reason ~= nil and reason:find('alternation', 1, true) ~= nil,
+    'the reason should name the alternation, got: ' .. tostring(reason)
+  )
+end)
+
+test('an anchor on a single branch still compiles', function()
+  assert_true(pattern_matches('^abc$', 'abc'), '^abc$ should match abc')
+  assert_false(pattern_matches('^abc$', 'xabc'), '^abc$ should not match xabc')
+end)
+
+test('an unanchored alternation still compiles', function()
+  assert_true(pattern_matches('abc|def', 'def'), 'abc|def should match def')
+end)
+
 -- ============================================================================
 -- KEYWORD COVERAGE
 -- ============================================================================

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -367,6 +367,12 @@ test('a refused escape inside a character class is reported too', function()
   assert_true(reason ~= nil, 'a reason should be given')
 end)
 
+test('a zero escape inside a character class is named an escape, not a backreference', function()
+  local branches, reason = schema._compile_pattern('[\\0]')
+  assert_eq(branches, nil, '[\\0] should not compile')
+  assert_contains(reason, 'unsupported escape "\\0"')
+end)
+
 test('a control escape inside a character class matches its character', function()
   assert_true(pattern_matches('[\\n]', '\n'), '[\\n] should match a newline')
   assert_false(pattern_matches('[\\n]', 'n'), '[\\n] should not match the letter n')


### PR DESCRIPTION
Two silent divergences in the pattern compiler. An anchor was applied to every branch of a top-level alternation, so `^abc|def$` compiled to `{'^abc$', '^def$'}` and rejected strings the expression accepts. Unmapped alphanumeric escapes fell through to the bare letter, so `\b` matched `b`.

Both now report a reason, which is what the module does for every other construct it cannot express.