### PR TITLE
fix(schema): correct empty string, alias and dependency handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - fix: report an error for every value of a field whose `pattern` the Lua reference validator cannot compile, instead of compiling that pattern to one that matches the wrong values. The refusal now covers an anchored alternation such as `^a|b$`, and the escapes `\b`, `\B`, `\0`, `\c`, `\u`, `\x`, `\p` and `\k`.
+- fix: treat an empty string as a value in the Lua reference validator. A key set to `""` keeps that value, does not take its `default`, and is tested against `minLength`, `const` and `enum`. An extension that relied on an empty string falling back to its default no longer gets that fallback.
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@
 ### Bug Fixes
 
 - fix: report an error for every value of a field whose `pattern` the Lua reference validator cannot compile, instead of compiling that pattern to one that matches the wrong values. The refusal now covers an anchored alternation such as `^a|b$`, and the escapes `\b`, `\B`, `\0`, `\c`, `\u`, `\x`, `\p` and `\k`.
-- fix: treat an empty string as a value in the Lua reference validator. A key set to `""` keeps that value, does not take its `default`, and is tested against `minLength`, `const` and `enum`. An extension that relied on an empty string falling back to its default no longer gets that fallback.
+- fix: treat an empty string as a value in the Lua reference validator. A key set to `""` keeps that value and is tested against `type`, `minLength`, `const` and `enum`.
+- fix: stop an empty string from taking a field's `default` in the Lua reference validator. `count: ""` on a field declared `type: number` is now an error that reads `must be of type "number", got "string"`, where it used to take the default.
+- fix: drop a `null` element from a document metadata sequence in the Lua reference validator, where it used to become an empty string. `tags: [a, ~]` now holds one element rather than two, so a field declared `minItems: 2` no longer passes.
 - fix: warn when a deprecated option is set to an empty string in the Lua reference validator. The deprecation warning used to be skipped for `""` in the same way as for an absent key.
 - fix: validate a surplus key matched by `additionalProperties`, and an array element matched by `items`, when the value is an empty string in the Lua reference validator. Both used to skip `""` instead of testing it.
+- fix: let the name a schema declares win over an alias in the Lua reference validator. The conflict warning now names the two keys the author wrote, rather than a name that only the schema uses.
+- fix: accept a document that supplies both a field's declared name and one of its aliases in the Lua reference validator. Under `additionalProperties: false` the leftover alias key made the document invalid, and it now produces a warning.
+- fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - fix: report an error for every value of a field whose `pattern` the Lua reference validator cannot compile, instead of compiling that pattern to one that matches the wrong values. The refusal now covers an anchored alternation such as `^a|b$`, and the escapes `\b`, `\B`, `\0`, `\c`, `\u`, `\x`, `\p` and `\k`.
 - fix: treat an empty string as a value in the Lua reference validator. A key set to `""` keeps that value, does not take its `default`, and is tested against `minLength`, `const` and `enum`. An extension that relied on an empty string falling back to its default no longer gets that fallback.
+- fix: warn when a deprecated option is set to an empty string in the Lua reference validator. The deprecation warning used to be skipped for `""` in the same way as for an absent key.
+- fix: validate a surplus key matched by `additionalProperties`, and an array element matched by `items`, when the value is an empty string in the Lua reference validator. Both used to skip `""` instead of testing it.
 
 ## 3.2.0 (2026-08-02)
 

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -167,6 +167,9 @@ end
 local function _format_value(value)
   local kind = type(value)
   if kind == 'string' then
+    if value == '' then
+      return '""'
+    end
     return value
   elseif kind == 'number' or kind == 'boolean' then
     return tostring(value)
@@ -693,11 +696,18 @@ end
 --- @param value any Pandoc metadata value
 --- @return any Native Lua value
 local function _convert_pandoc_value(value)
+  local kind = _env.pandoc_type(value)
+
+  -- A bare key, `null` and `~` all arrive as an empty Pandoc `string`, which
+  -- is how Pandoc collapses YAML null. An explicit `""` arrives as an empty
+  -- `Inlines` instead, so the two are told apart before either is unwrapped.
+  if kind == 'string' and value == '' then
+    return nil
+  end
+
   if type(value) ~= 'table' then
     return value
   end
-
-  local kind = _env.pandoc_type(value)
 
   if kind == 'Inlines' or kind == 'Blocks' or kind == 'Inline' or kind == 'Block' then
     return _env.stringify(value)
@@ -1730,7 +1740,7 @@ local function _check_items(value, spec, path, context)
   for index = 1, #value do
     local element = _coerce(value[index], spec.items.type)
     value[index] = element
-    if element ~= nil and element ~= '' then
+    if element ~= nil then
       _validate_value(element, spec.items, string.format('%s[%d]', path, index), context)
     end
   end
@@ -2021,7 +2031,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
         if options.additional then
           local coerced = _coerce(value, options.additional.type)
           merged[key] = coerced
-          if coerced ~= nil and coerced ~= '' then
+          if coerced ~= nil then
             _validate_value(coerced, options.additional, path, context)
           end
         elseif unknown_policy == 'error' then

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -728,9 +728,15 @@ local function _convert_pandoc_value(value)
   end
 
   if _is_array(value) and #value > 0 then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
     local result = {}
     for index = 1, #value do
-      result[index] = _convert_pandoc_value(value[index])
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
     end
     return result
   end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1781,8 +1781,10 @@ local function _check_object(value, spec, path, context)
     end
   end
 
+  local defaulted = {}
+
   if type(spec.properties) == 'table' then
-    local sub = _validate_map(value, spec.properties, path, context, {
+    local sub, filled = _validate_map(value, spec.properties, path, context, {
       unknown = spec.additionalProperties == false and 'error' or 'ignore',
       additional = type(spec.additionalProperties) == 'table' and spec.additionalProperties or nil,
     })
@@ -1802,6 +1804,7 @@ local function _check_object(value, spec, path, context)
     for key, member in pairs(sub) do
       value[key] = member
     end
+    defaulted = filled
   elseif type(spec.additionalProperties) == 'table' then
     for key, member in pairs(value) do
       local coerced = _coerce(member, spec.additionalProperties.type)
@@ -1813,11 +1816,13 @@ local function _check_object(value, spec, path, context)
   end
 
   -- Runs after the properties block, which writes the resolved members back
-  -- into `value`. Before that, a dependent supplied under an alias or filled
-  -- by a default is not yet there to be found.
+  -- into `value`. Before that, a dependent supplied under an alias is not yet
+  -- there to be found. A `default` is an annotation and does not change the
+  -- instance, so a key that only holds one never triggers a requirement.
   if type(spec.dependentRequired) == 'table' then
     for key, dependents in pairs(spec.dependentRequired) do
-      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
+      local trigger, trigger_key = _lookup(value, key)
+      if trigger ~= nil and not defaulted[trigger_key] and type(dependents) == 'table' then
         for _, dependent in ipairs(dependents) do
           if _lookup(value, dependent) == nil then
             _report(context, 'error', path, 'dependentRequired', string.format(
@@ -1939,6 +1944,7 @@ end
 --- @param context table Validation context
 --- @param options table|nil {unknown = 'warn'|'error'|'ignore', additional = descriptor}
 --- @return table merged Values with aliases, coercion and defaults applied
+--- @return table defaulted Set of field names whose value came from `default`
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1949,6 +1955,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
   end
 
   local claimed = {}
+  local defaulted = {}
   local fields = {}
 
   -- Three passes, because `pairs` yields descriptors in no particular order.
@@ -1966,6 +1973,18 @@ _validate_map = function(values, descriptors, base_path, context, options)
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
     -- never carries the same value twice, once coerced and once raw.
+    -- The declared name is read first, so it wins over any alias.
+    local supplied_key
+    local found, found_key = _lookup(merged, field)
+    if found ~= nil then
+      merged[field] = found
+      claimed[found_key] = true
+      supplied_key = found_key
+      if found_key ~= field then
+        merged[found_key] = nil
+      end
+    end
+
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
         claimed[alias] = true
@@ -1974,29 +1993,20 @@ _validate_map = function(values, descriptors, base_path, context, options)
           claimed[alias_key] = true
           if merged[field] == nil then
             merged[field] = aliased
+            supplied_key = alias_key
           elseif alias_key ~= field then
-            -- Both spellings were supplied. The declared name wins, and the
-            -- alias is reported rather than left behind unvalidated.
+            -- Two spellings were supplied. The first one read wins, and the
+            -- other is reported rather than left behind unvalidated. Both
+            -- names come from the document, never from the schema.
             _report(context, 'warning',
               base_path and (base_path .. '.' .. field) or field,
               'aliases',
               string.format('was given as both "%s" and "%s"; "%s" was used.',
-                field, alias_key, field))
+                supplied_key, alias_key, supplied_key))
           end
           if alias_key ~= field then
             merged[alias_key] = nil
           end
-        end
-      end
-    end
-
-    if merged[field] == nil then
-      local found, found_key = _lookup(merged, field)
-      if found ~= nil then
-        merged[field] = found
-        claimed[found_key] = true
-        if found_key ~= field then
-          merged[found_key] = nil
         end
       end
     end
@@ -2024,6 +2034,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
       if value == nil and spec.default ~= nil then
         value = spec.default
         merged[field] = value
+        defaulted[field] = true
       end
     end
 
@@ -2055,7 +2066,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     end
   end
 
-  return merged
+  return merged, defaulted
 end
 
 --- Start a validation run.

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2219,8 +2219,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
   end
 
   if type(entry.required) == 'table' then
+    -- `merged.attributes` is filled only when the entry declares `attributes`.
+    -- The vocabulary allows `required` on its own, so fall back to what the
+    -- caller supplied rather than reporting every name as missing.
+    local supplied = kwargs or {}
     for _, required in ipairs(entry.required) do
-      if _lookup(merged.attributes, required) == nil then
+      if _lookup(merged.attributes, required) == nil
+        and _lookup(supplied, required) == nil then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1759,20 +1759,6 @@ local function _check_object(value, spec, path, context)
     end
   end
 
-  if type(spec.dependentRequired) == 'table' then
-    for key, dependents in pairs(spec.dependentRequired) do
-      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
-        for _, dependent in ipairs(dependents) do
-          if _lookup(value, dependent) == nil then
-            _report(context, 'error', path, 'dependentRequired', string.format(
-              'requires "%s" when "%s" is present.', dependent, key
-            ))
-          end
-        end
-      end
-    end
-  end
-
   if type(spec.properties) == 'table' then
     local sub = _validate_map(value, spec.properties, path, context, {
       unknown = spec.additionalProperties == false and 'error' or 'ignore',
@@ -1800,6 +1786,23 @@ local function _check_object(value, spec, path, context)
       value[key] = coerced
       if coerced ~= nil and coerced ~= '' then
         _validate_value(coerced, spec.additionalProperties, path .. '.' .. tostring(key), context)
+      end
+    end
+  end
+
+  -- Runs after the properties block, which writes the resolved members back
+  -- into `value`. Before that, a dependent supplied under an alias or filled
+  -- by a default is not yet there to be found.
+  if type(spec.dependentRequired) == 'table' then
+    for key, dependents in pairs(spec.dependentRequired) do
+      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
+        for _, dependent in ipairs(dependents) do
+          if _lookup(value, dependent) == nil then
+            _report(context, 'error', path, 'dependentRequired', string.format(
+              'requires "%s" when "%s" is present.', dependent, key
+            ))
+          end
+        end
       end
     end
   end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -714,9 +714,15 @@ local function _convert_pandoc_value(value)
   end
 
   if kind == 'List' then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
     local result = {}
     for index = 1, #value do
-      result[index] = _convert_pandoc_value(value[index])
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
     end
     return result
   end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1944,14 +1944,22 @@ _validate_map = function(values, descriptors, base_path, context, options)
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
         claimed[alias] = true
-        if merged[field] == nil then
-          local aliased, alias_key = _lookup(merged, alias)
-          if aliased ~= nil then
+        local aliased, alias_key = _lookup(merged, alias)
+        if aliased ~= nil then
+          claimed[alias_key] = true
+          if merged[field] == nil then
             merged[field] = aliased
-            claimed[alias_key] = true
-            if alias_key ~= field then
-              merged[alias_key] = nil
-            end
+          elseif alias_key ~= field then
+            -- Both spellings were supplied. The declared name wins, and the
+            -- alias is reported rather than left behind unvalidated.
+            _report(context, 'warning',
+              base_path and (base_path .. '.' .. field) or field,
+              'aliases',
+              string.format('was given as both "%s" and "%s"; "%s" was used.',
+                field, alias_key, field))
+          end
+          if alias_key ~= field then
+            merged[alias_key] = nil
           end
         end
       end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1784,7 +1784,7 @@ local function _check_object(value, spec, path, context)
     for key, member in pairs(value) do
       local coerced = _coerce(member, spec.additionalProperties.type)
       value[key] = coerced
-      if coerced ~= nil and coerced ~= '' then
+      if coerced ~= nil then
         _validate_value(coerced, spec.additionalProperties, path .. '.' .. tostring(key), context)
       end
     end
@@ -1982,7 +1982,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   for _, entry in ipairs(fields) do
     local value = merged[entry.name]
-    if entry.spec.deprecated and value ~= nil and value ~= '' then
+    if entry.spec.deprecated and value ~= nil then
       local message, cleared = _apply_deprecation(entry.name, entry.spec, value, merged)
       _report(context, 'warning', entry.path, 'deprecated', message)
       entry.cleared = cleared
@@ -1999,17 +1999,17 @@ _validate_map = function(values, descriptors, base_path, context, options)
       value = _coerce(merged[field], spec.type)
       merged[field] = value
 
-      if (value == nil or value == '') and spec.default ~= nil then
+      if value == nil and spec.default ~= nil then
         value = spec.default
         merged[field] = value
       end
     end
 
-    local is_empty = value == nil or value == ''
-
-    if spec.required == true and is_empty then
+    -- An empty string is a value the author wrote. Only a missing key is
+    -- absent, so `minLength`, `const` and `enum` can be tested against ''.
+    if spec.required == true and value == nil then
       _report(context, 'error', path, 'required', 'is required but was not provided.')
-    elseif not is_empty then
+    elseif value ~= nil then
       _validate_value(value, spec, path, context)
     end
   end
@@ -2160,15 +2160,14 @@ function M.validate_arguments(args, argument_specs, options)
     local path = string.format('argument %d ("%s")', index, name)
 
     local value = _coerce(args[index], spec.type)
-    if (value == nil or value == '') and spec.default ~= nil then
+    if value == nil and spec.default ~= nil then
       value = spec.default
     end
     merged[name] = value
 
-    local is_empty = value == nil or value == ''
-    if spec.required == true and is_empty then
+    if spec.required == true and value == nil then
       _report(context, 'error', path, 'required', 'is required but was not provided.')
-    elseif not is_empty then
+    elseif value ~= nil then
       _validate_value(value, spec, path, context)
     end
   end

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -310,8 +310,8 @@ All properties are optional.
 | `content-media-type`    | `string`                      | Media type of a string value (e.g. `application/json`). Annotation only.                                      |
 
 An empty string is a value, not an absent key.
-A key set to `""` keeps that value, does not take its `default`, satisfies `required`, and is tested against `minLength`, `const` and `enum`.
-Only a key that is missing is absent.
+A key set to `""` keeps that value, does not take its `default`, satisfies `required`, and is tested against `minLength`, `const` and `enum`, for a plain option value, an array element, and a surplus key matched by `additionalProperties`.
+A key with no value, or set to `null` or `~`, is absent in the same way as a key that is missing entirely, and takes its `default`.
 
 The `integer` type validates that the value is a whole number.
 It supports the same numeric constraints as `number` (`min`, `max`, `exclusive-minimum`, `exclusive-maximum`, `multiple-of`).

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -312,6 +312,7 @@ All properties are optional.
 An empty string is a value, not an absent key.
 A key set to `""` keeps that value, does not take its `default`, satisfies `required`, and is tested against `minLength`, `const` and `enum`, for a plain option value, an array element, and a surplus key matched by `additionalProperties`.
 A key with no value, or set to `null` or `~`, is absent in the same way as a key that is missing entirely, and takes its `default`.
+A `null` or `~` element inside a sequence follows the same rule and is dropped, rather than becoming an empty string.
 
 The `integer` type validates that the value is a whole number.
 It supports the same numeric constraints as `number` (`min`, `max`, `exclusive-minimum`, `exclusive-maximum`, `multiple-of`).

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -321,8 +321,10 @@ The `content` type is specific to shortcode arguments and accepts any Pandoc Inl
 Quarto Wizard rejects `type: content` outside shortcode arguments.
 Validation only checks presence (for `required`); no further type or pattern checking applies.
 
-The `null` type matches the explicit YAML value `null` (or `~`).
-Combine it with another type for nullable fields, e.g. `type: [string, "null"]`.
+The `null` type never matches a supplied value, because a key set to `null` or `~` is read as an absent key.
+A field declared `type: "null"` and `required: true` is therefore reported as missing.
+List `"null"` beside another type, as in `type: [string, "null"]`, to document that a key may be written as `~`.
+Such a key takes its `default`, like any other absent key.
 
 In JSON schema files, multi-word property names use camelCase equivalents: `enumCaseInsensitive`, `patternExact`, `minLength`, `maxLength`, `minItems`, `maxItems`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `additionalProperties`, `propertyNames`, `dependentRequired`, `contentEncoding`, and `contentMediaType`.
 Mixing camelCase and kebab-case forms of the same keyword on one descriptor produces a warning.

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -309,6 +309,10 @@ All properties are optional.
 | `content-encoding`      | `string`                      | Content encoding for a string value (e.g. `base64`). Annotation only.                                         |
 | `content-media-type`    | `string`                      | Media type of a string value (e.g. `application/json`). Annotation only.                                      |
 
+An empty string is a value, not an absent key.
+A key set to `""` keeps that value, does not take its `default`, satisfies `required`, and is tested against `minLength`, `const` and `enum`.
+Only a key that is missing is absent.
+
 The `integer` type validates that the value is a whole number.
 It supports the same numeric constraints as `number` (`min`, `max`, `exclusive-minimum`, `exclusive-maximum`, `multiple-of`).
 

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -167,6 +167,9 @@ end
 local function _format_value(value)
   local kind = type(value)
   if kind == 'string' then
+    if value == '' then
+      return '""'
+    end
     return value
   elseif kind == 'number' or kind == 'boolean' then
     return tostring(value)
@@ -693,11 +696,18 @@ end
 --- @param value any Pandoc metadata value
 --- @return any Native Lua value
 local function _convert_pandoc_value(value)
+  local kind = _env.pandoc_type(value)
+
+  -- A bare key, `null` and `~` all arrive as an empty Pandoc `string`, which
+  -- is how Pandoc collapses YAML null. An explicit `""` arrives as an empty
+  -- `Inlines` instead, so the two are told apart before either is unwrapped.
+  if kind == 'string' and value == '' then
+    return nil
+  end
+
   if type(value) ~= 'table' then
     return value
   end
-
-  local kind = _env.pandoc_type(value)
 
   if kind == 'Inlines' or kind == 'Blocks' or kind == 'Inline' or kind == 'Block' then
     return _env.stringify(value)
@@ -1730,7 +1740,7 @@ local function _check_items(value, spec, path, context)
   for index = 1, #value do
     local element = _coerce(value[index], spec.items.type)
     value[index] = element
-    if element ~= nil and element ~= '' then
+    if element ~= nil then
       _validate_value(element, spec.items, string.format('%s[%d]', path, index), context)
     end
   end
@@ -2021,7 +2031,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
         if options.additional then
           local coerced = _coerce(value, options.additional.type)
           merged[key] = coerced
-          if coerced ~= nil and coerced ~= '' then
+          if coerced ~= nil then
             _validate_value(coerced, options.additional, path, context)
           end
         elseif unknown_policy == 'error' then

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -728,9 +728,15 @@ local function _convert_pandoc_value(value)
   end
 
   if _is_array(value) and #value > 0 then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
     local result = {}
     for index = 1, #value do
-      result[index] = _convert_pandoc_value(value[index])
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
     end
     return result
   end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1781,8 +1781,10 @@ local function _check_object(value, spec, path, context)
     end
   end
 
+  local defaulted = {}
+
   if type(spec.properties) == 'table' then
-    local sub = _validate_map(value, spec.properties, path, context, {
+    local sub, filled = _validate_map(value, spec.properties, path, context, {
       unknown = spec.additionalProperties == false and 'error' or 'ignore',
       additional = type(spec.additionalProperties) == 'table' and spec.additionalProperties or nil,
     })
@@ -1802,6 +1804,7 @@ local function _check_object(value, spec, path, context)
     for key, member in pairs(sub) do
       value[key] = member
     end
+    defaulted = filled
   elseif type(spec.additionalProperties) == 'table' then
     for key, member in pairs(value) do
       local coerced = _coerce(member, spec.additionalProperties.type)
@@ -1813,11 +1816,13 @@ local function _check_object(value, spec, path, context)
   end
 
   -- Runs after the properties block, which writes the resolved members back
-  -- into `value`. Before that, a dependent supplied under an alias or filled
-  -- by a default is not yet there to be found.
+  -- into `value`. Before that, a dependent supplied under an alias is not yet
+  -- there to be found. A `default` is an annotation and does not change the
+  -- instance, so a key that only holds one never triggers a requirement.
   if type(spec.dependentRequired) == 'table' then
     for key, dependents in pairs(spec.dependentRequired) do
-      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
+      local trigger, trigger_key = _lookup(value, key)
+      if trigger ~= nil and not defaulted[trigger_key] and type(dependents) == 'table' then
         for _, dependent in ipairs(dependents) do
           if _lookup(value, dependent) == nil then
             _report(context, 'error', path, 'dependentRequired', string.format(
@@ -1939,6 +1944,7 @@ end
 --- @param context table Validation context
 --- @param options table|nil {unknown = 'warn'|'error'|'ignore', additional = descriptor}
 --- @return table merged Values with aliases, coercion and defaults applied
+--- @return table defaulted Set of field names whose value came from `default`
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1949,6 +1955,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
   end
 
   local claimed = {}
+  local defaulted = {}
   local fields = {}
 
   -- Three passes, because `pairs` yields descriptors in no particular order.
@@ -1966,6 +1973,18 @@ _validate_map = function(values, descriptors, base_path, context, options)
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
     -- never carries the same value twice, once coerced and once raw.
+    -- The declared name is read first, so it wins over any alias.
+    local supplied_key
+    local found, found_key = _lookup(merged, field)
+    if found ~= nil then
+      merged[field] = found
+      claimed[found_key] = true
+      supplied_key = found_key
+      if found_key ~= field then
+        merged[found_key] = nil
+      end
+    end
+
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
         claimed[alias] = true
@@ -1974,29 +1993,20 @@ _validate_map = function(values, descriptors, base_path, context, options)
           claimed[alias_key] = true
           if merged[field] == nil then
             merged[field] = aliased
+            supplied_key = alias_key
           elseif alias_key ~= field then
-            -- Both spellings were supplied. The declared name wins, and the
-            -- alias is reported rather than left behind unvalidated.
+            -- Two spellings were supplied. The first one read wins, and the
+            -- other is reported rather than left behind unvalidated. Both
+            -- names come from the document, never from the schema.
             _report(context, 'warning',
               base_path and (base_path .. '.' .. field) or field,
               'aliases',
               string.format('was given as both "%s" and "%s"; "%s" was used.',
-                field, alias_key, field))
+                supplied_key, alias_key, supplied_key))
           end
           if alias_key ~= field then
             merged[alias_key] = nil
           end
-        end
-      end
-    end
-
-    if merged[field] == nil then
-      local found, found_key = _lookup(merged, field)
-      if found ~= nil then
-        merged[field] = found
-        claimed[found_key] = true
-        if found_key ~= field then
-          merged[found_key] = nil
         end
       end
     end
@@ -2024,6 +2034,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
       if value == nil and spec.default ~= nil then
         value = spec.default
         merged[field] = value
+        defaulted[field] = true
       end
     end
 
@@ -2055,7 +2066,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     end
   end
 
-  return merged
+  return merged, defaulted
 end
 
 --- Start a validation run.

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2219,8 +2219,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
   end
 
   if type(entry.required) == 'table' then
+    -- `merged.attributes` is filled only when the entry declares `attributes`.
+    -- The vocabulary allows `required` on its own, so fall back to what the
+    -- caller supplied rather than reporting every name as missing.
+    local supplied = kwargs or {}
     for _, required in ipairs(entry.required) do
-      if _lookup(merged.attributes, required) == nil then
+      if _lookup(merged.attributes, required) == nil
+        and _lookup(supplied, required) == nil then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1759,20 +1759,6 @@ local function _check_object(value, spec, path, context)
     end
   end
 
-  if type(spec.dependentRequired) == 'table' then
-    for key, dependents in pairs(spec.dependentRequired) do
-      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
-        for _, dependent in ipairs(dependents) do
-          if _lookup(value, dependent) == nil then
-            _report(context, 'error', path, 'dependentRequired', string.format(
-              'requires "%s" when "%s" is present.', dependent, key
-            ))
-          end
-        end
-      end
-    end
-  end
-
   if type(spec.properties) == 'table' then
     local sub = _validate_map(value, spec.properties, path, context, {
       unknown = spec.additionalProperties == false and 'error' or 'ignore',
@@ -1800,6 +1786,23 @@ local function _check_object(value, spec, path, context)
       value[key] = coerced
       if coerced ~= nil and coerced ~= '' then
         _validate_value(coerced, spec.additionalProperties, path .. '.' .. tostring(key), context)
+      end
+    end
+  end
+
+  -- Runs after the properties block, which writes the resolved members back
+  -- into `value`. Before that, a dependent supplied under an alias or filled
+  -- by a default is not yet there to be found.
+  if type(spec.dependentRequired) == 'table' then
+    for key, dependents in pairs(spec.dependentRequired) do
+      if _lookup(value, key) ~= nil and type(dependents) == 'table' then
+        for _, dependent in ipairs(dependents) do
+          if _lookup(value, dependent) == nil then
+            _report(context, 'error', path, 'dependentRequired', string.format(
+              'requires "%s" when "%s" is present.', dependent, key
+            ))
+          end
+        end
       end
     end
   end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -714,9 +714,15 @@ local function _convert_pandoc_value(value)
   end
 
   if kind == 'List' then
+    -- A null element is absent, the same rule this module applies to a null
+    -- key. Writing it into a running count rather than the source index
+    -- keeps the result a proper sequence instead of leaving a gap.
     local result = {}
     for index = 1, #value do
-      result[index] = _convert_pandoc_value(value[index])
+      local converted = _convert_pandoc_value(value[index])
+      if converted ~= nil then
+        result[#result + 1] = converted
+      end
     end
     return result
   end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1944,14 +1944,22 @@ _validate_map = function(values, descriptors, base_path, context, options)
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
         claimed[alias] = true
-        if merged[field] == nil then
-          local aliased, alias_key = _lookup(merged, alias)
-          if aliased ~= nil then
+        local aliased, alias_key = _lookup(merged, alias)
+        if aliased ~= nil then
+          claimed[alias_key] = true
+          if merged[field] == nil then
             merged[field] = aliased
-            claimed[alias_key] = true
-            if alias_key ~= field then
-              merged[alias_key] = nil
-            end
+          elseif alias_key ~= field then
+            -- Both spellings were supplied. The declared name wins, and the
+            -- alias is reported rather than left behind unvalidated.
+            _report(context, 'warning',
+              base_path and (base_path .. '.' .. field) or field,
+              'aliases',
+              string.format('was given as both "%s" and "%s"; "%s" was used.',
+                field, alias_key, field))
+          end
+          if alias_key ~= field then
+            merged[alias_key] = nil
           end
         end
       end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1784,7 +1784,7 @@ local function _check_object(value, spec, path, context)
     for key, member in pairs(value) do
       local coerced = _coerce(member, spec.additionalProperties.type)
       value[key] = coerced
-      if coerced ~= nil and coerced ~= '' then
+      if coerced ~= nil then
         _validate_value(coerced, spec.additionalProperties, path .. '.' .. tostring(key), context)
       end
     end
@@ -1982,7 +1982,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   for _, entry in ipairs(fields) do
     local value = merged[entry.name]
-    if entry.spec.deprecated and value ~= nil and value ~= '' then
+    if entry.spec.deprecated and value ~= nil then
       local message, cleared = _apply_deprecation(entry.name, entry.spec, value, merged)
       _report(context, 'warning', entry.path, 'deprecated', message)
       entry.cleared = cleared
@@ -1999,17 +1999,17 @@ _validate_map = function(values, descriptors, base_path, context, options)
       value = _coerce(merged[field], spec.type)
       merged[field] = value
 
-      if (value == nil or value == '') and spec.default ~= nil then
+      if value == nil and spec.default ~= nil then
         value = spec.default
         merged[field] = value
       end
     end
 
-    local is_empty = value == nil or value == ''
-
-    if spec.required == true and is_empty then
+    -- An empty string is a value the author wrote. Only a missing key is
+    -- absent, so `minLength`, `const` and `enum` can be tested against ''.
+    if spec.required == true and value == nil then
       _report(context, 'error', path, 'required', 'is required but was not provided.')
-    elseif not is_empty then
+    elseif value ~= nil then
       _validate_value(value, spec, path, context)
     end
   end
@@ -2160,15 +2160,14 @@ function M.validate_arguments(args, argument_specs, options)
     local path = string.format('argument %d ("%s")', index, name)
 
     local value = _coerce(args[index], spec.type)
-    if (value == nil or value == '') and spec.default ~= nil then
+    if value == nil and spec.default ~= nil then
       value = spec.default
     end
     merged[name] = value
 
-    local is_empty = value == nil or value == ''
-    if spec.required == true and is_empty then
+    if spec.required == true and value == nil then
       _report(context, 'error', path, 'required', 'is required but was not provided.')
-    elseif not is_empty then
+    elseif value ~= nil then
       _validate_value(value, spec, path, context)
     end
   end

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -778,6 +778,30 @@ shortcodes:
   assert_contains(warnings, 'arai-hidden', 'the typo is surfaced')
 end)
 
+test('shortcode required works without an attributes block', function()
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    required:
+      - icon
+]])
+  local valid, errors = schema.validate_shortcode(
+    'demo', {}, { icon = 'star' }, loaded.shortcodes.demo)
+  assert_valid(valid, errors)
+end)
+
+test('shortcode required still reports a missing attribute', function()
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    required:
+      - icon
+]])
+  local valid, errors = schema.validate_shortcode('demo', {}, {}, loaded.shortcodes.demo)
+  assert_false(valid, 'a missing required attribute should be reported')
+  assert_contains(errors, 'icon')
+end)
+
 test('S7: validate_attributes checks declared keys and ignores the rest', function()
   local loaded = load_schema([[
 attributes:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1238,6 +1238,71 @@ options:
   assert_contains(errors, 'got ""')
 end)
 
+test('a null element in the middle of a document metadata sequence does not leave a hole', function()
+  local loaded = load_schema([[
+options:
+  tags:
+    type: array
+    minItems: 1
+    items:
+      type: string
+]])
+  local options = doc_options('    tags: [~, b]')
+  local valid, errors, _, merged = schema.validate(options, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(#merged.tags, 1, 'the null element should be dropped, not leave a hole')
+  assert_eq(merged.tags[1], 'b', 'the surviving element should be first')
+end)
+
+test('a document metadata sequence of only null elements becomes an empty array', function()
+  local loaded = load_schema([[
+options:
+  tags:
+    type: array
+    minItems: 1
+    items:
+      type: string
+]])
+  local options = doc_options('    tags: [~]')
+  local valid, errors, _, merged = schema.validate(options, loaded.options)
+  assert_false(valid, 'an empty array should fail minItems 1')
+  assert_eq(#merged.tags, 0, 'the null element should be dropped, leaving an empty array')
+  assert_contains(errors, 'at least 1 items')
+end)
+
+test('a null element at the end of a document metadata sequence is dropped', function()
+  local loaded = load_schema([[
+options:
+  tags:
+    type: array
+    minItems: 1
+    items:
+      type: string
+]])
+  local options = doc_options('    tags: [a, ~]')
+  local valid, errors, _, merged = schema.validate(options, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(#merged.tags, 1, 'the null element should be dropped')
+  assert_eq(merged.tags[1], 'a', 'the surviving element should be kept')
+end)
+
+test('a document metadata sequence with no null elements is unaffected', function()
+  local loaded = load_schema([[
+options:
+  tags:
+    type: array
+    minItems: 1
+    items:
+      type: string
+]])
+  local options = doc_options('    tags: [a, b]')
+  local valid, errors, _, merged = schema.validate(options, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(#merged.tags, 2, 'both elements should be kept')
+  assert_eq(merged.tags[1], 'a', 'the first element should be kept')
+  assert_eq(merged.tags[2], 'b', 'the second element should be kept')
+end)
+
 -- ============================================================================
 -- REPORT
 -- ============================================================================

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -544,6 +544,46 @@ options:
   assert_valid(ok_valid, ok_errors)
 end)
 
+test('dependentRequired sees a value supplied under an alias', function()
+  local loaded = load_schema([[
+options:
+  auth:
+    type: object
+    dependentRequired:
+      user:
+        - password
+    properties:
+      user:
+        type: string
+      password:
+        type: string
+        aliases:
+          - pass
+]])
+  local valid, errors = schema.validate(
+    { auth = { user = 'me', pass = 'secret' } }, loaded.options)
+  assert_valid(valid, errors)
+end)
+
+test('dependentRequired still reports a genuinely missing dependent', function()
+  local loaded = load_schema([[
+options:
+  auth:
+    type: object
+    dependentRequired:
+      user:
+        - password
+    properties:
+      user:
+        type: string
+      password:
+        type: string
+]])
+  local valid, errors = schema.validate({ auth = { user = 'me' } }, loaded.options)
+  assert_false(valid, 'a missing dependent should be reported')
+  assert_contains(errors, 'password')
+end)
+
 test('nested properties contribute defaults and coercion to merged', function()
   local loaded = load_schema([[
 options:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1146,6 +1146,98 @@ options:
   assert_contains(errors, 'label')
 end)
 
+test('a bare option in document metadata is absent and takes its default', function()
+  local loaded = load_schema([[
+options:
+  count:
+    type: string
+    default: fallback
+]])
+  local options = doc_options('    count:')
+  local _, _, _, merged = schema.validate(options, loaded.options)
+  assert_eq(merged.count, 'fallback', 'a bare key should take the default')
+end)
+
+test('an option set to null in document metadata is absent and takes its default', function()
+  local loaded = load_schema([[
+options:
+  count:
+    type: string
+    default: fallback
+]])
+  local options = doc_options('    count: null')
+  local _, _, _, merged = schema.validate(options, loaded.options)
+  assert_eq(merged.count, 'fallback', 'an explicit null should take the default')
+end)
+
+test('an option set to ~ in document metadata is absent and takes its default', function()
+  local loaded = load_schema([[
+options:
+  count:
+    type: string
+    default: fallback
+]])
+  local options = doc_options('    count: ~')
+  local _, _, _, merged = schema.validate(options, loaded.options)
+  assert_eq(merged.count, 'fallback', 'an explicit ~ should take the default')
+end)
+
+test('an option set to "" in document metadata is an empty string, not the default', function()
+  local loaded = load_schema([[
+options:
+  count:
+    type: string
+    default: fallback
+]])
+  local options = doc_options('    count: ""')
+  local _, _, _, merged = schema.validate(options, loaded.options)
+  assert_eq(merged.count, '', 'an explicit empty string should survive, not take the default')
+end)
+
+test('minLength is enforced against an empty array element', function()
+  local loaded = load_schema([[
+options:
+  tags:
+    type: array
+    items:
+      type: string
+      minLength: 1
+]])
+  local valid, errors = schema.validate({ tags = { '' } }, loaded.options)
+  assert_false(valid, 'an empty array element should fail minLength 1')
+  assert_contains(errors, 'tags[1]')
+end)
+
+test('minLength is enforced against a surplus key when properties and additionalProperties are both declared', function()
+  local loaded = load_schema([[
+options:
+  layout:
+    type: object
+    properties:
+      columns:
+        type: number
+    additionalProperties:
+      type: string
+      minLength: 1
+]])
+  local valid, errors = schema.validate(
+    { layout = { columns = 2, extra = '' } }, loaded.options)
+  assert_false(valid, 'a surplus key set to an empty string should fail minLength 1')
+  assert_contains(errors, 'layout.extra')
+end)
+
+test('an empty string is rendered as "" in an error message', function()
+  local loaded = load_schema([[
+options:
+  echo:
+    type: string
+    enum: [a, b]
+]])
+  local valid, errors = schema.validate({ echo = '' }, loaded.options)
+  assert_false(valid, 'an empty string not in the enum should be reported')
+  assert_contains(errors, 'got ""')
+end)
+
 -- ============================================================================
 -- REPORT
 -- ============================================================================

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1090,6 +1090,62 @@ options:
   assert_eq(merged.text_color, nil, 'the normalised alias key should be removed')
 end)
 
+test('an explicit empty string is not replaced by the default', function()
+  local loaded = load_schema([[
+options:
+  label:
+    type: string
+    default: fallback
+]])
+  local _, _, _, merged = schema.validate({ label = '' }, loaded.options)
+  assert_eq(merged.label, '', 'an empty string should survive')
+end)
+
+test('an absent key still takes its default', function()
+  local loaded = load_schema([[
+options:
+  label:
+    type: string
+    default: fallback
+]])
+  local _, _, _, merged = schema.validate({}, loaded.options)
+  assert_eq(merged.label, 'fallback', 'an absent key should take the default')
+end)
+
+test('required is satisfied by an empty string', function()
+  local loaded = load_schema([[
+options:
+  label:
+    type: string
+    required: true
+]])
+  local valid, errors = schema.validate({ label = '' }, loaded.options)
+  assert_valid(valid, errors)
+end)
+
+test('required still reports an absent key', function()
+  local loaded = load_schema([[
+options:
+  label:
+    type: string
+    required: true
+]])
+  local valid = schema.validate({}, loaded.options)
+  assert_false(valid, 'an absent required key should be reported')
+end)
+
+test('minLength is enforced against an empty string', function()
+  local loaded = load_schema([[
+options:
+  label:
+    type: string
+    minLength: 1
+]])
+  local valid, errors = schema.validate({ label = '' }, loaded.options)
+  assert_false(valid, 'an empty string should fail minLength 1')
+  assert_contains(errors, 'label')
+end)
+
 -- ============================================================================
 -- REPORT
 -- ============================================================================

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -584,6 +584,46 @@ options:
   assert_contains(errors, 'password')
 end)
 
+test('a trigger key filled by its own default does not fire dependentRequired', function()
+  local loaded = load_schema([[
+options:
+  auth:
+    type: object
+    dependentRequired:
+      user:
+        - password
+    properties:
+      user:
+        type: string
+        default: anonymous
+      password:
+        type: string
+]])
+  local valid, errors, _, merged = schema.validate({ auth = {} }, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(merged.auth.user, 'anonymous', 'the default is still applied')
+end)
+
+test('a trigger key the author supplied still fires dependentRequired', function()
+  local loaded = load_schema([[
+options:
+  auth:
+    type: object
+    dependentRequired:
+      user:
+        - password
+    properties:
+      user:
+        type: string
+        default: anonymous
+      password:
+        type: string
+]])
+  local valid, errors = schema.validate({ auth = { user = 'me' } }, loaded.options)
+  assert_false(valid, 'a supplied trigger fires even when the field has a default')
+  assert_contains(errors, 'password')
+end)
+
 test('nested properties contribute defaults and coercion to merged', function()
   local loaded = load_schema([[
 options:
@@ -1074,6 +1114,42 @@ options:
   )
 end)
 
+test('the declared name wins over an alias, even in its normalised spelling', function()
+  local loaded = load_schema([[
+options:
+  text-color:
+    type: string
+    aliases:
+      - color
+]])
+  local valid, errors, warnings, merged = schema.validate(
+    { text_color = 'a', color = 'b' }, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(merged['text-color'], 'a', 'the declared name should win over the alias')
+  assert_eq(merged.color, nil, 'the alias key should be removed')
+  assert_eq(merged.text_color, nil, 'the normalised declared key should be removed')
+  assert_contains(warnings, '"text_color" and "color"', 'the warning names both supplied keys')
+  for _, warning in ipairs(warnings) do
+    assert_false(
+      warning:find('not a recognised key', 1, true) ~= nil,
+      'the declared spelling is not an unknown key: ' .. warning
+    )
+  end
+end)
+
+test('the conflict warning names the two keys the author supplied', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+      - color
+      - farbe
+]])
+  local _, _, warnings = schema.validate({ color = 'blue', farbe = 'rot' }, loaded.options)
+  assert_contains(warnings, 'was given as both "color" and "farbe"; "color" was used.')
+end)
+
 test('an alias matched via hyphen/underscore normalisation moves without a false conflict', function()
   local loaded = load_schema([[
 options:
@@ -1192,6 +1268,19 @@ options:
   local options = doc_options('    count: ""')
   local _, _, _, merged = schema.validate(options, loaded.options)
   assert_eq(merged.count, '', 'an explicit empty string should survive, not take the default')
+end)
+
+test('an empty string on a numeric field is a type error, not the default', function()
+  local loaded = load_schema([[
+options:
+  count:
+    type: number
+    default: 3
+]])
+  local valid, errors, _, merged = schema.validate({ count = '' }, loaded.options)
+  assert_false(valid, 'an empty string is not a number')
+  assert_contains(errors, 'must be of type "number", got "string"')
+  assert_eq(merged.count, '', 'the empty string is not replaced by the default')
 end)
 
 test('minLength is enforced against an empty array element', function()

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -958,6 +958,74 @@ options:
   assert_eq(loaded.options.count.default, before, 'the loaded schema is untouched')
 end)
 
+test('a value given under both spellings drops the alias key', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+      - color
+]])
+  local valid, errors, warnings, merged = schema.validate(
+    { colour = 'red', color = 'blue' }, loaded.options)
+  assert_eq(merged.colour, 'red', 'the declared name should win')
+  assert_eq(merged.color, nil, 'the alias key should not survive in merged')
+  assert_true(
+    #errors > 0 or #warnings > 0,
+    'supplying both spellings should be reported'
+  )
+end)
+
+test('a value given only under an alias still moves to the declared name', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+      - color
+]])
+  local valid, errors, _, merged = schema.validate({ color = 'blue' }, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(merged.colour, 'blue', 'the alias value should move to the declared name')
+  assert_eq(merged.color, nil, 'the alias key should be removed')
+end)
+
+test('two different aliases supplied for the same field both drop, with a warning', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+      - color
+      - farbe
+]])
+  local valid, errors, warnings, merged = schema.validate(
+    { color = 'blue', farbe = 'rot' }, loaded.options)
+  assert_eq(merged.colour, 'blue', 'the first alias in declaration order wins')
+  assert_eq(merged.color, nil, 'the first alias key should not survive in merged')
+  assert_eq(merged.farbe, nil, 'the second alias key should not survive in merged')
+  assert_true(
+    #errors > 0 or #warnings > 0,
+    'supplying two aliases for the same field should be reported'
+  )
+end)
+
+test('an alias matched via hyphen/underscore normalisation moves without a false conflict', function()
+  local loaded = load_schema([[
+options:
+  colour:
+    type: string
+    aliases:
+      - text-color
+]])
+  local valid, errors, warnings, merged = schema.validate(
+    { text_color = 'blue' }, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(#warnings, 0, 'a single spelling, even a normalised one, is not a conflict')
+  assert_eq(merged.colour, 'blue', 'the normalised alias value should move to the declared name')
+  assert_eq(merged.text_color, nil, 'the normalised alias key should be removed')
+end)
+
 -- ============================================================================
 -- REPORT
 -- ============================================================================


### PR DESCRIPTION
Four validation defects. An alias supplied beside its declared name survived unvalidated, and the declared name did not win. A shortcode declaring `required` without an `attributes` block rejected every argument. `dependentRequired` ran before aliases resolved. An empty string was read as an absent key.

The last one is a behaviour change, not a repair. Pandoc delivers `key:`, `key: null` and `key: ~` all as an empty string, so the module now tells null from an explicit `""`: null is absent and takes the default, `""` is a value. A null element in a sequence is dropped rather than left as a gap. Every user-visible change has a changelog entry.