### PR TITLE
fix: harden the readers over the Lua reference validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug Fixes
 
-- fix: report an error for every value of a field whose `pattern` the Lua reference validator cannot compile, instead of compiling that pattern to one that matches the wrong values. The refusal now covers an anchored alternation such as `^a|b$`, and the escapes `\b`, `\B`, `\0`, `\c`, `\u`, `\x`, `\p` and `\k`.
+- fix: report an error for every value of a field whose `pattern` the Lua reference validator cannot compile, instead of compiling that pattern to one that matches the wrong values. The refusal now covers an anchored alternation such as `^a|b$`, and the escapes `\b`, `\B`, `\c`, `\u`, `\x`, `\p` and `\k`.
 - fix: treat an empty string as a value in the Lua reference validator. A key set to `""` keeps that value and is tested against `type`, `minLength`, `const` and `enum`.
 - fix: stop an empty string from taking a field's `default` in the Lua reference validator. `count: ""` on a field declared `type: number` is now an error that reads `must be of type "number", got "string"`, where it used to take the default.
 - fix: drop a `null` element from a document metadata sequence in the Lua reference validator, where it used to become an empty string. `tags: [a, ~]` now holds one element rather than two, so a field declared `minItems: 2` no longer passes.

--- a/packages/schema/tests/helpers/schemaVocabulary.ts
+++ b/packages/schema/tests/helpers/schemaVocabulary.ts
@@ -1,0 +1,60 @@
+/**
+ * Readers over the Lua reference validator and the meta-schemas.
+ *
+ * The module keeps its own keyword table, because the `true` or `false`
+ * value marks whether the module acts on the keyword. The meta-schema
+ * holds no such distinction, so the table cannot be generated from it and
+ * the two are compared instead.
+ *
+ * A regular expression over one line of source used to read the table. It
+ * needed a line start, a bare identifier and a trailing comma, so a
+ * reformat could hide an entry and the comparison then ran against a short
+ * baseline without failing. These readers remove that failure mode.
+ */
+
+/** One entry of `M.KEYWORDS`: the name, and whether the module acts on it. */
+export function parseKeywordTable(luaSource: string): Map<string, boolean> {
+	const block = /^M\.KEYWORDS\s*=\s*\{([\s\S]*?)^\}/m.exec(luaSource);
+	if (block === null) {
+		throw new Error("M.KEYWORDS table not found");
+	}
+	const body = block[1].replace(/--[^\n]*/g, "");
+	const entry = /(?:\[\s*(['"])([^'"]+)\1\s*\]|([A-Za-z_][A-Za-z0-9_]*))\s*=\s*(true|false)\b/g;
+	const entries = new Map<string, boolean>();
+	for (const match of body.matchAll(entry)) {
+		entries.set(match[2] ?? match[3], match[4] === "true");
+	}
+	return entries;
+}
+
+/** The meta-schema URL that the module declares, or null when absent. */
+export function readSchemaVersion(luaSource: string): string | null {
+	const declared = /^\s*M\.SCHEMA_VERSION\s*=\s*(['"])([^'"]+)\1/m.exec(luaSource);
+	return declared === null ? null : declared[2];
+}
+
+/** The property names of `$defs.fieldDescriptor` in a meta-schema. */
+export function metaSchemaProperties(metaSchema: unknown): string[] {
+	const properties = (metaSchema as { $defs?: { fieldDescriptor?: { properties?: Record<string, unknown> } } })?.$defs
+		?.fieldDescriptor?.properties;
+	if (properties === undefined) {
+		throw new Error("$defs.fieldDescriptor.properties not found in meta-schema");
+	}
+	return Object.keys(properties);
+}
+
+/**
+ * Group the spellings of one keyword.
+ *
+ * v1 carries a camelCase and a kebab-case spelling for most keywords, so a
+ * count of property names counts the same keyword twice. The key of the
+ * returned map is the keyword, and the value holds every spelling of it.
+ */
+export function keywordGroups(properties: string[]): Map<string, string[]> {
+	const groups = new Map<string, string[]>();
+	for (const name of properties) {
+		const keyword = name.replace(/-/g, "").toLowerCase();
+		groups.set(keyword, [...(groups.get(keyword) ?? []), name]);
+	}
+	return groups;
+}

--- a/packages/schema/tests/helpers/schemaVocabulary.ts
+++ b/packages/schema/tests/helpers/schemaVocabulary.ts
@@ -7,9 +7,14 @@
  * the two are compared instead.
  *
  * A regular expression over one line of source used to read the table. It
- * needed a line start, a bare identifier and a trailing comma, so a
- * reformat could hide an entry and the comparison then ran against a short
- * baseline without failing. These readers remove that failure mode.
+ * needed a line start, a bare identifier and a trailing comma, so a reformat
+ * could hide an entry and the comparison then ran against a short baseline.
+ *
+ * That hole was one-directional. A hidden entry that the meta-schema also
+ * holds still failed the "every meta-schema property is named by the module"
+ * check, because the name dropped out of the module side. A hidden entry that
+ * the meta-schema does not hold passed both checks in silence, which is the
+ * divergence these readers close.
  */
 
 /** One entry of `M.KEYWORDS`: the name, and whether the module acts on it. */
@@ -29,14 +34,15 @@ export function parseKeywordTable(luaSource: string): Map<string, boolean> {
 
 /** The meta-schema URL that the module declares, or null when absent. */
 export function readSchemaVersion(luaSource: string): string | null {
-	const declared = /^\s*M\.SCHEMA_VERSION\s*=\s*(['"])([^'"]+)\1/m.exec(luaSource);
+	const declared = /^[ \t]*M\.SCHEMA_VERSION\s*=\s*(['"])([^'"]+)\1/m.exec(luaSource);
 	return declared === null ? null : declared[2];
 }
 
+type MetaSchemaShape = { $defs?: { fieldDescriptor?: { properties?: Record<string, unknown> } } };
+
 /** The property names of `$defs.fieldDescriptor` in a meta-schema. */
 export function metaSchemaProperties(metaSchema: unknown): string[] {
-	const properties = (metaSchema as { $defs?: { fieldDescriptor?: { properties?: Record<string, unknown> } } })?.$defs
-		?.fieldDescriptor?.properties;
+	const properties = (metaSchema as MetaSchemaShape).$defs?.fieldDescriptor?.properties;
 	if (properties === undefined) {
 		throw new Error("$defs.fieldDescriptor.properties not found in meta-schema");
 	}
@@ -44,17 +50,27 @@ export function metaSchemaProperties(metaSchema: unknown): string[] {
 }
 
 /**
- * Group the spellings of one keyword.
+ * Group the camelCase and the kebab-case spelling of one keyword.
  *
- * v1 carries a camelCase and a kebab-case spelling for most keywords, so a
- * count of property names counts the same keyword twice. The key of the
- * returned map is the keyword, and the value holds every spelling of it.
+ * v1 carries both spellings for most keywords, so a count of property names
+ * counts the same keyword twice. The key of the returned map is the name with
+ * the hyphens removed and the case dropped, and the value holds every spelling
+ * that maps onto that key.
+ *
+ * This groups a pair that differs by a hyphen only, such as `minLength` and
+ * `min-length`. It does not group a short alias with its long name, because
+ * `min` and `minimum` differ by more than a hyphen. `KEY_ALIASES` in
+ * `src/types/schema.ts` holds those pairs, and a caller that needs them has to
+ * read it. v1 therefore yields 34 groups from 48 property names, and `min`,
+ * `minimum`, `max` and `maximum` are four of those groups and not two.
  */
 export function keywordGroups(properties: string[]): Map<string, string[]> {
 	const groups = new Map<string, string[]>();
 	for (const name of properties) {
 		const keyword = name.replace(/-/g, "").toLowerCase();
-		groups.set(keyword, [...(groups.get(keyword) ?? []), name]);
+		const spellings = groups.get(keyword) ?? [];
+		spellings.push(name);
+		groups.set(keyword, spellings);
 	}
 	return groups;
 }

--- a/packages/schema/tests/helpers/schemaVocabulary.ts
+++ b/packages/schema/tests/helpers/schemaVocabulary.ts
@@ -59,7 +59,7 @@ export function metaSchemaProperties(metaSchema: unknown): string[] {
  *
  * This groups a pair that differs by a hyphen only, such as `minLength` and
  * `min-length`. It does not group a short alias with its long name, because
- * `min` and `minimum` differ by more than a hyphen. `KEY_ALIASES` in
+ * `min` and `minimum` differ by more than a hyphen. `FIELD_ALIAS_PAIRS` in
  * `src/types/schema.ts` holds those pairs, and a caller that needs them has to
  * read it. v1 therefore yields 34 groups from 48 property names, and `min`,
  * `minimum`, `max` and `maximum` are four of those groups and not two.

--- a/packages/schema/tests/validation/keyword-parity.test.ts
+++ b/packages/schema/tests/validation/keyword-parity.test.ts
@@ -13,7 +13,8 @@ const luaSource = readFileSync(join(validationDir, "schema.lua"), "utf-8");
 const metaSchema = JSON.parse(readFileSync(join(validationDir, "extension-schema-v2.json"), "utf-8"));
 
 describe("keyword parity", () => {
-	const inModule = new Set(parseKeywordTable(luaSource).keys());
+	const entries = parseKeywordTable(luaSource);
+	const inModule = new Set(entries.keys());
 	const inMetaSchema = new Set<string>(metaSchemaProperties(metaSchema));
 
 	it("every keyword the module names is in the meta-schema", () => {
@@ -28,7 +29,6 @@ describe("keyword parity", () => {
 	// cannot record which keywords the module acts on. A reformat that hides
 	// an entry now changes a count and fails here.
 	it("holds 25 acted-on keywords and 7 annotations", () => {
-		const entries = parseKeywordTable(luaSource);
 		expect([...entries.values()].filter((acted) => acted)).toHaveLength(25);
 		expect([...entries.values()].filter((acted) => !acted)).toHaveLength(7);
 	});

--- a/packages/schema/tests/validation/keyword-parity.test.ts
+++ b/packages/schema/tests/validation/keyword-parity.test.ts
@@ -5,26 +5,16 @@ import { describe, it, expect } from "vitest";
 import { ALLOWED_FIELD_PROPERTIES_V2 } from "../../src/validation/schema-derived.js";
 import { validateSchemaDefinitionStructure } from "../../src/validation/schema-definition.js";
 import { SCHEMA_V2_VERSION_URI } from "../../src/types/schema.js";
+import { parseKeywordTable, metaSchemaProperties } from "../helpers/schemaVocabulary.js";
 
 const validationDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "validation");
 
 const luaSource = readFileSync(join(validationDir, "schema.lua"), "utf-8");
 const metaSchema = JSON.parse(readFileSync(join(validationDir, "extension-schema-v2.json"), "utf-8"));
 
-// The module keeps its own keyword table because the `true`/`false` value marks
-// whether it acts on the keyword, which the meta-schema does not record. The
-// names have to agree, so they are compared rather than generated.
-function moduleKeywords(): Set<string> {
-	const block = /^M\.KEYWORDS\s*=\s*\{([\s\S]*?)^\}/m.exec(luaSource);
-	expect(block, "M.KEYWORDS table not found in schema.lua").not.toBeNull();
-	const names = [...block![1].matchAll(/^\s*([A-Za-z][A-Za-z0-9_]*)\s*=\s*(?:true|false)\s*,/gm)];
-	expect(names.length, "no keyword entries parsed from M.KEYWORDS").toBeGreaterThan(0);
-	return new Set(names.map((match) => match[1]));
-}
-
 describe("keyword parity", () => {
-	const inModule = moduleKeywords();
-	const inMetaSchema = new Set<string>(Object.keys(metaSchema.$defs.fieldDescriptor.properties));
+	const inModule = new Set(parseKeywordTable(luaSource).keys());
+	const inMetaSchema = new Set<string>(metaSchemaProperties(metaSchema));
 
 	it("every keyword the module names is in the meta-schema", () => {
 		expect([...inModule].filter((name) => !inMetaSchema.has(name))).toEqual([]);
@@ -32,6 +22,15 @@ describe("keyword parity", () => {
 
 	it("every meta-schema property is named by the module", () => {
 		expect([...inMetaSchema].filter((name) => !inModule.has(name))).toEqual([]);
+	});
+
+	// The split is the reason that this test exists, because the meta-schema
+	// cannot record which keywords the module acts on. A reformat that hides
+	// an entry now changes a count and fails here.
+	it("holds 25 acted-on keywords and 7 annotations", () => {
+		const entries = parseKeywordTable(luaSource);
+		expect([...entries.values()].filter((acted) => acted)).toHaveLength(25);
+		expect([...entries.values()].filter((acted) => !acted)).toHaveLength(7);
 	});
 });
 

--- a/packages/schema/tests/validation/keyword-parity.test.ts
+++ b/packages/schema/tests/validation/keyword-parity.test.ts
@@ -10,6 +10,10 @@ import { parseKeywordTable, metaSchemaProperties } from "../helpers/schemaVocabu
 const validationDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "validation");
 
 const luaSource = readFileSync(join(validationDir, "schema.lua"), "utf-8");
+
+// The meta-schema is read here rather than taken from ALLOWED_FIELD_PROPERTIES_V2,
+// which derives from the same file. This test holds the module to the shipped
+// artefact, so it must not compare it against another piece of source code.
 const metaSchema = JSON.parse(readFileSync(join(validationDir, "extension-schema-v2.json"), "utf-8"));
 
 describe("keyword parity", () => {
@@ -27,10 +31,13 @@ describe("keyword parity", () => {
 
 	// The split is the reason that this test exists, because the meta-schema
 	// cannot record which keywords the module acts on. A reformat that hides
-	// an entry now changes a count and fails here.
+	// an entry now changes a count and fails here. The two counts are asserted
+	// over the names and not over the values, so a failure prints the list and
+	// names the keyword that moved.
 	it("holds 25 acted-on keywords and 7 annotations", () => {
-		expect([...entries.values()].filter((acted) => acted)).toHaveLength(25);
-		expect([...entries.values()].filter((acted) => !acted)).toHaveLength(7);
+		const named = (wanted: boolean) => [...entries].filter(([, acted]) => acted === wanted).map(([name]) => name);
+		expect(named(true)).toHaveLength(25);
+		expect(named(false)).toHaveLength(7);
 	});
 });
 

--- a/packages/schema/tests/validation/published-artefacts.test.ts
+++ b/packages/schema/tests/validation/published-artefacts.test.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
+import { readSchemaVersion } from "../helpers/schemaVocabulary.js";
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const validationDir = join(pkgRoot, "src", "validation");
@@ -21,9 +22,9 @@ const metaSchema = JSON.parse(readFileSync(join(validationDir, "extension-schema
 
 describe("Lua reference validator", () => {
 	it("implements the meta-schema it ships beside", () => {
-		const declared = /^M\.SCHEMA_VERSION\s*=\s*'([^']+)'/m.exec(luaSource);
+		const declared = readSchemaVersion(luaSource);
 		expect(declared, "M.SCHEMA_VERSION assignment not found in schema.lua").not.toBeNull();
-		expect(declared?.[1]).toBe(metaSchema.$id);
+		expect(declared).toBe(metaSchema.$id);
 	});
 });
 

--- a/packages/schema/tests/validation/vocabulary-helper.test.ts
+++ b/packages/schema/tests/validation/vocabulary-helper.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parseKeywordTable, readSchemaVersion, keywordGroups } from "../helpers/schemaVocabulary.js";
+
+describe("parseKeywordTable", () => {
+	// Each case is a way the previous regular expression stopped matching
+	// without failing, so the comparison ran against a short baseline.
+
+	it("reads two entries written on one line", () => {
+		const table = "M.KEYWORDS = {\n  alpha = true, beta = false,\n}\n";
+		expect([...parseKeywordTable(table).keys()]).toEqual(["alpha", "beta"]);
+	});
+
+	it("reads a final entry that has no trailing comma", () => {
+		const table = "M.KEYWORDS = {\n  alpha = true,\n  beta = false\n}\n";
+		expect([...parseKeywordTable(table).keys()]).toEqual(["alpha", "beta"]);
+	});
+
+	it("reads a quoted key", () => {
+		const table = 'M.KEYWORDS = {\n  ["alpha-beta"] = true,\n}\n';
+		expect([...parseKeywordTable(table).keys()]).toEqual(["alpha-beta"]);
+	});
+
+	it("does not count a comment that resembles an entry", () => {
+		const table = "M.KEYWORDS = {\n  -- ghost = true,\n  alpha = true,\n}\n";
+		expect([...parseKeywordTable(table).keys()]).toEqual(["alpha"]);
+	});
+
+	it("keeps the value that marks an acted-on keyword", () => {
+		const table = "M.KEYWORDS = {\n  alpha = true,\n  beta = false,\n}\n";
+		const entries = parseKeywordTable(table);
+		expect(entries.get("alpha")).toBe(true);
+		expect(entries.get("beta")).toBe(false);
+	});
+});
+
+describe("readSchemaVersion", () => {
+	it("reads a single-quoted value", () => {
+		expect(readSchemaVersion("M.SCHEMA_VERSION = 'https://example.test/v2'")).toBe("https://example.test/v2");
+	});
+
+	it("reads a double-quoted value", () => {
+		expect(readSchemaVersion('M.SCHEMA_VERSION = "https://example.test/v2"')).toBe("https://example.test/v2");
+	});
+
+	it("returns null when the assignment is absent", () => {
+		expect(readSchemaVersion("local M = {}")).toBeNull();
+	});
+});
+
+describe("keywordGroups", () => {
+	it("groups the two spellings of one keyword", () => {
+		const groups = keywordGroups(["minLength", "min-length", "type"]);
+		expect(groups.get("minlength")).toEqual(["minLength", "min-length"]);
+		expect(groups.get("type")).toEqual(["type"]);
+	});
+});

--- a/packages/schema/tests/validation/vocabulary-helper.test.ts
+++ b/packages/schema/tests/validation/vocabulary-helper.test.ts
@@ -37,9 +37,10 @@ describe("parseKeywordTable", () => {
 		expect(entries.get("beta")).toBe(false);
 	});
 
-	// A missing table has to raise. A reader that returned an empty map would
-	// give every parity check a baseline of nothing to compare against, and
-	// each one would pass.
+	// A missing table has to raise, so that the failure names its cause. A
+	// reader that returned an empty map would report a parity mismatch
+	// instead, which names the wrong cause, and the check that every module
+	// keyword is held by the meta-schema would pass over nothing.
 	it("raises when the source holds no keyword table", () => {
 		expect(() => parseKeywordTable("local M = {}\n")).toThrow("M.KEYWORDS table not found");
 	});
@@ -65,8 +66,10 @@ describe("metaSchemaProperties", () => {
 		expect(metaSchemaProperties(metaSchema)).toEqual(["type", "min-length"]);
 	});
 
-	// The same reason as the missing keyword table: an empty list would give
-	// each parity check nothing to compare against, and it would pass.
+	// The same reason as the missing keyword table, in the other direction. An
+	// empty list would report a parity mismatch that names the wrong cause,
+	// and the check that every meta-schema property is named by the module
+	// would pass over nothing.
 	it("raises when the field descriptor is absent", () => {
 		expect(() => metaSchemaProperties({})).toThrow("$defs.fieldDescriptor.properties not found in meta-schema");
 	});

--- a/packages/schema/tests/validation/vocabulary-helper.test.ts
+++ b/packages/schema/tests/validation/vocabulary-helper.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseKeywordTable, readSchemaVersion, keywordGroups } from "../helpers/schemaVocabulary.js";
+import {
+	parseKeywordTable,
+	readSchemaVersion,
+	metaSchemaProperties,
+	keywordGroups,
+} from "../helpers/schemaVocabulary.js";
 
 describe("parseKeywordTable", () => {
 	// Each case is a way the previous regular expression stopped matching
@@ -31,6 +36,13 @@ describe("parseKeywordTable", () => {
 		expect(entries.get("alpha")).toBe(true);
 		expect(entries.get("beta")).toBe(false);
 	});
+
+	// A missing table has to raise. A reader that returned an empty map would
+	// give every parity check a baseline of nothing to compare against, and
+	// each one would pass.
+	it("raises when the source holds no keyword table", () => {
+		expect(() => parseKeywordTable("local M = {}\n")).toThrow("M.KEYWORDS table not found");
+	});
 });
 
 describe("readSchemaVersion", () => {
@@ -44,6 +56,19 @@ describe("readSchemaVersion", () => {
 
 	it("returns null when the assignment is absent", () => {
 		expect(readSchemaVersion("local M = {}")).toBeNull();
+	});
+});
+
+describe("metaSchemaProperties", () => {
+	it("reads the property names of a field descriptor", () => {
+		const metaSchema = { $defs: { fieldDescriptor: { properties: { type: {}, "min-length": {} } } } };
+		expect(metaSchemaProperties(metaSchema)).toEqual(["type", "min-length"]);
+	});
+
+	// The same reason as the missing keyword table: an empty list would give
+	// each parity check nothing to compare against, and it would pass.
+	it("raises when the field descriptor is absent", () => {
+		expect(() => metaSchemaProperties({})).toThrow("$defs.fieldDescriptor.properties not found in meta-schema");
 	});
 });
 


### PR DESCRIPTION
Closes the two loose ends of the reference validator work.

The readers over `M.KEYWORDS` and `M.SCHEMA_VERSION` used a regular expression that needed a line start, a bare identifier and a trailing comma. A reformat that put two entries on one line, that dropped the trailing comma on the last entry, or that used a quoted key, hid a name from the module side of the comparison. A comment that resembled an entry was counted as an entry.

That hole was one-directional. A hidden entry that the meta-schema also holds still failed the check that every meta-schema property is named by the module. A module entry that the meta-schema does not hold passed both checks in silence, and that is the divergence the readers close.

A shared reader now removes comments, accepts a quoted key, and needs no trailing comma. A count guard holds the table to 25 acted-on keywords and 7 annotations, which is the split that the meta-schema cannot record. Each reader raises when its table is absent, because a reader that returned nothing would give every parity check an empty baseline to compare against, and each one would pass.

One changelog entry named `\0` among the escapes that the refusal now covers. That escape was already refused, and only its reported reason changed.
