### PR TITLE
fix: show every vocabulary keyword in the example schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fix: let the name a schema declares win over an alias in the Lua reference validator. The conflict warning now names the two keys the author wrote, rather than a name that only the schema uses.
 - fix: accept a document that supplies both a field's declared name and one of its aliases in the Lua reference validator. Under `additionalProperties: false` the leftover alias key made the document invalid, and it now produces a warning.
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
+- fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
 
 ## 3.2.0 (2026-08-02)
 

--- a/docs/assets/schema/v1/extension-schema-example.json
+++ b/docs/assets/schema/v1/extension-schema-example.json
@@ -24,6 +24,13 @@
 			"min": 1,
 			"max": 100
 		},
+		"threshold": {
+			"type": "number",
+			"description": "Cut-off value between 0 and 1.",
+			"default": 0.8,
+			"minimum": 0,
+			"maximum": 1
+		},
 		"slug": {
 			"type": "string",
 			"description": "URL-safe identifier for the output.",
@@ -99,6 +106,12 @@
 				"type": "file",
 				"extensions": [".png", ".svg", ".jpg"]
 			}
+		},
+		"inlineLogo": {
+			"type": "string",
+			"description": "Inline logo image, encoded as base64.",
+			"contentEncoding": "base64",
+			"contentMediaType": "image/png"
 		},
 		"customCss": {
 			"type": "string",

--- a/docs/assets/schema/v1/extension-schema-example.yml
+++ b/docs/assets/schema/v1/extension-schema-example.yml
@@ -50,13 +50,21 @@ options:
     exclusive-maximum: 1
 
   # An integer option with inclusive min/max bounds.
-  # "minimum" and "maximum" are accepted aliases for "min" and "max".
   count:
     type: number
     description: "Number of items to display."
     default: 3
     min: 1
     max: 100
+
+  # The same two bounds, written with the "minimum" and "maximum" aliases.
+  # v1 accepts either spelling, and this file shows both.
+  threshold:
+    type: number
+    description: "Cut-off value between 0 and 1."
+    default: 0.8
+    minimum: 0
+    maximum: 1
 
   # A string option with pattern validation.
   slug:
@@ -142,6 +150,14 @@ options:
         - .png
         - .svg
         - .jpg
+
+  # content-encoding and content-media-type are annotations. They describe the
+  # string value, and no check rejects a value that disagrees with them.
+  inline-logo:
+    type: string
+    description: "Inline logo image, encoded as base64."
+    content-encoding: base64
+    content-media-type: image/png
 
   # A field with freeform completion and placeholder.
   custom-css:

--- a/docs/assets/schema/v2/extension-schema-example.json
+++ b/docs/assets/schema/v2/extension-schema-example.json
@@ -64,6 +64,7 @@
 			"description": "List of classification tags.",
 			"minItems": 1,
 			"maxItems": 10,
+			"uniqueItems": true,
 			"items": {
 				"type": "string",
 				"minLength": 1
@@ -121,6 +122,12 @@
 				"type": "file",
 				"extensions": [".png", ".svg", ".jpg"]
 			}
+		},
+		"inlineLogo": {
+			"type": "string",
+			"description": "Inline logo image, encoded as base64.",
+			"contentEncoding": "base64",
+			"contentMediaType": "image/png"
 		}
 	},
 	"shortcodes": {

--- a/docs/assets/schema/v2/extension-schema-example.yml
+++ b/docs/assets/schema/v2/extension-schema-example.yml
@@ -82,6 +82,7 @@ options:
     description: "List of classification tags."
     minItems: 1
     maxItems: 10
+    uniqueItems: true
     items:
       type: string
       minLength: 1
@@ -144,6 +145,14 @@ options:
         - .png
         - .svg
         - .jpg
+
+  # contentEncoding and contentMediaType are annotations. They describe the
+  # string value, and no check rejects a value that disagrees with them.
+  inlineLogo:
+    type: string
+    description: "Inline logo image, encoded as base64."
+    contentEncoding: base64
+    contentMediaType: image/png
 
 # ---------------------------------------------------------------------------
 # shortcodes

--- a/packages/schema/tests/validation/example-vocabulary.test.ts
+++ b/packages/schema/tests/validation/example-vocabulary.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import * as yaml from "js-yaml";
+import { validateSchemaDefinitionStructure } from "../../src/validation/schema-definition.js";
 import { metaSchemaProperties, keywordGroups } from "../helpers/schemaVocabulary.js";
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -101,5 +102,13 @@ describe.each(versions)("$name example files show the whole vocabulary", ({ name
 			.filter((spellings) => !spellings.some((spelling) => keys.has(spelling)))
 			.map((spellings) => spellings.join(" or "));
 		expect(uncovered).toEqual([]);
+	});
+
+	// Coverage alone lets an example gain an illegal key, or a v1 spelling in a
+	// v2 file, and stay green. The validator reads the `$schema` of the file, so
+	// it holds each example to the vocabulary of its own version.
+	it.each(formats)("the $format example is valid against its meta-schema", ({ extension, parse }) => {
+		const source = readFileSync(join(docsBase, name, `extension-schema-example.${extension}`), "utf-8");
+		expect(validateSchemaDefinitionStructure(parse(source))).toEqual([]);
 	});
 });

--- a/packages/schema/tests/validation/example-vocabulary.test.ts
+++ b/packages/schema/tests/validation/example-vocabulary.test.ts
@@ -18,17 +18,68 @@ const versions = [
 	{ name: "v2", metaSchema: "extension-schema-v2.json", dir: "v2" },
 ];
 
-/** Every key of a parsed document, at any depth. */
-function collectKeys(value: unknown, found: Set<string> = new Set()): Set<string> {
-	if (Array.isArray(value)) {
-		for (const element of value) {
-			collectKeys(element, found);
+type Descriptor = Record<string, unknown>;
+
+function asRecord(value: unknown): Descriptor | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Descriptor) : undefined;
+}
+
+/**
+ * The keys of one field descriptor, and of every descriptor nested in it.
+ *
+ * The walk goes down through `properties`, `items` and `additionalProperties`
+ * only, because those three hold a descriptor. It does not go down through
+ * `completion`, `deprecated` or `dependentRequired`, whose own keys belong to
+ * another vocabulary.
+ */
+function descriptorKeys(value: unknown, found: Set<string>): Set<string> {
+	const descriptor = asRecord(value);
+	if (descriptor === undefined) {
+		return found;
+	}
+	for (const [key, nested] of Object.entries(descriptor)) {
+		found.add(key);
+		if (key === "items" || key === "additionalProperties") {
+			descriptorKeys(nested, found);
+		} else if (key === "properties") {
+			for (const property of Object.values(asRecord(nested) ?? {})) {
+				descriptorKeys(property, found);
+			}
 		}
-	} else if (value !== null && typeof value === "object") {
-		for (const [key, nested] of Object.entries(value)) {
-			found.add(key);
-			collectKeys(nested, found);
+	}
+	return found;
+}
+
+/**
+ * Every keyword that an example file uses, read from descriptor positions only.
+ *
+ * A walk over all keys at all depths is wrong here. It reads an option name, a
+ * shortcode name and an attribute name as a keyword, so an example that names
+ * an option `title` covers the `title` keyword without using it. The test then
+ * passes after the last real use of that keyword is deleted, which is the drift
+ * that it exists to catch.
+ */
+function vocabularyKeys(document: unknown): Set<string> {
+	const found = new Set<string>();
+	const root = asRecord(document) ?? {};
+	const descriptorMap = (value: unknown) => {
+		for (const descriptor of Object.values(asRecord(value) ?? {})) {
+			descriptorKeys(descriptor, found);
 		}
+	};
+	descriptorMap(root.options);
+	for (const shortcode of Object.values(asRecord(root.shortcodes) ?? {})) {
+		const entry = asRecord(shortcode) ?? {};
+		for (const argument of Array.isArray(entry.arguments) ? entry.arguments : []) {
+			descriptorKeys(argument, found);
+		}
+		descriptorMap(entry.attributes);
+	}
+	for (const format of Object.values(asRecord(root.formats) ?? {})) {
+		descriptorMap(format);
+	}
+	for (const group of Object.values(asRecord(root.attributes) ?? {})) {
+		descriptorMap(group);
 	}
 	return found;
 }
@@ -37,16 +88,14 @@ describe.each(versions)("$name example files show the whole vocabulary", ({ meta
 	const properties = metaSchemaProperties(JSON.parse(readFileSync(join(validationDir, metaSchema), "utf-8")));
 	const groups = keywordGroups(properties);
 
-	// A key walk, and not a text search. A text search for `type` matches inside
-	// `contentMediaType`, so the test would pass on a wrong result.
 	const examples = [
 		{
 			format: "yaml",
-			keys: collectKeys(yaml.load(readFileSync(join(docsBase, dir, "extension-schema-example.yml"), "utf-8"))),
+			keys: vocabularyKeys(yaml.load(readFileSync(join(docsBase, dir, "extension-schema-example.yml"), "utf-8"))),
 		},
 		{
 			format: "json",
-			keys: collectKeys(JSON.parse(readFileSync(join(docsBase, dir, "extension-schema-example.json"), "utf-8"))),
+			keys: vocabularyKeys(JSON.parse(readFileSync(join(docsBase, dir, "extension-schema-example.json"), "utf-8"))),
 		},
 	];
 

--- a/packages/schema/tests/validation/example-vocabulary.test.ts
+++ b/packages/schema/tests/validation/example-vocabulary.test.ts
@@ -14,40 +14,46 @@ const docsBase = join(pkgRoot, "..", "..", "docs", "assets", "schema");
 // meta-schema could reach the published site while the example stayed behind,
 // which is how `uniqueItems` was missed.
 const versions = [
-	{ name: "v1", metaSchema: "extension-schema.json", dir: "v1" },
-	{ name: "v2", metaSchema: "extension-schema-v2.json", dir: "v2" },
+	{ name: "v1", metaSchema: "extension-schema.json" },
+	{ name: "v2", metaSchema: "extension-schema-v2.json" },
 ];
 
-type Descriptor = Record<string, unknown>;
+const formats = [
+	{ format: "yaml", extension: "yml", parse: (text: string): unknown => yaml.load(text) },
+	{ format: "json", extension: "json", parse: (text: string): unknown => JSON.parse(text) },
+];
 
-function asRecord(value: unknown): Descriptor | undefined {
-	return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Descriptor) : undefined;
+/** The value as a plain object, or an empty one when it is not a plain object. */
+function asRecord(value: unknown): Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+/** Every key that a nested descriptor holds. v1 spells one of these in kebab-case. */
+const NESTED_DESCRIPTOR_KEYS = new Set(["items", "additionalProperties", "additional-properties"]);
+
 /**
- * The keys of one field descriptor, and of every descriptor nested in it.
+ * Add the keys of one field descriptor, and of every descriptor nested in it.
  *
- * The walk goes down through `properties`, `items` and `additionalProperties`
- * only, because those three hold a descriptor. It does not go down through
- * `completion`, `deprecated` or `dependentRequired`, whose own keys belong to
- * another vocabulary.
+ * The walk goes down through the keys that hold a descriptor. It does not go
+ * down through `completion`, `deprecated` or `dependentRequired`, whose own
+ * keys belong to another vocabulary.
  */
-function descriptorKeys(value: unknown, found: Set<string>): Set<string> {
-	const descriptor = asRecord(value);
-	if (descriptor === undefined) {
-		return found;
-	}
-	for (const [key, nested] of Object.entries(descriptor)) {
+function descriptorKeys(value: unknown, found: Set<string>): void {
+	for (const [key, nested] of Object.entries(asRecord(value))) {
 		found.add(key);
-		if (key === "items" || key === "additionalProperties") {
+		if (NESTED_DESCRIPTOR_KEYS.has(key)) {
 			descriptorKeys(nested, found);
 		} else if (key === "properties") {
-			for (const property of Object.values(asRecord(nested) ?? {})) {
-				descriptorKeys(property, found);
-			}
+			descriptorMap(nested, found);
 		}
 	}
-	return found;
+}
+
+/** Add the keys of every descriptor in a map of name to descriptor. */
+function descriptorMap(value: unknown, found: Set<string>): void {
+	for (const descriptor of Object.values(asRecord(value))) {
+		descriptorKeys(descriptor, found);
+	}
 }
 
 /**
@@ -58,48 +64,37 @@ function descriptorKeys(value: unknown, found: Set<string>): Set<string> {
  * an option `title` covers the `title` keyword without using it. The test then
  * passes after the last real use of that keyword is deleted, which is the drift
  * that it exists to catch.
+ *
+ * `validateSchemaDefinitionStructure` in `src/validation/schema-definition.ts`
+ * walks the same sections. A section added there has to be added here as well.
  */
 function vocabularyKeys(document: unknown): Set<string> {
 	const found = new Set<string>();
-	const root = asRecord(document) ?? {};
-	const descriptorMap = (value: unknown) => {
-		for (const descriptor of Object.values(asRecord(value) ?? {})) {
-			descriptorKeys(descriptor, found);
-		}
-	};
-	descriptorMap(root.options);
-	for (const shortcode of Object.values(asRecord(root.shortcodes) ?? {})) {
-		const entry = asRecord(shortcode) ?? {};
+	const root = asRecord(document);
+	descriptorMap(root.options, found);
+	for (const shortcode of Object.values(asRecord(root.shortcodes))) {
+		const entry = asRecord(shortcode);
 		for (const argument of Array.isArray(entry.arguments) ? entry.arguments : []) {
 			descriptorKeys(argument, found);
 		}
-		descriptorMap(entry.attributes);
+		descriptorMap(entry.attributes, found);
 	}
-	for (const format of Object.values(asRecord(root.formats) ?? {})) {
-		descriptorMap(format);
-	}
-	for (const group of Object.values(asRecord(root.attributes) ?? {})) {
-		descriptorMap(group);
+	for (const container of [root.formats, root.attributes]) {
+		for (const group of Object.values(asRecord(container))) {
+			descriptorMap(group, found);
+		}
 	}
 	return found;
 }
 
-describe.each(versions)("$name example files show the whole vocabulary", ({ metaSchema, dir }) => {
-	const properties = metaSchemaProperties(JSON.parse(readFileSync(join(validationDir, metaSchema), "utf-8")));
-	const groups = keywordGroups(properties);
+describe.each(versions)("$name example files show the whole vocabulary", ({ name, metaSchema }) => {
+	const groups = keywordGroups(
+		metaSchemaProperties(JSON.parse(readFileSync(join(validationDir, metaSchema), "utf-8"))),
+	);
 
-	const examples = [
-		{
-			format: "yaml",
-			keys: vocabularyKeys(yaml.load(readFileSync(join(docsBase, dir, "extension-schema-example.yml"), "utf-8"))),
-		},
-		{
-			format: "json",
-			keys: vocabularyKeys(JSON.parse(readFileSync(join(docsBase, dir, "extension-schema-example.json"), "utf-8"))),
-		},
-	];
-
-	it.each(examples)("the $format example shows one spelling of every keyword", ({ keys }) => {
+	it.each(formats)("the $format example shows one spelling of every keyword", ({ extension, parse }) => {
+		const source = readFileSync(join(docsBase, name, `extension-schema-example.${extension}`), "utf-8");
+		const keys = vocabularyKeys(parse(source));
 		// One spelling is enough. v1 YAML uses kebab-case and v1 JSON uses
 		// camelCase, by the stated design of those files.
 		const uncovered = [...groups.values()]

--- a/packages/schema/tests/validation/example-vocabulary.test.ts
+++ b/packages/schema/tests/validation/example-vocabulary.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import * as yaml from "js-yaml";
+import { metaSchemaProperties, keywordGroups } from "../helpers/schemaVocabulary.js";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const validationDir = join(pkgRoot, "src", "validation");
+const docsBase = join(pkgRoot, "..", "..", "docs", "assets", "schema");
+
+// The example files are written by hand. Nothing copies them, so nothing held
+// them to the vocabulary that they claim to show. A keyword added to a
+// meta-schema could reach the published site while the example stayed behind,
+// which is how `uniqueItems` was missed.
+const versions = [
+	{ name: "v1", metaSchema: "extension-schema.json", dir: "v1" },
+	{ name: "v2", metaSchema: "extension-schema-v2.json", dir: "v2" },
+];
+
+/** Every key of a parsed document, at any depth. */
+function collectKeys(value: unknown, found: Set<string> = new Set()): Set<string> {
+	if (Array.isArray(value)) {
+		for (const element of value) {
+			collectKeys(element, found);
+		}
+	} else if (value !== null && typeof value === "object") {
+		for (const [key, nested] of Object.entries(value)) {
+			found.add(key);
+			collectKeys(nested, found);
+		}
+	}
+	return found;
+}
+
+describe.each(versions)("$name example files show the whole vocabulary", ({ metaSchema, dir }) => {
+	const properties = metaSchemaProperties(JSON.parse(readFileSync(join(validationDir, metaSchema), "utf-8")));
+	const groups = keywordGroups(properties);
+
+	// A key walk, and not a text search. A text search for `type` matches inside
+	// `contentMediaType`, so the test would pass on a wrong result.
+	const examples = [
+		{
+			format: "yaml",
+			keys: collectKeys(yaml.load(readFileSync(join(docsBase, dir, "extension-schema-example.yml"), "utf-8"))),
+		},
+		{
+			format: "json",
+			keys: collectKeys(JSON.parse(readFileSync(join(docsBase, dir, "extension-schema-example.json"), "utf-8"))),
+		},
+	];
+
+	it.each(examples)("the $format example shows one spelling of every keyword", ({ keys }) => {
+		// One spelling is enough. v1 YAML uses kebab-case and v1 JSON uses
+		// camelCase, by the stated design of those files.
+		const uncovered = [...groups.values()]
+			.filter((spellings) => !spellings.some((spelling) => keys.has(spelling)))
+			.map((spellings) => spellings.join(" or "));
+		expect(uncovered).toEqual([]);
+	});
+});


### PR DESCRIPTION
The published examples claim to show every supported property, and they did not.

Counted by keyword rather than by property name, every example missed `contentEncoding` and `contentMediaType`, the two v1 examples also missed `minimum` and `maximum`, and the two v2 examples also missed `uniqueItems`.
Counting property names is wrong for v1, which carries a camelCase and a kebab-case spelling of most keywords, so the v1 YAML file and the v1 JSON file are each complete in their own style.
`minimum` and `maximum` are not a spelling of `min` and `max`, so v1 needs both pairs.

A new test walks the parsed keys of each example, groups the two spellings of one keyword, and asks whether any one spelling appears.
It holds both versions to full coverage and carries no allow-list, because this change closes every gap.

Each example gains one option for the two content keywords, named `inline-logo` in the v1 YAML file and `inlineLogo` elsewhere.
The v1 examples gain a `threshold` option that uses the `minimum` and `maximum` spelling.
All four files stay valid against their meta-schemas, measured with `ajv` for draft 2020-12.
