### PR TITLE
fix: teach the canonical v2 vocabulary in the schema prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fix: accept a document that supplies both a field's declared name and one of its aliases in the Lua reference validator. Under `additionalProperties: false` the leftover alias key made the document invalid, and it now produces a warning.
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
+- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 14 v1 spellings such as `min-length` and `pattern-exact`, and told the author to declare the v2 meta-schema, which rejects all of them. A test now holds every property that the prompt names to the v2 vocabulary.
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - fix: accept a document that supplies both a field's declared name and one of its aliases in the Lua reference validator. Under `additionalProperties: false` the leftover alias key made the document invalid, and it now produces a warning.
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
-- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 14 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
+- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 15 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - fix: accept a document that supplies both a field's declared name and one of its aliases in the Lua reference validator. Under `additionalProperties: false` the leftover alias key made the document invalid, and it now produces a warning.
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
-- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 14 v1 spellings such as `min-length` and `pattern-exact`, and told the author to declare the v2 meta-schema, which rejects all of them. A test now holds every property that the prompt names to the v2 vocabulary. (#382)
+- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 14 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - fix: accept a document that supplies both a field's declared name and one of its aliases in the Lua reference validator. Under `additionalProperties: false` the leftover alias key made the document invalid, and it now produces a warning.
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
-- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 14 v1 spellings such as `min-length` and `pattern-exact`, and told the author to declare the v2 meta-schema, which rejects all of them. A test now holds every property that the prompt names to the v2 vocabulary.
+- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 14 v1 spellings such as `min-length` and `pattern-exact`, and told the author to declare the v2 meta-schema, which rejects all of them. A test now holds every property that the prompt names to the v2 vocabulary. (#382)
 
 ## 3.2.0 (2026-08-02)
 

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -693,7 +693,7 @@ For every field use the following properties where applicable:
 - `examples`: list of example values for documentation and tooling.
 - `aliases`: alternative key names accepted by the code.
 - `deprecated`: `true`, a message string, or an object with `since`,
-  `message`, and `replace-with` keys.
+  `message`, and `replaceWith` keys.
 - `description`: one sentence in British English explaining the option.
 - `completion`: controls IDE autocompletion behaviour. Sub-properties:
   `type` (`color` for CSS colour values, `file` for file paths,

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -282,34 +282,34 @@ All properties are optional.
 
 ### Type and Value Constraints
 
-| Property                | Type                          | Description                                                                                                                                                         |
-| ----------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`                  | `string`                      | Expected value type: `string`, `number`, `integer`, `boolean`, `array`, `object`, `null`, or `content`.                                                             |
-| `required`              | `boolean`                     | Whether the field must be present. Default: `false`.                                                                                                                |
-| `default`               | any                           | Default value applied when not provided.                                                                                                                            |
-| `const`                 | any                           | Fixed value the field must equal.                                                                                                                                   |
-| `enum`                  | array                         | List of allowed values.                                                                                                                                             |
-| `enum-case-insensitive` | `boolean`                     | Case-insensitive enum matching. Default: `false`.                                                                                                                   |
-| `pattern`               | `string`                      | Regular expression the value must match (JS regex syntax).                                                                                                          |
-| `pattern-exact`         | `boolean`                     | Deprecated. Anchor the pattern to match the entire value (wraps in `^...$`). Prefer writing `^...$` directly.                                                       |
-| `min`                   | `number`                      | Minimum value (inclusive, for `type: number` or `type: integer`).                                                                                                   |
-| `max`                   | `number`                      | Maximum value (inclusive, for `type: number` or `type: integer`).                                                                                                   |
-| `minimum`               | `number`                      | Alias for `min`.                                                                                                                                                    |
-| `maximum`               | `number`                      | Alias for `max`.                                                                                                                                                    |
-| `exclusive-minimum`     | `number`                      | Exclusive minimum (value must be strictly greater).                                                                                                                 |
-| `exclusive-maximum`     | `number`                      | Exclusive maximum (value must be strictly less).                                                                                                                    |
-| `multiple-of`           | `number`                      | Value must be a positive multiple of this number (for `type: number` or `type: integer`).                                                                           |
-| `min-length`            | `integer`                     | Minimum string length (for `type: string`).                                                                                                                         |
-| `max-length`            | `integer`                     | Maximum string length (for `type: string`).                                                                                                                         |
-| `min-items`             | `integer`                     | Minimum number of items (for `type: array`).                                                                                                                        |
-| `max-items`             | `integer`                     | Maximum number of items (for `type: array`).                                                                                                                        |
+| Property                | Type                          | Description                                                                                                                                                                                                                  |
+| ----------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                  | `string`                      | Expected value type: `string`, `number`, `integer`, `boolean`, `array`, `object`, `null`, or `content`.                                                                                                                      |
+| `required`              | `boolean`                     | Whether the field must be present. Default: `false`.                                                                                                                                                                         |
+| `default`               | any                           | Default value applied when not provided.                                                                                                                                                                                     |
+| `const`                 | any                           | Fixed value the field must equal.                                                                                                                                                                                            |
+| `enum`                  | array                         | List of allowed values.                                                                                                                                                                                                      |
+| `enum-case-insensitive` | `boolean`                     | Case-insensitive enum matching. Default: `false`.                                                                                                                                                                            |
+| `pattern`               | `string`                      | Regular expression the value must match (JS regex syntax).                                                                                                                                                                   |
+| `pattern-exact`         | `boolean`                     | Deprecated. Anchor the pattern to match the entire value (wraps in `^...$`). Prefer writing `^...$` directly.                                                                                                                |
+| `min`                   | `number`                      | Minimum value (inclusive, for `type: number` or `type: integer`).                                                                                                                                                            |
+| `max`                   | `number`                      | Maximum value (inclusive, for `type: number` or `type: integer`).                                                                                                                                                            |
+| `minimum`               | `number`                      | Alias for `min`.                                                                                                                                                                                                             |
+| `maximum`               | `number`                      | Alias for `max`.                                                                                                                                                                                                             |
+| `exclusive-minimum`     | `number`                      | Exclusive minimum (value must be strictly greater).                                                                                                                                                                          |
+| `exclusive-maximum`     | `number`                      | Exclusive maximum (value must be strictly less).                                                                                                                                                                             |
+| `multiple-of`           | `number`                      | Value must be a positive multiple of this number (for `type: number` or `type: integer`).                                                                                                                                    |
+| `min-length`            | `integer`                     | Minimum string length (for `type: string`).                                                                                                                                                                                  |
+| `max-length`            | `integer`                     | Maximum string length (for `type: string`).                                                                                                                                                                                  |
+| `min-items`             | `integer`                     | Minimum number of items (for `type: array`).                                                                                                                                                                                 |
+| `max-items`             | `integer`                     | Maximum number of items (for `type: array`).                                                                                                                                                                                 |
 | `uniqueItems`           | `boolean`                     | Reject an array that repeats an item, for `type: array`. Items are compared by type, so the number `1` and the string `"1"` are different items; a string is compared by its own text, and any other value by its rendering. |
-| `additional-properties` | `boolean` or field descriptor | Whether object values may carry keys beyond those in `properties`. Default: `true`.                                                                                 |
-| `property-names`        | `string`                      | Regular expression all object keys must match (for `type: object`).                                                                                                 |
-| `dependent-required`    | `object`                      | Map of key → list of keys that become required when that key is present (for `type: object`).                                                                       |
-| `format`                | `string`                      | JSON Schema format hint (e.g. `uri`, `email`, `date-time`). Annotation only.                                                                                        |
-| `content-encoding`      | `string`                      | Content encoding for a string value (e.g. `base64`). Annotation only.                                                                                               |
-| `content-media-type`    | `string`                      | Media type of a string value (e.g. `application/json`). Annotation only.                                                                                            |
+| `additional-properties` | `boolean` or field descriptor | Whether object values may carry keys beyond those in `properties`. Default: `true`.                                                                                                                                          |
+| `property-names`        | `string`                      | Regular expression all object keys must match (for `type: object`).                                                                                                                                                          |
+| `dependent-required`    | `object`                      | Map of key → list of keys that become required when that key is present (for `type: object`).                                                                                                                                |
+| `format`                | `string`                      | JSON Schema format hint (e.g. `uri`, `email`, `date-time`). Annotation only.                                                                                                                                                 |
+| `content-encoding`      | `string`                      | Content encoding for a string value (e.g. `base64`). Annotation only.                                                                                                                                                        |
+| `content-media-type`    | `string`                      | Media type of a string value (e.g. `application/json`). Annotation only.                                                                                                                                                     |
 
 An empty string is a value, not an absent key.
 A key set to `""` keeps that value, does not take its `default`, satisfies `required`, and is tested against `minLength`, `const` and `enum`, for a plain option value, an array element, and a surplus key matched by `additionalProperties`.
@@ -665,25 +665,30 @@ For every field use the following properties where applicable:
   exactly one value.
 - `enum`: list of allowed values when the code checks against a
   fixed set.
-- `enum-case-insensitive`: `true` when the code lowercases or
+- `enumCaseInsensitive`: `true` when the code lowercases or
   case-folds before comparing.
 - `pattern`: regular expression the value must match (JS syntax).
-- `pattern-exact`: `true` to anchor the pattern with `^...$`.
-- `min` / `max`: inclusive numeric bounds
-  (`minimum` and `maximum` are accepted as aliases).
-- `exclusive-minimum` / `exclusive-maximum`: exclusive numeric bounds
+  Anchor it with `^` and `$` in the value itself when the whole string
+  must match.
+- `minimum` / `maximum`: inclusive numeric bounds.
+- `exclusiveMinimum` / `exclusiveMaximum`: exclusive numeric bounds
   (value must be strictly greater / strictly less).
-- `multiple-of`: value must be a positive multiple of this number.
-- `min-length` / `max-length`: string length constraints.
-- `min-items` / `max-items`: array item count constraints.
-- `additional-properties`: `false` to forbid extra keys on a
+- `multipleOf`: value must be a positive multiple of this number.
+- `minLength` / `maxLength`: string length constraints.
+- `minItems` / `maxItems`: array item count constraints.
+- `uniqueItems`: `true` when every element of an `array` must differ.
+- `additionalProperties`: `false` to forbid extra keys on a
   `type: object`, or a nested field descriptor that every extra value
   must match.
-- `property-names`: regular expression every object key must match.
-- `dependent-required`: map of key → list of keys that become required
+- `propertyNames`: regular expression every object key must match.
+- `dependentRequired`: map of key → list of keys that become required
   whenever that key is present.
 - `format`: JSON Schema format hint (`uri`, `email`, `date-time`, etc.).
   Annotation only.
+- `contentEncoding`: how a string value is encoded, for example
+  `base64`. Annotation only.
+- `contentMediaType`: the media type of a string value, for example
+  `image/png`. Annotation only.
 - `title`: short human-readable label.
 - `examples`: list of example values for documentation and tooling.
 - `aliases`: alternative key names accepted by the code.
@@ -703,8 +708,10 @@ For every field use the following properties where applicable:
   to describe each expected key and its constraints.
 
 Output only the YAML content of `_schema.yml`, nothing else.
-Use kebab-case for multi-word property names (`enum-case-insensitive`,
-not `enumCaseInsensitive`).
+Use camelCase for multi-word property names (`enumCaseInsensitive`,
+not `enum-case-insensitive`).
+The v2 vocabulary holds the canonical names only, and it rejects the v1
+dual-key spellings such as `min`, `max` and `pattern-exact`.
 Add a one-line comment header: `# Schema for the <name> extension`.
 Optionally include `$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json`
 at the top level.

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -706,6 +706,8 @@ For every field use the following properties where applicable:
   describe what each array element looks like (its type, enum, etc.).
 - `properties`: schema for keys of an `object` type. Use `properties`
   to describe each expected key and its constraints.
+- `name`: the name of a positional shortcode argument. Required in an
+  entry of an `arguments` list, and used nowhere else.
 
 Output only the YAML content of `_schema.yml`, nothing else.
 Use camelCase for multi-word property names (`enumCaseInsensitive`,

--- a/packages/schema/tests/helpers/schemaVocabulary.ts
+++ b/packages/schema/tests/helpers/schemaVocabulary.ts
@@ -49,6 +49,26 @@ export function metaSchemaProperties(metaSchema: unknown): string[] {
 	return Object.keys(properties);
 }
 
+type DefsShape = { $defs?: Record<string, { properties?: Record<string, unknown> } | undefined> };
+
+/**
+ * Every property name that a meta-schema declares, from every entry of `$defs`.
+ *
+ * A vocabulary is wider than one field descriptor. The structured `deprecated`
+ * value and the completion hint carry their own keys, and a caller that
+ * compares two versions has to see them, because a superseded spelling can sit
+ * in any of those maps. Naming the entries one by one leaves the next entry out
+ * in silence, so every entry is read.
+ */
+export function metaSchemaVocabulary(metaSchema: unknown): string[] {
+	const defs = Object.values((metaSchema as DefsShape).$defs ?? {});
+	const names = new Set(defs.flatMap((def) => Object.keys(def?.properties ?? {})));
+	if (names.size === 0) {
+		throw new Error("no $defs entry holds properties in meta-schema");
+	}
+	return [...names];
+}
+
 /**
  * Group the camelCase and the kebab-case spelling of one keyword.
  *

--- a/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
+++ b/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { metaSchemaProperties } from "../helpers/schemaVocabulary.js";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const repoRoot = join(pkgRoot, "..", "..");
+const page = readFileSync(join(repoRoot, "docs", "reference", "schema-specification.qmd"), "utf-8");
+const metaSchema: unknown = JSON.parse(
+	readFileSync(join(pkgRoot, "src", "validation", "extension-schema-v2.json"), "utf-8"),
+);
+
+// The prompt tells the author to declare the v2 meta-schema, and
+// `$defs.fieldDescriptor` sets `additionalProperties: false`, so a property
+// that the prompt names and the vocabulary does not hold is an error in every
+// schema that a reader writes from it. Correcting the prose alone leaves the
+// next edit free to reintroduce a v1 spelling.
+const PROMPT_BLOCK = /```\{\.markdown filename="Prompt for generating[^"]*"\}\n([\s\S]*?)\n```/;
+
+// The prompt lists each property as a bullet whose head is the name in
+// backticks, and a pair of bounds shares one bullet, as in
+// "- `minLength` / `maxLength`: string length constraints.". The head stops at
+// the colon, because the description that follows names values and not
+// properties.
+const BULLET_HEAD = /^- ((?:`[A-Za-z][A-Za-z0-9-]*`(?: \/ )?)+):/gm;
+
+/** Every property name that the AI prompt teaches. */
+function promptPropertyNames(): string[] {
+	const block = PROMPT_BLOCK.exec(page);
+	expect(block, "AI prompt code block not found in schema-specification.qmd").not.toBeNull();
+	const named = [...block![1].matchAll(BULLET_HEAD)].flatMap((head) =>
+		[...head[1].matchAll(/`([^`]+)`/g)].map((name) => name[1]),
+	);
+	expect(named.length, "no property bullets parsed from the prompt").toBeGreaterThan(0);
+	return [...new Set(named)];
+}
+
+describe("AI prompt vocabulary", () => {
+	it("names only properties that the v2 meta-schema holds", () => {
+		const allowed = new Set(metaSchemaProperties(metaSchema));
+		expect(promptPropertyNames().filter((name) => !allowed.has(name))).toEqual([]);
+	});
+
+	it("does not tell the author to use kebab-case", () => {
+		expect(page).not.toMatch(/Use kebab-case for multi-word property names/);
+	});
+});

--- a/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
+++ b/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
@@ -7,7 +7,12 @@ import { metaSchemaProperties, metaSchemaVocabulary } from "../helpers/schemaVoc
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const repoRoot = join(pkgRoot, "..", "..");
 const validationDir = join(pkgRoot, "src", "validation");
-const page = readFileSync(join(repoRoot, "docs", "reference", "schema-specification.qmd"), "utf-8");
+// Every pattern below anchors on a line feed, and a Windows checkout holds a
+// carriage return before each one, so the page is normalised on read.
+const page = readFileSync(join(repoRoot, "docs", "reference", "schema-specification.qmd"), "utf-8").replace(
+	/\r\n/g,
+	"\n",
+);
 
 /** A meta-schema, read from the directory that publishes it. */
 function readMetaSchema(file: string): unknown {

--- a/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
+++ b/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
@@ -6,10 +6,15 @@ import { metaSchemaProperties } from "../helpers/schemaVocabulary.js";
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const repoRoot = join(pkgRoot, "..", "..");
+const validationDir = join(pkgRoot, "src", "validation");
 const page = readFileSync(join(repoRoot, "docs", "reference", "schema-specification.qmd"), "utf-8");
-const metaSchema: unknown = JSON.parse(
-	readFileSync(join(pkgRoot, "src", "validation", "extension-schema-v2.json"), "utf-8"),
-);
+
+/** A meta-schema, read from the directory that publishes it. */
+function readMetaSchema(file: string): unknown {
+	return JSON.parse(readFileSync(join(validationDir, file), "utf-8"));
+}
+
+const metaSchema = readMetaSchema("extension-schema-v2.json");
 
 // The prompt tells the author to declare the v2 meta-schema, and
 // `$defs.fieldDescriptor` sets `additionalProperties: false`, so a property
@@ -20,26 +25,66 @@ const PROMPT_BLOCK = /```\{\.markdown filename="Prompt for generating[^"]*"\}\n(
 
 // The prompt lists each property as a bullet whose head is the name in
 // backticks, and a pair of bounds shares one bullet, as in
-// "- `minLength` / `maxLength`: string length constraints.". The head stops at
-// the colon, because the description that follows names values and not
-// properties.
-const BULLET_HEAD = /^- ((?:`[A-Za-z][A-Za-z0-9-]*`(?: \/ )?)+):/gm;
+// "- `minLength` / `maxLength`: string length constraints.". A bullet runs to
+// the next bullet or to the blank line that ends the list, because a
+// description can take several lines.
+const PROPERTY_BULLET = /^- (`[A-Za-z][A-Za-z0-9-]*`(?: \/ `[A-Za-z][A-Za-z0-9-]*`)*):([\s\S]*?)(?=\n- `|\n\n)/gm;
 
-/** Every property name that the AI prompt teaches. */
-function promptPropertyNames(): string[] {
+/** The body of the code block that holds the AI prompt. */
+function promptBlock(): string {
 	const block = PROMPT_BLOCK.exec(page);
 	expect(block, "AI prompt code block not found in schema-specification.qmd").not.toBeNull();
-	const named = [...block![1].matchAll(BULLET_HEAD)].flatMap((head) =>
-		[...head[1].matchAll(/`([^`]+)`/g)].map((name) => name[1]),
-	);
-	expect(named.length, "no property bullets parsed from the prompt").toBeGreaterThan(0);
-	return [...new Set(named)];
+	return block![1];
+}
+
+/** Every property bullet of the prompt, as a head and a description. */
+function propertyBullets(): { head: string; description: string }[] {
+	const bullets = [...promptBlock().matchAll(PROPERTY_BULLET)].map((bullet) => ({
+		head: bullet[1],
+		description: bullet[2],
+	}));
+	expect(bullets.length, "no property bullets parsed from the prompt").toBeGreaterThan(0);
+	return bullets;
+}
+
+/** Every backticked name in a piece of prompt text. */
+function backtickedNames(text: string): string[] {
+	return [...text.matchAll(/`([^`]+)`/g)].map((name) => name[1]);
+}
+
+/**
+ * Every spelling that v1 holds and v2 does not.
+ *
+ * The prompt names a key of the structured `deprecated` value as well as a
+ * field descriptor property, so both maps are read. A name here is one that
+ * the v2 meta-schema rejects, and the prompt must not teach it.
+ */
+function supersededSpellings(): Set<string> {
+	const properties = (version: unknown): string[] => [
+		...metaSchemaProperties(version),
+		...Object.keys(
+			(version as { $defs: { deprecatedSpec: { properties: Record<string, unknown> } } }).$defs.deprecatedSpec
+				.properties,
+		),
+	];
+	const canonical = new Set(properties(metaSchema));
+	return new Set(properties(readMetaSchema("extension-schema.json")).filter((name) => !canonical.has(name)));
 }
 
 describe("AI prompt vocabulary", () => {
 	it("names only properties that the v2 meta-schema holds", () => {
 		const allowed = new Set(metaSchemaProperties(metaSchema));
-		expect(promptPropertyNames().filter((name) => !allowed.has(name))).toEqual([]);
+		const named = [...new Set(propertyBullets().flatMap((bullet) => backtickedNames(bullet.head)))];
+		expect(named.filter((name) => !allowed.has(name))).toEqual([]);
+	});
+
+	// A description names a key as well, as in "an object with `since`,
+	// `message`, and `replaceWith` keys". The head alone therefore leaves a v1
+	// spelling free to survive inside a description.
+	it("teaches no spelling that v2 supersedes", () => {
+		const superseded = supersededSpellings();
+		const taught = propertyBullets().flatMap((bullet) => backtickedNames(bullet.description));
+		expect([...new Set(taught)].filter((name) => superseded.has(name))).toEqual([]);
 	});
 
 	it("does not tell the author to use kebab-case", () => {

--- a/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
+++ b/packages/schema/tests/validation/ai-prompt-vocabulary.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
-import { metaSchemaProperties } from "../helpers/schemaVocabulary.js";
+import { metaSchemaProperties, metaSchemaVocabulary } from "../helpers/schemaVocabulary.js";
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const repoRoot = join(pkgRoot, "..", "..");
@@ -16,6 +16,19 @@ function readMetaSchema(file: string): unknown {
 
 const metaSchema = readMetaSchema("extension-schema-v2.json");
 
+/**
+ * Every spelling that v1 holds and v2 does not.
+ *
+ * The prompt names a key of the structured `deprecated` value as well as a
+ * field descriptor property, so the whole vocabulary of each version is read. A
+ * name here is one that the v2 meta-schema rejects, and the prompt must not
+ * teach it.
+ */
+const canonical = new Set(metaSchemaVocabulary(metaSchema));
+const superseded = new Set(
+	metaSchemaVocabulary(readMetaSchema("extension-schema.json")).filter((name) => !canonical.has(name)),
+);
+
 // The prompt tells the author to declare the v2 meta-schema, and
 // `$defs.fieldDescriptor` sets `additionalProperties: false`, so a property
 // that the prompt names and the vocabulary does not hold is an error in every
@@ -28,7 +41,7 @@ const PROMPT_BLOCK = /```\{\.markdown filename="Prompt for generating[^"]*"\}\n(
 // "- `minLength` / `maxLength`: string length constraints.". A bullet runs to
 // the next bullet or to the blank line that ends the list, because a
 // description can take several lines.
-const PROPERTY_BULLET = /^- (`[A-Za-z][A-Za-z0-9-]*`(?: \/ `[A-Za-z][A-Za-z0-9-]*`)*):([\s\S]*?)(?=\n- `|\n\n)/gm;
+const PROPERTY_BULLET = /^- (`[^`]+`(?: \/ `[^`]+`)*):([\s\S]*?)(?=\n- `|\n\n)/gm;
 
 /** The body of the code block that holds the AI prompt. */
 function promptBlock(): string {
@@ -52,42 +65,37 @@ function backtickedNames(text: string): string[] {
 	return [...text.matchAll(/`([^`]+)`/g)].map((name) => name[1]);
 }
 
-/**
- * Every spelling that v1 holds and v2 does not.
- *
- * The prompt names a key of the structured `deprecated` value as well as a
- * field descriptor property, so both maps are read. A name here is one that
- * the v2 meta-schema rejects, and the prompt must not teach it.
- */
-function supersededSpellings(): Set<string> {
-	const properties = (version: unknown): string[] => [
-		...metaSchemaProperties(version),
-		...Object.keys(
-			(version as { $defs: { deprecatedSpec: { properties: Record<string, unknown> } } }).$defs.deprecatedSpec
-				.properties,
-		),
-	];
-	const canonical = new Set(properties(metaSchema));
-	return new Set(properties(readMetaSchema("extension-schema.json")).filter((name) => !canonical.has(name)));
+/** Every property name that the head of a bullet declares. */
+function namedProperties(): string[] {
+	return propertyBullets().flatMap((bullet) => backtickedNames(bullet.head));
 }
 
 describe("AI prompt vocabulary", () => {
 	it("names only properties that the v2 meta-schema holds", () => {
 		const allowed = new Set(metaSchemaProperties(metaSchema));
-		const named = [...new Set(propertyBullets().flatMap((bullet) => backtickedNames(bullet.head)))];
-		expect(named.filter((name) => !allowed.has(name))).toEqual([]);
+		expect(namedProperties().filter((name) => !allowed.has(name))).toEqual([]);
+	});
+
+	// The other direction, and the one that a reformat breaks. A bullet head
+	// written in a shape that `PROPERTY_BULLET` does not match drops out of the
+	// list in silence, and the check above then passes over a short baseline.
+	// This check fails instead, because the dropped name is no longer covered.
+	it("names every property of the v2 vocabulary", () => {
+		const named = new Set(namedProperties());
+		expect(metaSchemaProperties(metaSchema).filter((name) => !named.has(name))).toEqual([]);
 	});
 
 	// A description names a key as well, as in "an object with `since`,
 	// `message`, and `replaceWith` keys". The head alone therefore leaves a v1
 	// spelling free to survive inside a description.
 	it("teaches no spelling that v2 supersedes", () => {
-		const superseded = supersededSpellings();
 		const taught = propertyBullets().flatMap((bullet) => backtickedNames(bullet.description));
-		expect([...new Set(taught)].filter((name) => superseded.has(name))).toEqual([]);
+		expect(taught.filter((name) => superseded.has(name))).toEqual([]);
 	});
 
+	// The closing instruction is prose and not a bullet, so no check above
+	// reaches it. It is also where the v1 rule was stated.
 	it("does not tell the author to use kebab-case", () => {
-		expect(page).not.toMatch(/Use kebab-case for multi-word property names/);
+		expect(promptBlock()).not.toContain("Use kebab-case for multi-word property names");
 	});
 });

--- a/packages/schema/tests/validation/vocabulary-helper.test.ts
+++ b/packages/schema/tests/validation/vocabulary-helper.test.ts
@@ -3,6 +3,7 @@ import {
 	parseKeywordTable,
 	readSchemaVersion,
 	metaSchemaProperties,
+	metaSchemaVocabulary,
 	keywordGroups,
 } from "../helpers/schemaVocabulary.js";
 
@@ -72,6 +73,27 @@ describe("metaSchemaProperties", () => {
 	// would pass over nothing.
 	it("raises when the field descriptor is absent", () => {
 		expect(() => metaSchemaProperties({})).toThrow("$defs.fieldDescriptor.properties not found in meta-schema");
+	});
+});
+
+describe("metaSchemaVocabulary", () => {
+	it("reads the property names of every definition", () => {
+		const metaSchema = {
+			$defs: {
+				fieldDescriptor: { properties: { type: {}, deprecated: {} } },
+				deprecatedSpec: { properties: { since: {}, type: {} } },
+			},
+		};
+		expect(metaSchemaVocabulary(metaSchema)).toEqual(["type", "deprecated", "since"]);
+	});
+
+	// The same reason as the two readers above. An empty list would report that
+	// one version supersedes no spelling of the other, which is the answer that
+	// a caller reads as "nothing to correct".
+	it("raises when no definition holds properties", () => {
+		expect(() => metaSchemaVocabulary({ $defs: { fieldDescriptor: {} } })).toThrow(
+			"no $defs entry holds properties in meta-schema",
+		);
 	});
 });
 


### PR DESCRIPTION
The published prompt tells an author to declare the v2 meta-schema, then teaches 14 property names that the v2 vocabulary does not hold. `$defs.fieldDescriptor` sets `additionalProperties: false`, so each one is an error. A reader who obeys the prompt gets a schema that its own `$schema` rejects.

The property list moves to the canonical camelCase names, `pattern-exact` goes, and `uniqueItems`, `contentEncoding` and `contentMediaType` join it so the prompt covers the whole vocabulary.

A test holds every property that the prompt names to the v2 vocabulary, because correcting the prose alone leaves the next edit free to reintroduce a v1 spelling. It reads the names from the head of each bullet, so a pair such as `minimum` / `maximum` is read as two names.

The formatter realigned one table on the same page. That change is whitespace only.