### PR TITLE
docs: describe what sync-package-metadata actually synchronises

### DIFF
--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -722,4 +722,3 @@ Reference: https://m.canouil.dev/quarto-wizard/reference/schema-specification.ll
 ```
 
 :::
-```

--- a/docs/reference/schema-specification.qmd
+++ b/docs/reference/schema-specification.qmd
@@ -620,7 +620,7 @@ Example instances showing every supported property are also available:
 The prompt below can be used with an AI assistant to generate a `_schema.yml` for an existing extension.
 Copy the prompt, attach your extension's `_extension.yml` and Lua source files, and the assistant will produce a schema that matches your extension's actual behaviour.
 
-```{.markdown filename="Prompt for generating `\_schema.yml`"}
+```{.markdown filename="Prompt for generating _schema.yml"}
 Generate a `\_schema.yml` file for the attached Quarto extension.
 
 Read the attached `_extension.yml` to identify the extension name and

--- a/scripts/sync-package-metadata.mjs
+++ b/scripts/sync-package-metadata.mjs
@@ -2,14 +2,13 @@
 /**
  * Synchronises metadata fields from the root package.json to every workspace package.
  *
- * Fields synchronised: author, license, bugs, homepage, version, sponsor.
+ * SYNC_FIELDS below lists the fields that are copied as they are.
  * `repository` is synchronised as well, but not through SYNC_FIELDS, because
  * each package gets its own `directory` inside the copied value.
- * `version` is synchronised, so a workspace package is not independent: the
- * root version is written into every package. `packages/schema` therefore
- * reports the version of the extension by design, and anything that reasons
- * about a published package version has to know this.
- * Nothing is merged, because MERGE_ARRAY_FIELDS is empty.
+ * `version` is one of the copied fields, so a workspace package is not
+ * independent: the root version is written into every package.
+ * `packages/schema` therefore reports the version of the extension by design,
+ * and anything that reasons about a published package version has to know this.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
@@ -21,9 +20,6 @@ const rootDir = join(__dirname, "..");
 
 /** Fields to copy directly from root to packages */
 const SYNC_FIELDS = ["author", "license", "bugs", "homepage", "version", "sponsor"];
-
-/** Fields to merge (package values are preserved, root values added if missing) */
-const MERGE_ARRAY_FIELDS = [];
 
 function readJson(filePath) {
 	return JSON.parse(readFileSync(filePath, "utf-8"));
@@ -56,13 +52,6 @@ function syncRepository(rootRepo, pkgPath) {
 	};
 }
 
-// function mergeKeywords(rootKeywords, pkgKeywords) {
-// 	if (!rootKeywords && !pkgKeywords) return undefined;
-// 	const root = rootKeywords || [];
-// 	const pkg = pkgKeywords || [];
-// 	return [...new Set([...pkg, ...root])];
-// }
-
 function syncPackage(rootPkg, pkgDir) {
 	const pkgPath = join(pkgDir, "package.json");
 	const pkg = readJson(pkgPath);
@@ -88,12 +77,6 @@ function syncPackage(rootPkg, pkgDir) {
 			changed = true;
 		}
 	}
-
-	// const mergedKeywords = mergeKeywords(rootPkg.keywords, pkg.keywords);
-	// if (mergedKeywords && JSON.stringify(mergedKeywords) !== JSON.stringify(pkg.keywords)) {
-	// 	pkg.keywords = mergedKeywords;
-	// 	changed = true;
-	// }
 
 	if (changed) {
 		writeJson(pkgPath, pkg);

--- a/scripts/sync-package-metadata.mjs
+++ b/scripts/sync-package-metadata.mjs
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 /**
- * Synchronises metadata fields from root package.json to all workspace packages.
+ * Synchronises metadata fields from the root package.json to every workspace package.
  *
- * Fields synchronised: author, license, repository, bugs, homepage
- * Version is NOT synchronised as packages may have independent versioning.
- * Keywords are merged (package-specific keywords are preserved).
+ * Fields synchronised: author, license, bugs, homepage, version, sponsor.
+ * `repository` is synchronised as well, but not through SYNC_FIELDS, because
+ * each package gets its own `directory` inside the copied value.
+ * `version` is synchronised, so a workspace package is not independent: the
+ * root version is written into every package. `packages/schema` therefore
+ * reports the version of the extension by design, and anything that reasons
+ * about a published package version has to know this.
+ * Nothing is merged, because MERGE_ARRAY_FIELDS is empty.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";

--- a/scripts/sync-package-metadata.mjs
+++ b/scripts/sync-package-metadata.mjs
@@ -18,7 +18,6 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
 
-/** Fields to copy directly from root to packages */
 const SYNC_FIELDS = ["author", "license", "bugs", "homepage", "version", "sponsor"];
 
 function readJson(filePath) {
@@ -42,16 +41,6 @@ function getPackageDirs() {
 		});
 }
 
-function syncRepository(rootRepo, pkgPath) {
-	if (!rootRepo) return undefined;
-
-	const relativePath = pkgPath.replace(rootDir + "/", "");
-	return {
-		...rootRepo,
-		directory: relativePath,
-	};
-}
-
 function syncPackage(rootPkg, pkgDir) {
 	const pkgPath = join(pkgDir, "package.json");
 	const pkg = readJson(pkgPath);
@@ -71,7 +60,7 @@ function syncPackage(rootPkg, pkgDir) {
 	}
 
 	if (rootPkg.repository) {
-		const newRepo = syncRepository(rootPkg.repository, relativePath);
+		const newRepo = { ...rootPkg.repository, directory: relativePath };
 		if (JSON.stringify(newRepo) !== JSON.stringify(pkg.repository)) {
 			pkg.repository = newRepo;
 			changed = true;
@@ -104,8 +93,6 @@ function main() {
 	}
 
 	console.log(`\nDone. Updated ${updatedCount} of ${packageDirs.length} packages.`);
-
-	return updatedCount > 0 ? 0 : 0;
 }
 
 main();


### PR DESCRIPTION
The header comment of `scripts/sync-package-metadata.mjs` disagreed with the code below it, so a reader who trusted it got the behaviour of the script wrong.

- It omitted `version` and `sponsor`, which `SYNC_FIELDS` holds.
- It said that version is not synchronised because packages may have independent versions. The opposite is true: the root version is written into every workspace package.
- It said that keywords are merged. Nothing was merged.

The comment drifted because it repeated the field list in prose. It now points at `SYNC_FIELDS` instead, so there is no second copy to fall out of step, and it keeps only what the code cannot state: why `repository` takes its own path, and the consequence that `packages/schema` reports the version of the extension by design.

The dead code that the old comment described is removed as well: the empty `MERGE_ARRAY_FIELDS`, the commented-out `mergeKeywords` function and its commented-out call site. Three further pieces of dead scaffolding go with them. `syncRepository` guarded a condition that its only call site already checked and re-stripped a path that was already relative, so its one remaining line is inlined. The return of `main` was a ternary with two identical branches, and its value was discarded.

Nothing here changes behaviour. `npm run sync-metadata` writes no `package.json`, so every synchronised value, `repository.directory` included, is unchanged.

---

Two unrelated fence corrections in `docs/reference/schema-specification.qmd` travel with this branch.

The page ended with a stray closing fence after the `:::` that had nothing to open it.

The AI prompt block opened with backticks inside its info string, which CommonMark forbids on a backtick fence. The line therefore never opened a code block, the body parsed as ordinary Markdown, and the closing fence read as a new block with no language. Pandoc accepts both forms, so the code block itself renders as before, and the caption loses two literal backtick characters that the built site showed as stray punctuation.

`markdownlint` now reports no issue on the page.
