### PR TITLE
fix: resolve the GitHub default branch when a source has no release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
 - fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 15 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
-- fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`.
+- fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`. (#385)
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - fix: apply `dependentRequired` after aliases resolve in the Lua reference validator, so a dependent supplied under an alias is found. A trigger key whose value came from its own `default` no longer requires its dependents.
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
 - fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 15 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
+- fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`.
 
 ## 3.2.0 (2026-08-02)
 

--- a/packages/core/src/github/releases.ts
+++ b/packages/core/src/github/releases.ts
@@ -137,10 +137,7 @@ function getGitHubHeaders(auth?: AuthConfig): Record<string, string> {
  */
 function repoApiUrl(owner: string, repo: string, ...segments: string[]): string {
 	const base = `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
-	if (segments.length === 0) {
-		return base;
-	}
-	return `${base}/${segments.map(encodeURIComponent).join("/")}`;
+	return [base, ...segments.map(encodeURIComponent)].join("/");
 }
 
 /**

--- a/packages/core/src/github/releases.ts
+++ b/packages/core/src/github/releases.ts
@@ -67,6 +67,13 @@ interface RawRelease {
 }
 
 /**
+ * Raw repository response from GitHub API.
+ */
+interface RawRepository {
+	default_branch: string;
+}
+
+/**
  * Raw tag response from GitHub API.
  */
 interface RawTag {
@@ -129,8 +136,11 @@ function getGitHubHeaders(auth?: AuthConfig): Record<string, string> {
  * Build a GitHub API URL with encoded path segments.
  */
 function repoApiUrl(owner: string, repo: string, ...segments: string[]): string {
-	const encoded = segments.map(encodeURIComponent);
-	return `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encoded.join("/")}`;
+	const base = `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+	if (segments.length === 0) {
+		return base;
+	}
+	return `${base}/${segments.map(encodeURIComponent).join("/")}`;
 }
 
 /**
@@ -256,6 +266,42 @@ async function validateCommit(owner: string, repo: string, commit: string, optio
 }
 
 /**
+ * Fetch the default branch of a repository.
+ *
+ * This is used only when no release, no tag and no registry entry give a
+ * reference to install. A failed lookup returns `undefined`, so the caller keeps
+ * its own fallback. A SAML SSO error is rethrown, because the user must act on
+ * it.
+ *
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param options - GitHub options
+ * @returns Default branch name, or undefined when the lookup fails
+ */
+async function fetchDefaultBranch(
+	owner: string,
+	repo: string,
+	options: GitHubOptions = {},
+): Promise<string | undefined> {
+	const { auth, timeout, signal } = options;
+
+	try {
+		const raw = await fetchJson<RawRepository>(repoApiUrl(owner, repo), {
+			headers: getGitHubHeaders(auth),
+			timeout,
+			retries: 1,
+			signal,
+		});
+		return raw.default_branch || undefined;
+	} catch (error) {
+		if (error instanceof SamlSsoError) {
+			throw error;
+		}
+		return undefined;
+	}
+}
+
+/**
  * Fetch releases for a repository.
  *
  * @param owner - Repository owner
@@ -359,7 +405,7 @@ export async function resolveVersion(
 	version: VersionSpec,
 	options: ResolveVersionOptions = {},
 ): Promise<ResolvedVersion> {
-	const { defaultBranch = "main", latestCommit } = options;
+	const { defaultBranch, latestCommit } = options;
 
 	switch (version.type) {
 		case "latest": {
@@ -381,12 +427,14 @@ export async function resolveVersion(
 				};
 			}
 
-			// Fallback to default branch with commit tracking
+			// Fallback to default branch with commit tracking. The registry hint is
+			// preferred, then GitHub itself, because the branch is not always "main".
+			const branch = defaultBranch ?? (await fetchDefaultBranch(owner, repo, options)) ?? "main";
 			const commitSha = latestCommit?.substring(0, 7);
 			return {
 				tagName: commitSha ?? "HEAD",
-				zipballUrl: constructArchiveUrl(owner, repo, defaultBranch, "branch", "zip"),
-				tarballUrl: constructArchiveUrl(owner, repo, defaultBranch, "branch", "tarball"),
+				zipballUrl: constructArchiveUrl(owner, repo, branch, "branch", "zip"),
+				tarballUrl: constructArchiveUrl(owner, repo, branch, "branch", "tarball"),
 				commitSha,
 			};
 		}

--- a/packages/core/src/github/releases.ts
+++ b/packages/core/src/github/releases.ts
@@ -11,7 +11,14 @@ import type { AuthConfig } from "../types/auth.js";
 import type { VersionSpec } from "../types/extension.js";
 import { getAuthHeaders } from "../types/auth.js";
 import { USER_AGENT } from "../constants.js";
-import { AuthenticationError, NetworkError, RepositoryNotFoundError, SamlSsoError, VersionError } from "../errors.js";
+import {
+	AuthenticationError,
+	NetworkError,
+	RepositoryNotFoundError,
+	SamlSsoError,
+	VersionError,
+	isCancellationError,
+} from "../errors.js";
 import { fetchJson } from "../registry/http.js";
 
 const GITHUB_API_BASE = "https://api.github.com";
@@ -268,7 +275,8 @@ async function validateCommit(owner: string, repo: string, commit: string, optio
  * This is used only when no release, no tag and no registry entry give a
  * reference to install. A failed lookup returns `undefined`, so the caller keeps
  * its own fallback. A SAML SSO error is rethrown, because the user must act on
- * it.
+ * it, and a cancellation is rethrown, because the user asked the operation to
+ * stop.
  *
  * @param owner - Repository owner
  * @param repo - Repository name
@@ -291,7 +299,7 @@ async function fetchDefaultBranch(
 		});
 		return raw.default_branch || undefined;
 	} catch (error) {
-		if (error instanceof SamlSsoError) {
+		if (error instanceof SamlSsoError || isCancellationError(error)) {
 			throw error;
 		}
 		return undefined;

--- a/packages/core/tests/github-releases.test.ts
+++ b/packages/core/tests/github-releases.test.ts
@@ -79,7 +79,9 @@ function repoMetadataCalls(fetchJson: { mock: { calls: unknown[][] } }): unknown
 
 /**
  * Build a `fetchJson` implementation for the three endpoints `resolveVersion` reads.
- * An endpoint with no answer rejects, so a test states what it expects to be called.
+ * The releases and the tags endpoints answer with an empty list unless a test gives
+ * one. The repository endpoint rejects unless a test gives an answer, so a test that
+ * expects no default branch lookup fails when one is made.
  */
 function githubApiMock(endpoints: { releases?: unknown[]; tags?: unknown[]; repoMetadata?: () => Promise<unknown> }) {
 	const { releases = [], tags = [], repoMetadata } = endpoints;

--- a/packages/core/tests/github-releases.test.ts
+++ b/packages/core/tests/github-releases.test.ts
@@ -65,7 +65,7 @@ import {
 	resolveVersion,
 	constructArchiveUrl,
 } from "../src/github/releases.js";
-import { AuthenticationError, NetworkError, SamlSsoError } from "../src/errors.js";
+import { AuthenticationError, CancellationError, NetworkError, SamlSsoError } from "../src/errors.js";
 
 const REPO_METADATA_URL = "https://api.github.com/repos/owner/repo";
 
@@ -256,6 +256,13 @@ describe("resolveVersion", () => {
 		);
 
 		await expect(resolveVersion("owner", "repo", { type: "latest" })).rejects.toBeInstanceOf(SamlSsoError);
+	});
+
+	it("propagates a cancellation from the default branch lookup", async () => {
+		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
+		fetchJson.mockImplementation(githubApiMock({ repoMetadata: () => Promise.reject(new CancellationError()) }));
+
+		await expect(resolveVersion("owner", "repo", { type: "latest" })).rejects.toBeInstanceOf(CancellationError);
 	});
 
 	it("does not look up the default branch when a release exists", async () => {

--- a/packages/core/tests/github-releases.test.ts
+++ b/packages/core/tests/github-releases.test.ts
@@ -77,6 +77,20 @@ function repoMetadataCalls(fetchJson: { mock: { calls: unknown[][] } }): unknown
 	return fetchJson.mock.calls.filter((call) => typeof call[0] === "string" && isRepoMetadataUrl(call[0]));
 }
 
+/**
+ * Build a `fetchJson` implementation for the three endpoints `resolveVersion` reads.
+ * An endpoint with no answer rejects, so a test states what it expects to be called.
+ */
+function githubApiMock(endpoints: { releases?: unknown[]; tags?: unknown[]; repoMetadata?: () => Promise<unknown> }) {
+	const { releases = [], tags = [], repoMetadata } = endpoints;
+	return (url: string) => {
+		if (url.includes("/releases")) return Promise.resolve(releases);
+		if (url.includes("/tags")) return Promise.resolve(tags);
+		if (repoMetadata && isRepoMetadataUrl(url)) return repoMetadata();
+		return Promise.reject(new Error("Unknown URL"));
+	};
+}
+
 describe("handleGitHubError SAML pass-through", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -191,11 +205,7 @@ describe("resolveVersion", () => {
 
 	it("uses custom default branch when no releases/tags", async () => {
 		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
-		fetchJson.mockImplementation((url: string) => {
-			if (url.includes("/releases")) return Promise.resolve([]);
-			if (url.includes("/tags")) return Promise.resolve([]);
-			return Promise.reject(new Error("Unknown URL"));
-		});
+		fetchJson.mockImplementation(githubApiMock({}));
 
 		const result = await resolveVersion(
 			"owner",
@@ -212,12 +222,7 @@ describe("resolveVersion", () => {
 
 	it("reads the default branch from GitHub when no releases, tags or registry hint exist", async () => {
 		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
-		fetchJson.mockImplementation((url: string) => {
-			if (url.includes("/releases")) return Promise.resolve([]);
-			if (url.includes("/tags")) return Promise.resolve([]);
-			if (isRepoMetadataUrl(url)) return Promise.resolve({ default_branch: "master" });
-			return Promise.reject(new Error("Unknown URL"));
-		});
+		fetchJson.mockImplementation(githubApiMock({ repoMetadata: () => Promise.resolve({ default_branch: "master" }) }));
 
 		const result = await resolveVersion("owner", "repo", { type: "latest" });
 
@@ -228,14 +233,11 @@ describe("resolveVersion", () => {
 
 	it("falls back to main when the default branch lookup fails", async () => {
 		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
-		fetchJson.mockImplementation((url: string) => {
-			if (url.includes("/releases")) return Promise.resolve([]);
-			if (url.includes("/tags")) return Promise.resolve([]);
-			if (isRepoMetadataUrl(url)) {
-				return Promise.reject(new NetworkError("HTTP 403: rate limit exceeded", { statusCode: 403 }));
-			}
-			return Promise.reject(new Error("Unknown URL"));
-		});
+		fetchJson.mockImplementation(
+			githubApiMock({
+				repoMetadata: () => Promise.reject(new NetworkError("HTTP 403: rate limit exceeded", { statusCode: 403 })),
+			}),
+		);
 
 		const result = await resolveVersion("owner", "repo", { type: "latest" });
 
@@ -246,24 +248,19 @@ describe("resolveVersion", () => {
 	it("propagates a SAML SSO error from the default branch lookup", async () => {
 		const samlUrl = "https://github.com/orgs/myorg/sso?authorization_request=abc";
 		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
-		fetchJson.mockImplementation((url: string) => {
-			if (url.includes("/releases")) return Promise.resolve([]);
-			if (url.includes("/tags")) return Promise.resolve([]);
-			if (isRepoMetadataUrl(url)) {
-				return Promise.reject(new SamlSsoError("HTTP 403: SAML SSO enforcement", { authorizationUrl: samlUrl }));
-			}
-			return Promise.reject(new Error("Unknown URL"));
-		});
+		fetchJson.mockImplementation(
+			githubApiMock({
+				repoMetadata: () =>
+					Promise.reject(new SamlSsoError("HTTP 403: SAML SSO enforcement", { authorizationUrl: samlUrl })),
+			}),
+		);
 
 		await expect(resolveVersion("owner", "repo", { type: "latest" })).rejects.toBeInstanceOf(SamlSsoError);
 	});
 
 	it("does not look up the default branch when a release exists", async () => {
 		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
-		fetchJson.mockImplementation((url: string) => {
-			if (url.includes("/releases")) return Promise.resolve(mockReleases);
-			return Promise.reject(new Error("Unknown URL"));
-		});
+		fetchJson.mockImplementation(githubApiMock({ releases: mockReleases }));
 
 		const result = await resolveVersion("owner", "repo", { type: "latest" });
 

--- a/packages/core/tests/github-releases.test.ts
+++ b/packages/core/tests/github-releases.test.ts
@@ -65,7 +65,17 @@ import {
 	resolveVersion,
 	constructArchiveUrl,
 } from "../src/github/releases.js";
-import { AuthenticationError, SamlSsoError } from "../src/errors.js";
+import { AuthenticationError, NetworkError, SamlSsoError } from "../src/errors.js";
+
+const REPO_METADATA_URL = "https://api.github.com/repos/owner/repo";
+
+function isRepoMetadataUrl(url: string): boolean {
+	return url === REPO_METADATA_URL;
+}
+
+function repoMetadataCalls(fetchJson: { mock: { calls: unknown[][] } }): unknown[][] {
+	return fetchJson.mock.calls.filter((call) => typeof call[0] === "string" && isRepoMetadataUrl(call[0]));
+}
 
 describe("handleGitHubError SAML pass-through", () => {
 	beforeEach(() => {
@@ -180,7 +190,8 @@ describe("resolveVersion", () => {
 	});
 
 	it("uses custom default branch when no releases/tags", async () => {
-		vi.mocked(await import("../src/registry/http.js")).fetchJson.mockImplementation((url: string) => {
+		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
+		fetchJson.mockImplementation((url: string) => {
 			if (url.includes("/releases")) return Promise.resolve([]);
 			if (url.includes("/tags")) return Promise.resolve([]);
 			return Promise.reject(new Error("Unknown URL"));
@@ -196,6 +207,68 @@ describe("resolveVersion", () => {
 		expect(result.tagName).toBe("abc1234");
 		expect(result.zipballUrl).toContain("refs/heads/develop");
 		expect(result.commitSha).toBe("abc1234");
+		expect(repoMetadataCalls(fetchJson)).toHaveLength(0);
+	});
+
+	it("reads the default branch from GitHub when no releases, tags or registry hint exist", async () => {
+		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
+		fetchJson.mockImplementation((url: string) => {
+			if (url.includes("/releases")) return Promise.resolve([]);
+			if (url.includes("/tags")) return Promise.resolve([]);
+			if (isRepoMetadataUrl(url)) return Promise.resolve({ default_branch: "master" });
+			return Promise.reject(new Error("Unknown URL"));
+		});
+
+		const result = await resolveVersion("owner", "repo", { type: "latest" });
+
+		expect(result.zipballUrl).toBe("https://github.com/owner/repo/archive/refs/heads/master.zip");
+		expect(result.tarballUrl).toBe("https://github.com/owner/repo/archive/refs/heads/master.tar.gz");
+		expect(repoMetadataCalls(fetchJson)).toHaveLength(1);
+	});
+
+	it("falls back to main when the default branch lookup fails", async () => {
+		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
+		fetchJson.mockImplementation((url: string) => {
+			if (url.includes("/releases")) return Promise.resolve([]);
+			if (url.includes("/tags")) return Promise.resolve([]);
+			if (isRepoMetadataUrl(url)) {
+				return Promise.reject(new NetworkError("HTTP 403: rate limit exceeded", { statusCode: 403 }));
+			}
+			return Promise.reject(new Error("Unknown URL"));
+		});
+
+		const result = await resolveVersion("owner", "repo", { type: "latest" });
+
+		expect(result.tagName).toBe("HEAD");
+		expect(result.zipballUrl).toBe("https://github.com/owner/repo/archive/refs/heads/main.zip");
+	});
+
+	it("propagates a SAML SSO error from the default branch lookup", async () => {
+		const samlUrl = "https://github.com/orgs/myorg/sso?authorization_request=abc";
+		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
+		fetchJson.mockImplementation((url: string) => {
+			if (url.includes("/releases")) return Promise.resolve([]);
+			if (url.includes("/tags")) return Promise.resolve([]);
+			if (isRepoMetadataUrl(url)) {
+				return Promise.reject(new SamlSsoError("HTTP 403: SAML SSO enforcement", { authorizationUrl: samlUrl }));
+			}
+			return Promise.reject(new Error("Unknown URL"));
+		});
+
+		await expect(resolveVersion("owner", "repo", { type: "latest" })).rejects.toBeInstanceOf(SamlSsoError);
+	});
+
+	it("does not look up the default branch when a release exists", async () => {
+		const { fetchJson } = vi.mocked(await import("../src/registry/http.js"));
+		fetchJson.mockImplementation((url: string) => {
+			if (url.includes("/releases")) return Promise.resolve(mockReleases);
+			return Promise.reject(new Error("Unknown URL"));
+		});
+
+		const result = await resolveVersion("owner", "repo", { type: "latest" });
+
+		expect(result.tagName).toBe("v2.0.0");
+		expect(repoMetadataCalls(fetchJson)).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
`resolveVersion` resolves a `latest` source in three steps: releases first, then tags, then an archive of the default branch. That last step used a branch name that came from the registry entry, and fell back to `main` when the registry had nothing to say. A repository with no release, no tag and no registry entry, whose default branch is `master`, therefore produced an archive URL that returned 404.

The branch name now comes from GitHub itself on that step. The registry hint still wins when it exists, so a source with a release or a tag costs no extra request, and `main` stays the last resort when the lookup fails.

- `fetchDefaultBranch()` reads `default_branch` from `GET /repos/{owner}/{repo}`. It returns `undefined` on a failed lookup, and rethrows a SAML SSO error and a cancellation.
- `repoApiUrl()` accepts an empty segment list, which the repository endpoint needs.
- Both install and brand reach this through `downloadGitHubArchive`, so neither needed a change.

Six tests cover hint precedence, a successful lookup, the fallback after a failure, SAML and cancellation propagation, and the absence of a lookup when a release exists.

Reported upstream as quarto-dev/quarto-cli#14821 for the Quarto CLI, which has the same assumption.