### PR TITLE
ci: gate the build on changed paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           # A rename carries the old path in previous_filename. Without it, a
           # file renamed out of src/ reports only its new path, and the build
           # would skip although its inputs lost a file.
-          changed=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+          changed=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             --jq '.[] | .filename, (.previous_filename // empty)')
           echo "Changed files:"
           echo "${changed}"
@@ -81,6 +81,7 @@ jobs:
           inputs+='|webpack\.config\.js$'                 # webpack
           inputs+='|eslint\.config\.mjs$'                 # lint
           inputs+='|\.prettierrc\.json$|\.prettierignore$' # format:check
+          inputs+='|\.vscode-test\.mjs$'                  # npm test
           inputs+='|\.vscodeignore$'                      # vsce package
           inputs+='|\.github/workflows/build\.yml$)'      # this workflow
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,18 +34,17 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Compare the pull request against its base
+      # No checkout. The file list comes from the API, so this job does not
+      # clone the repository at all, where a `git diff` between the base and
+      # the head would need the full history.
+      - name: List the files the pull request touches
         id: filter
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # A manual run has no pull request to compare against, so it builds.
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
@@ -53,7 +52,7 @@ jobs:
             exit 0
           fi
 
-          changed=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          changed=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
           echo "Changed files:"
           echo "${changed}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,15 +70,24 @@ jobs:
           echo "Changed files:"
           echo "${changed}"
 
-          # The inputs of the build. Fixtures are swept by the Lua job and are
+          # The inputs of the build: the sources, and every file that a step of
+          # the build job reads. Fixtures are swept by the Lua job and are
           # edited through pull requests. The vendored schemas under docs/ are
           # not listed: a bot updates those straight on the default branch,
           # where no pull request event fires at all.
-          #
+          inputs='^(src/|packages/|test-fixtures/.+/_schema\.yml$'
+          inputs+='|package\.json$|package-lock\.json$'   # npm ci
+          inputs+='|tsconfig\.json$'                      # test-compile
+          inputs+='|webpack\.config\.js$'                 # webpack
+          inputs+='|eslint\.config\.mjs$'                 # lint
+          inputs+='|\.prettierrc\.json$|\.prettierignore$' # format:check
+          inputs+='|\.vscodeignore$'                      # vsce package
+          inputs+='|\.github/workflows/build\.yml$)'      # this workflow
+
           # A here-string and not a pipe. The runner sets pipefail, and grep -q
           # exits at the first match, so a list past the pipe buffer would send
           # SIGPIPE to the writer and the whole condition would read as false.
-          if grep -qE '^(src/|packages/|package\.json$|package-lock\.json$|test-fixtures/.+/_schema\.yml$)' <<< "${changed}"; then
+          if grep -qE "${inputs}" <<< "${changed}"; then
             echo "code=true" >> "${GITHUB_OUTPUT}"
           else
             echo "code=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,21 @@ jobs:
             exit 0
           fi
 
-          changed=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          # The files endpoint stops at 3000 entries, so a larger pull request
+          # gives a short list. Build rather than skip in that case: a wrong
+          # skip merges an untested change, a wrong build only costs time.
+          total=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files')
+          if [[ "${total}" -gt 3000 ]]; then
+            echo "${total} changed files exceeds the API limit, so the build runs."
+            echo "code=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # A rename carries the old path in previous_filename. Without it, a
+          # file renamed out of src/ reports only its new path, and the build
+          # would skip although its inputs lost a file.
+          changed=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | .filename, (.previous_filename // empty)')
           echo "Changed files:"
           echo "${changed}"
 
@@ -60,7 +74,11 @@ jobs:
           # edited through pull requests. The vendored schemas under docs/ are
           # not listed: a bot updates those straight on the default branch,
           # where no pull request event fires at all.
-          if echo "${changed}" | grep -qE '^(src/|packages/|package\.json$|package-lock\.json$|test-fixtures/.+/_schema\.yml$)'; then
+          #
+          # A here-string and not a pipe. The runner sets pipefail, and grep -q
+          # exits at the first match, so a list past the pipe buffer would send
+          # SIGPIPE to the writer and the whole condition would read as false.
+          if grep -qE '^(src/|packages/|package\.json$|package-lock\.json$|test-fixtures/.+/_schema\.yml$)' <<< "${changed}"; then
             echo "code=true" >> "${GITHUB_OUTPUT}"
           else
             echo "code=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,10 @@ on:
       - ready_for_review
     branches:
       - main
-    paths:
-      - "src/**"
-      - "packages/**"
-      - "package.json"
-      - "package-lock.json"
-      # Swept by the Lua conformance job, and edited through pull requests.
-      # The vendored schemas under docs/ are not listed: a bot updates those
-      # straight on the default branch, where a pull request filter cannot fire.
-      - "test-fixtures/**/_schema.yml"
+    # No paths filter. The ruleset requires the summary job, and a required
+    # check that never starts blocks a pull request for ever. The workflow
+    # therefore always runs, and the changes job below decides whether the
+    # expensive jobs have anything to do.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.action }}-${{ github.ref }}-${{ github.event_name }}
@@ -31,8 +26,50 @@ concurrency:
 permissions: read-all
 
 jobs:
-  build:
+  changes:
     if: github.event.pull_request.draft == false
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compare the pull request against its base
+        id: filter
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # A manual run has no pull request to compare against, so it builds.
+          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            echo "code=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          echo "Changed files:"
+          echo "${changed}"
+
+          # The inputs of the build. Fixtures are swept by the Lua job and are
+          # edited through pull requests. The vendored schemas under docs/ are
+          # not listed: a bot updates those straight on the default branch,
+          # where no pull request event fires at all.
+          if echo "${changed}" | grep -qE '^(src/|packages/|package\.json$|package-lock\.json$|test-fixtures/.+/_schema\.yml$)'; then
+            echo "code=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "code=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -175,7 +212,8 @@ jobs:
           retention-days: 1
 
   lua:
-    if: github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     name: Lua reference validator
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -216,6 +254,7 @@ jobs:
   summary:
     if: always() && github.event.pull_request.draft == false
     needs:
+      - changes
       - build
       - lua
     timeout-minutes: 10
@@ -291,16 +330,24 @@ jobs:
           # The verdict comes from the job results, which are reported whatever
           # a job managed to upload. A matrix cell killed by its timeout leaves
           # no summary file, so counting files would call that run a success.
+          # A skipped job is not a failure: this job is the required check, so
+          # a pull request that changes no build input has nothing to run and
+          # must still report a verdict.
           failed_names=""
-          for job in "build:${{ needs.build.result }}" "lua:${{ needs.lua.result }}"; do
-            if [[ "${job#*:}" != "success" ]]; then
-              failed_names="${failed_names} ${job}"
-            fi
+          for job in "changes:${{ needs.changes.result }}" "build:${{ needs.build.result }}" "lua:${{ needs.lua.result }}"; do
+            case "${job#*:}" in
+              "success" | "skipped") ;;
+              *) failed_names="${failed_names} ${job}" ;;
+            esac
           done
 
           if [[ -z "${failed_names}" ]]; then
             echo "## 🎉 Overall Result: SUCCESS" >> ${GITHUB_STEP_SUMMARY}
-            echo "Every job completed successfully." >> ${GITHUB_STEP_SUMMARY}
+            if [[ "${{ needs.changes.outputs.code }}" == "true" ]]; then
+              echo "Every job completed successfully." >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "This pull request changes no build input, so the build matrix and the Lua job did not run." >> "${GITHUB_STEP_SUMMARY}"
+            fi
           else
             echo "## ⚠️ Overall Result: FAILURE" >> ${GITHUB_STEP_SUMMARY}
             echo "Not successful:${failed_names}. Check the individual job logs for details." >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
The ruleset requires the three `build` matrix checks, and `build.yml` carried a `paths` filter listing only `src`, `packages`, `package.json`, `package-lock.json` and the swept fixtures. A pull request that touched only documentation, scripts or a workflow therefore never started those checks, and a required check that never starts blocks a pull request for ever. That is why #383 and #384 had to be merged with administrator rights.

The workflow now always runs on a pull request. A `changes` job reads the file list from the pull request files endpoint and decides whether any build input moved; the build matrix and the Lua job run only when one did. The `summary` job already aggregated both, and now treats a skipped job as no failure, so it reports a verdict on every pull request and can serve as the single required check.

The gate covers the sources and every file a build step reads, which the old filter did not: `tsconfig.json`, `webpack.config.js`, `eslint.config.mjs`, the Prettier files, `.vscode-test.mjs`, `.vscodeignore` and this workflow. It reads renames through `previous_filename`, so a file moved out of `src` still counts, and it builds rather than skips when a pull request exceeds the endpoint's 3000 file cap.

Switching the required check from the three matrix contexts to `summary` is a repository setting, not part of this diff.