### PR TITLE
feat: parse Typst blocks, sizes and errors

### DIFF
--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { findTypstBlocks, typstBlockAt, precedingRawBlocks } from "../../utils/typst/typstBlocks";
+import { findTypstBlocks, typstBlockAt, precedingRawBlocks, hasLateOptionLine } from "../../utils/typst/typstBlocks";
 
 /** A minimal document holding one fence with the given info string. */
 function fence(info: string): string {
@@ -169,6 +169,35 @@ suite("Typst Blocks Test Suite", () => {
 			const block = findTypstBlocks("```{=typst}\n//| dpi: 300\n#a\n```\n")[0];
 			assert.deepStrictEqual(block.options, {});
 			assert.strictEqual(block.code, "//| dpi: 300\n#a\n");
+		});
+	});
+
+	suite("hasLateOptionLine", () => {
+		test("Should report a cell whose option line comes after the code", () => {
+			const block = findTypstBlocks("```{typst}\n#a\n//| dpi: 300\n```\n")[0];
+			assert.strictEqual(hasLateOptionLine(block), true);
+		});
+
+		test("Should not report a cell whose options are all in the leading run", () => {
+			const block = findTypstBlocks("```{typst}\n//| dpi: 300\n#a\n```\n")[0];
+			assert.strictEqual(hasLateOptionLine(block), false);
+		});
+
+		test("Should not report a plain or a raw block", () => {
+			// A comment-pipe line is an ordinary Typst comment in both, so there is
+			// nothing to warn about.
+			const text = "```typst\n#a\n//| dpi: 300\n```\n\n```{=typst}\n#b\n//| dpi: 300\n```\n";
+			for (const block of findTypstBlocks(text)) {
+				assert.strictEqual(hasLateOptionLine(block), false, block.kind);
+			}
+		});
+
+		test("Should not report a late line written without a space after the colon", () => {
+			// The Lua guard at `:110` ends with a colon and one whitespace, while
+			// the key pattern at `:89` does not, so upstream passes over this line
+			// in silence. The port keeps that difference.
+			const block = findTypstBlocks("```{typst}\n#a\n//| dpi:300\n```\n")[0];
+			assert.strictEqual(hasLateOptionLine(block), false);
 		});
 	});
 

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -1,0 +1,222 @@
+import * as assert from "assert";
+import { findTypstBlocks, typstBlockAt, precedingRawBlocks } from "../../utils/typst/typstBlocks";
+
+/** A minimal document holding one fence with the given info string. */
+function fence(info: string): string {
+	return "```" + info + "\nx\n```\n";
+}
+
+suite("Typst Blocks Test Suite", () => {
+	suite("findTypstBlocks classification", () => {
+		// The three kinds behave differently and must never be conflated, so
+		// every accepted spelling and every rejected one has its own case.
+		const cases: [string, string | undefined][] = [
+			["typst", "plain"],
+			["{.typst}", "plain"],
+			['{.typst filename="a.typ"}', "plain"],
+			["{=typst}", "raw"],
+			["{typst}", "cell"],
+			["{{typst}}", undefined],
+			["typ", undefined],
+			["python", undefined],
+		];
+
+		for (const [info, kind] of cases) {
+			test(`Should classify \`${info}\` as ${kind ?? "excluded"}`, () => {
+				const found = findTypstBlocks(fence(info));
+				assert.strictEqual(found[0]?.kind, kind);
+			});
+		}
+	});
+
+	// Each case below is one the module inherits from `getCodeBlockRanges`, and
+	// one a second fence scanner would have had to earn again.
+	suite("findTypstBlocks body derivation", () => {
+		test("Should read a body written with CRLF line endings", () => {
+			const found = findTypstBlocks("```typst\r\n#let a = 1\r\n#a\r\n```\r\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "#let a = 1\r\n#a\r\n");
+		});
+
+		test("Should remove the fence indent from every body line", () => {
+			const found = findTypstBlocks("- item\n\n  ```typst\n  #let a = 1\n  #a\n  ```\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].indent, 2);
+			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
+		});
+
+		test("Should read an unclosed block to the end of the text", () => {
+			const found = findTypstBlocks("```typst\n#let a = 1\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "#let a = 1\n");
+		});
+
+		test("Should read an unclosed block whose fence is the last line", () => {
+			const found = findTypstBlocks("text\n\n```typst");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].kind, "plain");
+			assert.strictEqual(found[0].body, "");
+		});
+
+		test("Should read a fence that starts at offset zero", () => {
+			const found = findTypstBlocks("```typst\n#a\n```\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].fenceLine, 0);
+			assert.strictEqual(found[0].body, "#a\n");
+		});
+
+		test("Should ignore a Typst fence nested in a demonstration block", () => {
+			const text = "````markdown\n```{typst}\n#a\n```\n````\n";
+			assert.deepStrictEqual(findTypstBlocks(text), []);
+		});
+
+		test("Should ignore a fence inside the YAML front matter", () => {
+			const text = '---\ntitle: "```typst"\n---\n\n```typst\n#a\n```\n';
+			const found = findTypstBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "#a\n");
+		});
+
+		test("Should report the fence line of each block", () => {
+			const found = findTypstBlocks("intro\n\n```typst\n#a\n```\n\n```{=typst}\n#b\n```\n");
+			assert.deepStrictEqual(
+				found.map((block) => [block.kind, block.fenceLine]),
+				[
+					["plain", 2],
+					["raw", 6],
+				],
+			);
+		});
+	});
+
+	// A bug-compatible port of `_modules/code-cell.lua:84-122`. Each quirk is a
+	// quirk of that pattern, so each test names the behaviour and cites the line
+	// it ports. An upstream fix to any of them is a breaking change here.
+	suite("findTypstBlocks comment-pipe options", () => {
+		/** One cell block wrapping the given body. */
+		function cell(body: string): string {
+			return "```{typst}\n" + body + "\n```\n";
+		}
+
+		test("Should read a hyphenated key, which the key pattern allows (:89)", () => {
+			assert.deepStrictEqual(findTypstBlocks(cell("//| fig-width: 3\n#a"))[0].options, { "fig-width": "3" });
+		});
+
+		test("Should end the run at an underscore key, which the key pattern rejects (:89)", () => {
+			const block = findTypstBlocks(cell("//| my_key: v\n//| dpi: 300\n#a"))[0];
+			assert.deepStrictEqual(block.options, {});
+			assert.strictEqual(block.code, "//| my_key: v\n//| dpi: 300\n#a\n");
+		});
+
+		test("Should end the run at an empty value, which needs one character (:89)", () => {
+			const block = findTypstBlocks(cell("//| dpi:\n//| width: 3\n#a"))[0];
+			assert.deepStrictEqual(block.options, {});
+		});
+
+		test("Should read an empty value when a space follows the colon (:89)", () => {
+			// The pattern backtracks, so the trailing space alone decides whether
+			// the line parses. Verified against the Lua pattern itself.
+			assert.deepStrictEqual(findTypstBlocks(cell("//| dpi: \n#a"))[0].options, { dpi: "" });
+		});
+
+		test("Should count only the leading run and keep a later option as code (:105-118)", () => {
+			const block = findTypstBlocks(cell("//| dpi: 300\n#a\n//| width: 3"))[0];
+			assert.deepStrictEqual(block.options, { dpi: "300" });
+			assert.strictEqual(block.code, "#a\n//| width: 3\n");
+		});
+
+		test("Should read true and false as booleans (:95-98)", () => {
+			assert.deepStrictEqual(findTypstBlocks(cell("//| a: true\n//| b: false\n#a"))[0].options, {
+				a: true,
+				b: false,
+			});
+		});
+
+		test("Should strip one layer of matching quotes, either style (:100-101)", () => {
+			assert.deepStrictEqual(findTypstBlocks(cell("//| a: \"q\"\n//| b: 'q'\n#a"))[0].options, { a: "q", b: "q" });
+		});
+
+		test("Should keep every other value as a trimmed string (:102)", () => {
+			assert.deepStrictEqual(findTypstBlocks(cell("//| dpi: 300\n//| k:   spaced   \n#a"))[0].options, {
+				dpi: "300",
+				k: "spaced",
+			});
+		});
+
+		test("Should allow whitespace around the prefix (:89)", () => {
+			assert.deepStrictEqual(findTypstBlocks(cell("  //| a: 1\n//|b: 2\n#a"))[0].options, { a: "1", b: "2" });
+		});
+
+		test("Should read every option of a block written with CRLF", () => {
+			// A deliberate deviation. Lua splits on `[^\r\n]*`, which yields an
+			// empty line between each pair on CRLF, so the run would end after the
+			// first option. That is unreachable in a render, because Pandoc does
+			// not recognise a fenced block in a CRLF document at all, so matching
+			// it here would only break the preview of a file an author can write.
+			assert.deepStrictEqual(findTypstBlocks("```{typst}\r\n//| a: 1\r\n//| b: 2\r\n#x\r\n```\r\n")[0].options, {
+				a: "1",
+				b: "2",
+			});
+		});
+
+		test("Should parse no options for a plain block and keep the lines verbatim", () => {
+			const block = findTypstBlocks("```typst\n//| dpi: 300\n#a\n```\n")[0];
+			assert.deepStrictEqual(block.options, {});
+			assert.strictEqual(block.code, "//| dpi: 300\n#a\n");
+		});
+
+		test("Should parse no options for a raw block and keep the lines verbatim", () => {
+			const block = findTypstBlocks("```{=typst}\n//| dpi: 300\n#a\n```\n")[0];
+			assert.deepStrictEqual(block.options, {});
+			assert.strictEqual(block.code, "//| dpi: 300\n#a\n");
+		});
+	});
+
+	suite("typstBlockAt", () => {
+		const text = "intro\n\n```typst\n#a\n```\n\ntext\n\n```{=typst}\n#b\n```\n";
+
+		test("Should find the block holding an offset inside a body", () => {
+			assert.strictEqual(typstBlockAt(text, text.indexOf("#a"))?.kind, "plain");
+			assert.strictEqual(typstBlockAt(text, text.indexOf("#b"))?.kind, "raw");
+		});
+
+		test("Should find the block when the cursor sits on its opening fence", () => {
+			// A reader who puts the cursor on the fence means that block, and the
+			// body range starts after the fence line, so the fence needs its own case.
+			assert.strictEqual(typstBlockAt(text, text.indexOf("```typst"))?.kind, "plain");
+		});
+
+		test("Should find nothing outside every block", () => {
+			assert.strictEqual(typstBlockAt(text, 0), undefined);
+			assert.strictEqual(typstBlockAt(text, text.indexOf("text")), undefined);
+		});
+	});
+
+	suite("precedingRawBlocks", () => {
+		test("Should return every earlier raw block in document order", () => {
+			const text = "```{=typst}\n#let a = 1\n```\n\n```{=typst}\n#let b = 2\n```\n\n```{=typst}\n#a\n```\n";
+			const blocks = findTypstBlocks(text);
+			assert.deepStrictEqual(
+				precedingRawBlocks(blocks, blocks[2]).map((block) => block.code),
+				["#let a = 1\n", "#let b = 2\n"],
+			);
+		});
+
+		test("Should exclude a cell and a plain block sitting between raw blocks", () => {
+			// Only a raw block reaches the Typst output, so only a raw block can
+			// put a binding in scope for a later one.
+			const text = "```{=typst}\n#let a = 1\n```\n\n```{typst}\n#x\n```\n\n```typst\n#y\n```\n\n```{=typst}\n#a\n```\n";
+			const blocks = findTypstBlocks(text);
+			const target = blocks[blocks.length - 1];
+			assert.deepStrictEqual(
+				precedingRawBlocks(blocks, target).map((block) => block.code),
+				["#let a = 1\n"],
+			);
+		});
+
+		test("Should return nothing when the target is the first raw block", () => {
+			const blocks = findTypstBlocks("```{=typst}\n#a\n```\n");
+			assert.deepStrictEqual(precedingRawBlocks(blocks, blocks[0]), []);
+		});
+	});
+});

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -77,6 +77,26 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(found[0].body, "#a\n");
 		});
 
+		test("Should find a block below a fence line inside the front matter", () => {
+			// A block scalar can hold a line that looks like a fence. Scanning the
+			// whole document opens a phantom block there, and because that block
+			// only closes on a bare fence line it swallows the opening fence of the
+			// real block below, which then goes unreported.
+			const text = "---\ndescription: |\n  text\n```\n---\n\n```typst\n#a\n```\n";
+			const found = findTypstBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].kind, "plain");
+			assert.strictEqual(found[0].body, "#a\n");
+		});
+
+		test("Should report offsets and line numbers past the front matter", () => {
+			const text = "---\ntitle: t\n---\n\n```typst\n#a\n```\n";
+			const found = findTypstBlocks(text);
+			assert.strictEqual(found[0].fenceLine, 4);
+			assert.strictEqual(text.slice(found[0].fenceStart, found[0].fenceStart + 8), "```typst");
+			assert.strictEqual(text.slice(found[0].bodyStart, found[0].bodyEnd), "#a\n```");
+		});
+
 		test("Should report the fence line of each block", () => {
 			const found = findTypstBlocks("intro\n\n```typst\n#a\n```\n\n```{=typst}\n#b\n```\n");
 			assert.deepStrictEqual(

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -97,6 +97,22 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(text.slice(found[0].bodyStart, found[0].bodyEnd), "#a\n```");
 		});
 
+		test("Should read a tilde fence and keep a backtick line in its body", () => {
+			// A tilde block closes only on tildes, so a backtick line inside it is
+			// content. The bare-backtick rule does not apply to a tilde fence either.
+			const found = findTypstBlocks("~~~typst\n#a\n```\n#b\n~~~\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].kind, "plain");
+			assert.strictEqual(found[0].body, "#a\n```\n#b\n");
+		});
+
+		test("Should keep the line endings of a CRLF cell in its code", () => {
+			// `body` and `code` describe the same text, so one must not be
+			// normalised while the other is not.
+			const block = findTypstBlocks("```{typst}\r\n//| a: 1\r\n#x\r\n#y\r\n```\r\n")[0];
+			assert.strictEqual(block.code, "#x\r\n#y\r\n");
+		});
+
 		test("Should report the fence line of each block", () => {
 			const found = findTypstBlocks("intro\n\n```typst\n#a\n```\n\n```{=typst}\n#b\n```\n");
 			assert.deepStrictEqual(

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -1,0 +1,73 @@
+import * as assert from "assert";
+import { parseTypstStderr } from "../../utils/typst/typstDiagnostics";
+
+// Both samples below are the real output of
+// `typst compile --format svg - -`, captured from the binary that ships inside
+// Quarto. The message is on the first line and the position on the second, so
+// a reader that looks only for `<stdin>:line:column` loses every message.
+const ONE_ERROR = ["error: expected pattern", "  ┌─ <stdin>:2:4", "  │", "2 │ #let", "  │     ^", ""].join("\n");
+
+const TWO_ERRORS = [
+	"error: expected expression",
+	"  ┌─ <stdin>:1:8",
+	"  │",
+	"1 │ #let a = ",
+	"  │         ^",
+	"",
+	"error: unclosed delimiter",
+	"  ┌─ <stdin>:3:2",
+	"  │",
+	"3 │ #c(",
+	"  │   ^",
+	"",
+].join("\n");
+
+suite("Typst Diagnostics Test Suite", () => {
+	test("Should read the message and the position of one error", () => {
+		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 0), [
+			{ line: 1, column: 4, message: "expected pattern", severity: "error" },
+		]);
+	});
+
+	test("Should read every diagnostic of a run", () => {
+		assert.deepStrictEqual(parseTypstStderr(TWO_ERRORS, 0), [
+			{ line: 0, column: 8, message: "expected expression", severity: "error" },
+			{ line: 2, column: 2, message: "unclosed delimiter", severity: "error" },
+		]);
+	});
+
+	test("Should subtract the injected lines so a position maps to the document", () => {
+		// The compiled source carries a header the author never wrote, so the
+		// reported line is ahead of the block by exactly that many lines.
+		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 2), [
+			{ line: 0, column: 4, message: "expected pattern", severity: "error" },
+		]);
+	});
+
+	test("Should never report a negative line", () => {
+		// An error inside the injected header itself maps above the block, and a
+		// negative line is not a position any editor can take.
+		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 10), [
+			{ line: 0, column: 4, message: "expected pattern", severity: "error" },
+		]);
+	});
+
+	test("Should read a warning as well as an error", () => {
+		const stderr = ["warning: unnecessary import", "  ┌─ <stdin>:1:1", "  │", "1 │ #import", ""].join("\n");
+		assert.deepStrictEqual(parseTypstStderr(stderr, 0), [
+			{ line: 0, column: 1, message: "unnecessary import", severity: "warning" },
+		]);
+	});
+
+	test("Should ignore a diagnostic that names a file other than the source", () => {
+		// A preamble read from disk reports its own path, and mapping that line
+		// onto the block would point at the wrong text entirely.
+		const stderr = ["error: file not found", "  ┌─ preamble.typ:4:2", "  │", "4 │ #x", ""].join("\n");
+		assert.deepStrictEqual(parseTypstStderr(stderr, 0), []);
+	});
+
+	test("Should return nothing for output that holds no diagnostic", () => {
+		assert.deepStrictEqual(parseTypstStderr("", 0), []);
+		assert.deepStrictEqual(parseTypstStderr("<svg></svg>", 0), []);
+	});
+});

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -70,6 +70,16 @@ suite("Typst Diagnostics Test Suite", () => {
 		assert.deepStrictEqual(parseTypstStderr(stderr, 0), []);
 	});
 
+	test("Should keep a diagnostic that carries no position", () => {
+		// A failure to read the input or to fetch a package has nothing to point
+		// at. Dropping it leaves a caller that counts diagnostics reporting a
+		// clean block for a compile that produced no image at all.
+		const stderr = "error: failed to download package @preview/example:0.1.0\n";
+		assert.deepStrictEqual(parseTypstStderr(stderr, 0), [
+			{ line: 0, column: 0, message: "failed to download package @preview/example:0.1.0", severity: "error" },
+		]);
+	});
+
 	test("Should return nothing for output that holds no diagnostic", () => {
 		assert.deepStrictEqual(parseTypstStderr("", 0), []);
 		assert.deepStrictEqual(parseTypstStderr("<svg></svg>", 0), []);

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -39,16 +39,20 @@ suite("Typst Diagnostics Test Suite", () => {
 	test("Should subtract the injected lines so a position maps to the document", () => {
 		// The compiled source carries a header the author never wrote, so the
 		// reported line is ahead of the block by exactly that many lines.
-		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 2), [
+		// One injected line above a report on Typst line 2 leaves the first line
+		// of the body, and the column survives because the line is still inside it.
+		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 1), [
 			{ line: 0, column: 4, message: "expected pattern", severity: "error" },
 		]);
 	});
 
-	test("Should never report a negative line", () => {
-		// An error inside the injected header itself maps above the block, and a
-		// negative line is not a position any editor can take.
+	test("Should point at the start of the body for an error in the header", () => {
+		// An error inside the injected header maps above the block. A negative
+		// line is not a position any editor can take, and the column that came
+		// with it was measured against a line the author never wrote, so keeping
+		// it would put the mark at an arbitrary character of the first body line.
 		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 10), [
-			{ line: 0, column: 4, message: "expected pattern", severity: "error" },
+			{ line: 0, column: 0, message: "expected pattern", severity: "error" },
 		]);
 	});
 

--- a/src/test/suite/typstSvg.test.ts
+++ b/src/test/suite/typstSvg.test.ts
@@ -1,0 +1,62 @@
+import * as assert from "assert";
+import { svgSize, clampSvg, svgDataUri } from "../../utils/typst/typstSvg";
+
+// The root element below is the real one, taken from
+// `typst compile --format svg - -` over a two line document. Typst writes the
+// viewBox first, then width and height in points.
+const REAL_ROOT =
+	'<svg viewBox="0 0 41.236188889 18.513" width="41.236188889pt" height="18.513pt" ' +
+	'xmlns="http://www.w3.org/2000/svg"><path d="M 0 0"/></svg>';
+
+suite("Typst SVG Test Suite", () => {
+	suite("svgSize", () => {
+		test("Should read the width and height of a real root element", () => {
+			assert.deepStrictEqual(svgSize(REAL_ROOT), { width: 41.236188889, height: 18.513 });
+		});
+
+		test("Should read a size given without a unit", () => {
+			assert.deepStrictEqual(svgSize('<svg width="10" height="20"></svg>'), { width: 10, height: 20 });
+		});
+
+		test("Should return undefined when the root carries no size", () => {
+			assert.strictEqual(svgSize('<svg viewBox="0 0 10 20"></svg>'), undefined);
+		});
+
+		test("Should return undefined for text that is not an SVG", () => {
+			assert.strictEqual(svgSize("error: expected expression"), undefined);
+		});
+
+		test("Should not read a width from a child element", () => {
+			// A `use` or `rect` further down carries its own width, and reading it
+			// would size the image from an arbitrary glyph.
+			const svg = '<svg viewBox="0 0 1 2"><rect width="999" height="999"/></svg>';
+			assert.strictEqual(svgSize(svg), undefined);
+		});
+	});
+
+	suite("clampSvg", () => {
+		test("Should leave an image under the limit unchanged", () => {
+			assert.strictEqual(clampSvg(REAL_ROOT, 100), REAL_ROOT);
+		});
+
+		test("Should scale both dimensions and keep the viewBox", () => {
+			const clamped = clampSvg(REAL_ROOT, 9.2565);
+			assert.deepStrictEqual(svgSize(clamped), { width: 20.6180944445, height: 9.2565 });
+			assert.ok(clamped.includes('viewBox="0 0 41.236188889 18.513"'), "the viewBox must not change");
+		});
+
+		test("Should leave an image with no readable size unchanged", () => {
+			const svg = '<svg viewBox="0 0 10 20"></svg>';
+			assert.strictEqual(clampSvg(svg, 5), svg);
+		});
+	});
+
+	suite("svgDataUri", () => {
+		test("Should build a base64 data URI that decodes to the source", () => {
+			const uri = svgDataUri(REAL_ROOT);
+			assert.ok(uri.startsWith("data:image/svg+xml;base64,"), uri.slice(0, 40));
+			const encoded = uri.slice("data:image/svg+xml;base64,".length);
+			assert.strictEqual(Buffer.from(encoded, "base64").toString("utf-8"), REAL_ROOT);
+		});
+	});
+});

--- a/src/test/suite/typstSvg.test.ts
+++ b/src/test/suite/typstSvg.test.ts
@@ -26,6 +26,13 @@ suite("Typst SVG Test Suite", () => {
 			assert.strictEqual(svgSize("error: expected expression"), undefined);
 		});
 
+		test("Should not read a hyphenated attribute as the size", () => {
+			// A word boundary holds between a hyphen and a letter, so a plain
+			// `\bwidth` also matches `stroke-width` and reads the stroke instead.
+			const svg = '<svg stroke-width="2" width="41pt" height="18pt"></svg>';
+			assert.deepStrictEqual(svgSize(svg), { width: 41, height: 18 });
+		});
+
 		test("Should not read a width from a child element", () => {
 			// A `use` or `rect` further down carries its own width, and reading it
 			// would size the image from an arbitrary glyph.
@@ -43,6 +50,12 @@ suite("Typst SVG Test Suite", () => {
 			const clamped = clampSvg(REAL_ROOT, 9.2565);
 			assert.deepStrictEqual(svgSize(clamped), { width: 20.6180944445, height: 9.2565 });
 			assert.ok(clamped.includes('viewBox="0 0 41.236188889 18.513"'), "the viewBox must not change");
+		});
+
+		test("Should rewrite the size and not a hyphenated attribute", () => {
+			const clamped = clampSvg('<svg stroke-width="2" width="40pt" height="20pt"></svg>', 10);
+			assert.ok(clamped.includes('stroke-width="2"'), clamped);
+			assert.deepStrictEqual(svgSize(clamped), { width: 20, height: 10 });
 		});
 
 		test("Should leave an image with no readable size unchanged", () => {

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -1,4 +1,4 @@
-import { getCodeBlockRanges, getYamlFrontMatterRange } from "../yamlPosition";
+import { getCodeBlockRanges, getYamlFrontMatterRange, OPENING_FENCE, closingFenceRegExp } from "../yamlPosition";
 
 /**
  * The three fence kinds that carry Typst source in a Quarto document.
@@ -87,7 +87,7 @@ function blockBody(text: string, bodyStart: number, bodyEnd: number, fence: stri
 	// glue the last body line to whatever follows it.
 	const slice = text.slice(bodyStart, bodyEnd);
 	const lastNewline = slice.lastIndexOf("\n");
-	const closing = new RegExp(`^\\s*${fence[0]}{${fence.length},}\\s*$`);
+	const closing = closingFenceRegExp(fence);
 	const body = closing.test(stripCarriageReturn(slice.slice(lastNewline + 1)))
 		? slice.slice(0, lastNewline + 1)
 		: slice;
@@ -191,7 +191,14 @@ export function hasLateOptionLine(block: TypstBlock): boolean {
  * block and is never reported here.
  */
 export function findTypstBlocks(text: string): TypstBlock[] {
+	// Scan below the front matter rather than dropping its ranges afterwards. A
+	// block scalar can hold a line that looks like a fence, and that opens a
+	// block which only closes on a bare fence line, so it swallows the opening
+	// fence of the first real block and takes it out of the results entirely.
 	const frontMatter = getYamlFrontMatterRange(text);
+	const from = frontMatter?.end ?? 0;
+	const source = from === 0 ? text : text.slice(from);
+
 	const blocks: TypstBlock[] = [];
 	// The ranges come back sorted, so the line number of each fence continues
 	// from the last one. Counting from the start of the document for every block
@@ -199,14 +206,15 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 	// carry ninety fences.
 	let counted = 0;
 	let line = 0;
-
-	for (const range of getCodeBlockRanges(text)) {
-		if (frontMatter !== undefined && range.start < frontMatter.end) {
-			continue;
+	for (let index = 0; index < from; index++) {
+		if (text[index] === "\n") {
+			line++;
 		}
+	}
 
-		const fence = fenceLineRange(text, range.start);
-		const opening = /^(\s*)(`{3,}|~{3,})(.*)$/.exec(stripCarriageReturn(text.slice(fence.start, fence.end)));
+	for (const range of getCodeBlockRanges(source)) {
+		const fence = fenceLineRange(source, range.start);
+		const opening = OPENING_FENCE.exec(stripCarriageReturn(source.slice(fence.start, fence.end)));
 		if (opening === null) {
 			continue;
 		}
@@ -217,13 +225,13 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 		}
 
 		for (; counted < fence.start; counted++) {
-			if (text[counted] === "\n") {
+			if (source[counted] === "\n") {
 				line++;
 			}
 		}
 
 		const indent = opening[1].length;
-		const body = blockBody(text, range.start, range.end, opening[2], indent);
+		const body = blockBody(source, range.start, range.end, opening[2], indent);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
 		// ordinary Typst comment, so the body passes through untouched.
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };
@@ -233,9 +241,10 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			body,
 			code: parsed.code,
 			options: parsed.options,
-			bodyStart: range.start,
-			bodyEnd: range.end,
-			fenceStart: fence.start,
+			// Offsets are reported against the document, not against the slice.
+			bodyStart: range.start + from,
+			bodyEnd: range.end + from,
+			fenceStart: fence.start + from,
 			fenceLine: line,
 			indent,
 		});

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -119,7 +119,17 @@ function blockBody(text: string, bodyStart: number, bodyEnd: number, fence: stri
  */
 const OPTION_LINE = /^\s*\/\/\|\s*([A-Za-z0-9-]+):\s*(.+)$/;
 
-/** The Lua guard at `:110`, which warns about an option line that came late. */
+/**
+ * The Lua guard at `_modules/code-cell.lua:110`, which warns about an option
+ * line that came after the code.
+ *
+ * It is deliberately not the same rule as the key pattern above, because the
+ * two are not the same in Lua either: the guard ends with a colon and one
+ * whitespace character, while the key pattern accepts a colon with nothing
+ * after it. So a line spelled without that space parses as an option at the top
+ * of a block and is passed over in silence lower down. That is upstream
+ * behaviour, and it is reproduced rather than corrected.
+ */
 const LATE_OPTION_LINE = /^\s*\/\/\|\s*[A-Za-z0-9-]+:\s/;
 
 /** One parsed value, following `code-cell.lua:95-102`. */

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -34,6 +34,8 @@ export interface TypstBlock {
 	bodyStart: number;
 	/** Offset one past the last character of the body. */
 	bodyEnd: number;
+	/** Offset of the first character of the opening fence line. */
+	fenceStart: number;
 	/** Zero-based line number of the opening fence. */
 	fenceLine: number;
 	/** Indent of the opening fence, in characters. */
@@ -181,6 +183,12 @@ export function hasLateOptionLine(block: TypstBlock): boolean {
 export function findTypstBlocks(text: string): TypstBlock[] {
 	const frontMatter = getYamlFrontMatterRange(text);
 	const blocks: TypstBlock[] = [];
+	// The ranges come back sorted, so the line number of each fence continues
+	// from the last one. Counting from the start of the document for every block
+	// would walk the whole prefix again each time, and a page of examples can
+	// carry ninety fences.
+	let counted = 0;
+	let line = 0;
 
 	for (const range of getCodeBlockRanges(text)) {
 		if (frontMatter !== undefined && range.start < frontMatter.end) {
@@ -198,6 +206,12 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			continue;
 		}
 
+		for (; counted < fence.start; counted++) {
+			if (text[counted] === "\n") {
+				line++;
+			}
+		}
+
 		const indent = opening[1].length;
 		const body = blockBody(text, range.start, range.end, opening[2], indent);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
@@ -211,7 +225,8 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			options: parsed.options,
 			bodyStart: range.start,
 			bodyEnd: range.end,
-			fenceLine: text.slice(0, fence.start).split("\n").length - 1,
+			fenceStart: fence.start,
+			fenceLine: line,
 			indent,
 		});
 	}
@@ -226,10 +241,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
  * cursor on the fence means that block, and the body range starts after it.
  */
 export function typstBlockAt(text: string, offset: number): TypstBlock | undefined {
-	return findTypstBlocks(text).find((block) => {
-		const fence = fenceLineRange(text, block.bodyStart);
-		return offset >= fence.start && offset <= block.bodyEnd;
-	});
+	return findTypstBlocks(text).find((block) => offset >= block.fenceStart && offset <= block.bodyEnd);
 }
 
 /**

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -1,0 +1,245 @@
+import { getCodeBlockRanges, getYamlFrontMatterRange } from "../yamlPosition";
+
+/**
+ * The three fence kinds that carry Typst source in a Quarto document.
+ *
+ * Quarto treats each one differently, and conflating them produces a preview
+ * that does not match the render:
+ *
+ * - `plain` is a ```` ```typst ```` block. Quarto only highlights it, so it is
+ *   never executed and its `//|` lines are ordinary Typst comments.
+ * - `raw` is a ```` ```{=typst} ```` block. Pandoc passes it through to Typst
+ *   output and drops it in every other format.
+ * - `cell` is a ```` ```{typst} ```` block, an executable cell owned by the
+ *   `typst-render` extension. Only this kind carries options.
+ */
+export type TypstBlockKind = "plain" | "raw" | "cell";
+
+/** One Typst block found in a document. */
+export interface TypstBlock {
+	/** Which of the three fence kinds this is. */
+	kind: TypstBlockKind;
+	/** The block body, without the fences, de-indented to column zero. */
+	body: string;
+	/**
+	 * The body without its leading option run.
+	 *
+	 * Identical to `body` for `plain` and `raw`, where a `//|` line is an
+	 * ordinary Typst comment and must survive verbatim.
+	 */
+	code: string;
+	/** The `//|` options, empty for every kind but `cell`. */
+	options: Record<string, string | boolean>;
+	/** Offset of the first character of the body. */
+	bodyStart: number;
+	/** Offset one past the last character of the body. */
+	bodyEnd: number;
+	/** Zero-based line number of the opening fence. */
+	fenceLine: number;
+	/** Indent of the opening fence, in characters. */
+	indent: number;
+}
+
+/** Drop a trailing carriage return left by a CRLF document. */
+function stripCarriageReturn(line: string): string {
+	return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+/**
+ * The opening fence line that precedes a code block body.
+ *
+ * `getCodeBlockRanges` starts each range after the opening fence line, so the
+ * info string has to be recovered by walking back. When the opening fence is
+ * the last line and the document has no trailing newline, the range is empty
+ * and starts at the end of the text, which is why the newline test comes first.
+ */
+function fenceLineRange(text: string, bodyStart: number): { start: number; end: number } {
+	const end = bodyStart > 0 && text[bodyStart - 1] === "\n" ? bodyStart - 1 : bodyStart;
+	return { start: text.lastIndexOf("\n", end - 1) + 1, end };
+}
+
+/** The kind an info string declares, or undefined when it is not Typst. */
+function classifyInfoString(info: string): TypstBlockKind | undefined {
+	const trimmed = info.trim();
+	if (trimmed === "{=typst}") {
+		return "raw";
+	}
+	if (trimmed === "{typst}") {
+		return "cell";
+	}
+	if (trimmed === "typst" || /^\{\.typst(\s[^}]*)?\}$/.test(trimmed)) {
+		return "plain";
+	}
+	return undefined;
+}
+
+/**
+ * The body of a block, without its closing fence and without the fence indent.
+ *
+ * Typst is whitespace sensitive, so an indented fence must not leave its indent
+ * on every line of the compiled source.
+ */
+function blockBody(text: string, bodyStart: number, bodyEnd: number, fence: string, indent: number): string {
+	// Cut at the start of the closing fence line rather than dropping that line
+	// after a split, which would take the newline of the line above with it and
+	// glue the last body line to whatever follows it.
+	const slice = text.slice(bodyStart, bodyEnd);
+	const lastNewline = slice.lastIndexOf("\n");
+	const closing = new RegExp(`^\\s*${fence[0]}{${fence.length},}\\s*$`);
+	const body = closing.test(stripCarriageReturn(slice.slice(lastNewline + 1)))
+		? slice.slice(0, lastNewline + 1)
+		: slice;
+
+	if (indent === 0) {
+		return body;
+	}
+	// Spaces and tabs only. A carriage return is part of the line ending on a
+	// CRLF document, and stripping it here would corrupt the source.
+	const leading = new RegExp(`^[ \\t]{0,${indent}}`);
+	return body
+		.split("\n")
+		.map((line) => line.replace(leading, ""))
+		.join("\n");
+}
+
+/**
+ * The Lua key pattern at `_modules/code-cell.lua:89`, in JavaScript.
+ *
+ * That pattern anchors at the line start, skips leading whitespace, takes the
+ * comment-pipe prefix, then a key of `%w` and hyphen, a colon, and a value of
+ * one or more characters, with whitespace allowed on both sides.
+ *
+ * `%w` is alphanumeric and carries no underscore, so an underscore key does not
+ * match and ends the option run. The value needs one character, so a key with
+ * nothing after its colon does not match either, while the same line with one
+ * trailing space does: the pattern backtracks, the value becomes that space,
+ * and the trim which follows leaves an empty string.
+ */
+const OPTION_LINE = /^\s*\/\/\|\s*([A-Za-z0-9-]+):\s*(.+)$/;
+
+/** The Lua guard at `:110`, which warns about an option line that came late. */
+const LATE_OPTION_LINE = /^\s*\/\/\|\s*[A-Za-z0-9-]+:\s/;
+
+/** One parsed value, following `code-cell.lua:95-102`. */
+function optionValue(raw: string): string | boolean {
+	if (raw === "true") {
+		return true;
+	}
+	if (raw === "false") {
+		return false;
+	}
+	const quoted = /^"(.*)"$/.exec(raw) ?? /^'(.*)'$/.exec(raw);
+	return quoted === null ? raw : quoted[1];
+}
+
+/**
+ * The leading `//|` run of a cell body, and the code that follows it.
+ *
+ * A port of `cell.parse_options` at `_modules/code-cell.lua:84-122`, kept
+ * bug-compatible except for the line split. Lua iterates `[^\r\n]*`, which
+ * yields an empty line between each pair on a CRLF document and so ends the run
+ * after the first option. That is unreachable in a render, because Pandoc does
+ * not recognise a fenced block in a CRLF document at all, so reproducing it
+ * would only break the preview of a file an author can legitimately write.
+ */
+function parseOptions(body: string): { options: Record<string, string | boolean>; code: string } {
+	const options: Record<string, string | boolean> = {};
+	const lines = body.split(/\r?\n/);
+	let index = 0;
+
+	for (; index < lines.length; index++) {
+		const match = OPTION_LINE.exec(lines[index]);
+		if (match === null) {
+			break;
+		}
+		// Lua trims after the capture, not inside the pattern, and the order
+		// matters: a value of one space captures as a space and trims to empty.
+		options[match[1]] = optionValue(match[2].trim());
+	}
+
+	// The Lua reader warns here and keeps the line as code. Nothing in this
+	// module reports to the user, so the line is kept and the warning belongs to
+	// whichever surface renders the block.
+	const code = lines.slice(index).join("\n");
+	return { options, code };
+}
+
+/** Whether a body carries an option line after its code, which Lua warns about. */
+export function hasLateOptionLine(block: TypstBlock): boolean {
+	return block.kind === "cell" && block.code.split(/\r?\n/).some((line) => LATE_OPTION_LINE.test(line));
+}
+
+/**
+ * Every Typst block in a document, in document order.
+ *
+ * Block scanning reuses `getCodeBlockRanges`, which already handles CRLF, an
+ * indented fence, an unclosed block, and the CommonMark rule that a backtick
+ * info string carries no bare backtick. It also means a fence nested inside a
+ * longer fence, as in a Markdown demonstration block, is part of that outer
+ * block and is never reported here.
+ */
+export function findTypstBlocks(text: string): TypstBlock[] {
+	const frontMatter = getYamlFrontMatterRange(text);
+	const blocks: TypstBlock[] = [];
+
+	for (const range of getCodeBlockRanges(text)) {
+		if (frontMatter !== undefined && range.start < frontMatter.end) {
+			continue;
+		}
+
+		const fence = fenceLineRange(text, range.start);
+		const opening = /^(\s*)(`{3,}|~{3,})(.*)$/.exec(stripCarriageReturn(text.slice(fence.start, fence.end)));
+		if (opening === null) {
+			continue;
+		}
+
+		const kind = classifyInfoString(opening[3]);
+		if (kind === undefined) {
+			continue;
+		}
+
+		const indent = opening[1].length;
+		const body = blockBody(text, range.start, range.end, opening[2], indent);
+		// Only a cell carries options. For the other two kinds a `//|` line is an
+		// ordinary Typst comment, so the body passes through untouched.
+		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };
+
+		blocks.push({
+			kind,
+			body,
+			code: parsed.code,
+			options: parsed.options,
+			bodyStart: range.start,
+			bodyEnd: range.end,
+			fenceLine: text.slice(0, fence.start).split("\n").length - 1,
+			indent,
+		});
+	}
+
+	return blocks;
+}
+
+/**
+ * The Typst block that holds an offset, or undefined when none does.
+ *
+ * The opening fence line counts as part of its block. A reader who puts the
+ * cursor on the fence means that block, and the body range starts after it.
+ */
+export function typstBlockAt(text: string, offset: number): TypstBlock | undefined {
+	return findTypstBlocks(text).find((block) => {
+		const fence = fenceLineRange(text, block.bodyStart);
+		return offset >= fence.start && offset <= block.bodyEnd;
+	});
+}
+
+/**
+ * Every raw block before a target, in document order.
+ *
+ * Pandoc emits raw blocks into the Typst output in order, so an earlier one can
+ * bind a name the target uses. Only a raw block reaches that output: a cell is
+ * compiled to an image by the filter, and a plain block is never executed, so
+ * neither can put a binding in scope.
+ */
+export function precedingRawBlocks(blocks: TypstBlock[], target: TypstBlock): TypstBlock[] {
+	return blocks.filter((block) => block.kind === "raw" && block.bodyStart < target.bodyStart);
+}

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -169,11 +169,20 @@ function parseOptions(body: string): { options: Record<string, string | boolean>
 		options[match[1]] = optionValue(match[2].trim());
 	}
 
-	// The Lua reader warns here and keeps the line as code. Nothing in this
-	// module reports to the user, so the line is kept and the warning belongs to
-	// whichever surface renders the block.
-	const code = lines.slice(index).join("\n");
-	return { options, code };
+	// Slice the body at the end of the option run rather than joining the
+	// remaining lines. Joining would write one line ending everywhere and leave
+	// `code` normalised while `body` kept its own, so an offset taken in one
+	// would drift against the other by a character a line.
+	//
+	// The Lua reader warns about a late option line and keeps it as code. Nothing
+	// in this module reports to the user, so the line is kept here too and the
+	// warning belongs to whichever surface renders the block.
+	let offset = 0;
+	for (let consumed = 0; consumed < index; consumed++) {
+		const newline = body.indexOf("\n", offset);
+		offset = newline === -1 ? body.length : newline + 1;
+	}
+	return { options, code: body.slice(offset) };
 }
 
 /** Whether a body carries an option line after its code, which Lua warns about. */

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -17,12 +17,14 @@ export interface TypstDiagnostic {
 const HEADING = /^(error|warning): (.+)$/;
 
 /**
- * The second line, which carries the position.
+ * The second line, which names a file and a position in it.
  *
- * Only `<stdin>` counts. A preamble read from disk reports its own path, and
- * mapping that line onto the block would point at unrelated text.
+ * The file matters. Only `<stdin>` is the block being compiled: a preamble read
+ * from disk reports its own path, and mapping that line onto the block would
+ * point at unrelated text. A diagnostic with no position line at all is a
+ * different case again, and is kept.
  */
-const POSITION = /^\s*┌─\s*<stdin>:(\d+):(\d+)/;
+const POSITION = /^\s*┌─\s*(\S+):(\d+):(\d+)/;
 
 /**
  * Every diagnostic in a Typst run, mapped onto the block body.
@@ -45,19 +47,33 @@ export function parseTypstStderr(stderr: string, injectedLines: number): TypstDi
 	const lines = stderr.split(/\r?\n/);
 	const diagnostics: TypstDiagnostic[] = [];
 
-	for (let index = 0; index < lines.length - 1; index++) {
+	for (let index = 0; index < lines.length; index++) {
 		const heading = HEADING.exec(lines[index]);
 		if (heading === null) {
 			continue;
 		}
-		const position = POSITION.exec(lines[index + 1]);
+
+		const severity = heading[1] as "error" | "warning";
+		const position = index + 1 < lines.length ? POSITION.exec(lines[index + 1]) : null;
+
 		if (position === null) {
+			// A failure to read the input, or to fetch a package, has nothing to
+			// point at. It still has to be reported: a caller that counts
+			// diagnostics would otherwise call a failed compile a clean block.
+			diagnostics.push({ line: 0, column: 0, message: heading[2], severity });
 			continue;
 		}
+
+		if (position[1] !== "<stdin>") {
+			// A real place, but not one in this block, so there is nothing here to
+			// mark and nothing useful to say about where it is.
+			continue;
+		}
+
 		// Typst mixes its bases, which was checked against the caret it prints:
 		// for `#let a = ` it reports 1:8, and the caret sits at index 8 of that
 		// line. So the line counts from one and the column counts from zero.
-		const line = Number(position[1]) - 1 - injectedLines;
+		const line = Number(position[2]) - 1 - injectedLines;
 
 		diagnostics.push({
 			// A position inside the injected header is not a place in the block, so
@@ -65,9 +81,9 @@ export function parseTypstStderr(stderr: string, injectedLines: number): TypstDi
 			// a column measured against a header line means nothing on the first
 			// line of the body, and would put the mark at an arbitrary character.
 			line: Math.max(0, line),
-			column: line < 0 ? 0 : Number(position[2]),
+			column: line < 0 ? 0 : Number(position[3]),
 			message: heading[2],
-			severity: heading[1] as "error" | "warning",
+			severity,
 		});
 	}
 

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -54,14 +54,18 @@ export function parseTypstStderr(stderr: string, injectedLines: number): TypstDi
 		if (position === null) {
 			continue;
 		}
+		// Typst mixes its bases, which was checked against the caret it prints:
+		// for `#let a = ` it reports 1:8, and the caret sits at index 8 of that
+		// line. So the line counts from one and the column counts from zero.
+		const line = Number(position[1]) - 1 - injectedLines;
+
 		diagnostics.push({
-			// Typst mixes its bases, which was checked against the caret it prints:
-			// for `#let a = ` it reports 1:8, and the caret sits at index 8 of that
-			// line. So the line counts from one and the column counts from zero.
 			// A position inside the injected header is not a place in the block, so
-			// it clamps to the first line.
-			line: Math.max(0, Number(position[1]) - 1 - injectedLines),
-			column: Number(position[2]),
+			// it points at the start of the body instead. The column goes with it:
+			// a column measured against a header line means nothing on the first
+			// line of the body, and would put the mark at an arbitrary character.
+			line: Math.max(0, line),
+			column: line < 0 ? 0 : Number(position[2]),
 			message: heading[2],
 			severity: heading[1] as "error" | "warning",
 		});

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -1,0 +1,71 @@
+/**
+ * One diagnostic Typst reported, mapped back onto the block body.
+ *
+ * Both fields are zero-based, which is what a VS Code position takes.
+ */
+export interface TypstDiagnostic {
+	/** Zero-based line within the block body. */
+	line: number;
+	/** Zero-based column. */
+	column: number;
+	/** The message, without its severity prefix. */
+	message: string;
+	severity: "error" | "warning";
+}
+
+/** The first line of a diagnostic, which carries the severity and the message. */
+const HEADING = /^(error|warning): (.+)$/;
+
+/**
+ * The second line, which carries the position.
+ *
+ * Only `<stdin>` counts. A preamble read from disk reports its own path, and
+ * mapping that line onto the block would point at unrelated text.
+ */
+const POSITION = /^\s*┌─\s*<stdin>:(\d+):(\d+)/;
+
+/**
+ * Every diagnostic in a Typst run, mapped onto the block body.
+ *
+ * Typst writes the message and the position on separate lines:
+ *
+ * ```text
+ * error: expected pattern
+ *   ┌─ <stdin>:2:4
+ * ```
+ *
+ * so a reader that looks only for `<stdin>:line:column` finds the position and
+ * loses every message. The two are paired here instead.
+ *
+ * @param stderr - The captured standard error of the compiler.
+ * @param injectedLines - How many lines the assembled source adds above the
+ *   block body, which is what the reported line has to lose.
+ */
+export function parseTypstStderr(stderr: string, injectedLines: number): TypstDiagnostic[] {
+	const lines = stderr.split(/\r?\n/);
+	const diagnostics: TypstDiagnostic[] = [];
+
+	for (let index = 0; index < lines.length - 1; index++) {
+		const heading = HEADING.exec(lines[index]);
+		if (heading === null) {
+			continue;
+		}
+		const position = POSITION.exec(lines[index + 1]);
+		if (position === null) {
+			continue;
+		}
+		diagnostics.push({
+			// Typst mixes its bases, which was checked against the caret it prints:
+			// for `#let a = ` it reports 1:8, and the caret sits at index 8 of that
+			// line. So the line counts from one and the column counts from zero.
+			// A position inside the injected header is not a place in the block, so
+			// it clamps to the first line.
+			line: Math.max(0, Number(position[1]) - 1 - injectedLines),
+			column: Number(position[2]),
+			message: heading[2],
+			severity: heading[1] as "error" | "warning",
+		});
+	}
+
+	return diagnostics;
+}

--- a/src/utils/typst/typstSvg.ts
+++ b/src/utils/typst/typstSvg.ts
@@ -24,15 +24,17 @@ function rootLength(root: string, name: string): number | undefined {
 	return Number.isFinite(value) ? value : undefined;
 }
 
+/** The size a root element declares, or undefined when it declares none. */
+function rootSize(root: string): SvgSize | undefined {
+	const width = rootLength(root, "width");
+	const height = rootLength(root, "height");
+	return width === undefined || height === undefined ? undefined : { width, height };
+}
+
 /** The intrinsic size the root element declares, or undefined when it has none. */
 export function svgSize(svg: string): SvgSize | undefined {
 	const root = ROOT_ELEMENT.exec(svg);
-	if (root === null) {
-		return undefined;
-	}
-	const width = rootLength(root[0], "width");
-	const height = rootLength(root[0], "height");
-	return width === undefined || height === undefined ? undefined : { width, height };
+	return root === null ? undefined : rootSize(root[0]);
 }
 
 /**
@@ -43,15 +45,12 @@ export function svgSize(svg: string): SvgSize | undefined {
  * root declares no size, is returned unchanged.
  */
 export function clampSvg(svg: string, maxHeight: number): string {
-	const size = svgSize(svg);
-	if (size === undefined || size.height <= maxHeight || size.height <= 0) {
+	const root = ROOT_ELEMENT.exec(svg);
+	const size = root === null ? undefined : rootSize(root[0]);
+	if (root === null || size === undefined || size.height <= maxHeight || size.height <= 0) {
 		return svg;
 	}
 	const scale = maxHeight / size.height;
-	const root = ROOT_ELEMENT.exec(svg);
-	if (root === null) {
-		return svg;
-	}
 	const scaled = root[0]
 		.replace(/\bwidth="(-?[0-9.]+)(pt|px)?"/, `width="${size.width * scale}$2"`)
 		.replace(/\bheight="(-?[0-9.]+)(pt|px)?"/, `height="${maxHeight}$2"`);

--- a/src/utils/typst/typstSvg.ts
+++ b/src/utils/typst/typstSvg.ts
@@ -14,9 +14,15 @@ export interface SvgSize {
  */
 const ROOT_ELEMENT = /^\s*<svg\b[^>]*>/;
 
-/** One length attribute of the root element, with an optional unit. */
+/**
+ * One length attribute of the root element, with an optional unit.
+ *
+ * The name is preceded by a lookbehind and not a word boundary, because a
+ * boundary holds between a hyphen and a letter: `\bwidth` also matches the
+ * `stroke-width` of a root element and would read the stroke as the size.
+ */
 function rootLength(root: string, name: string): number | undefined {
-	const found = new RegExp(`\\b${name}="(-?[0-9.]+)(?:pt|px)?"`).exec(root);
+	const found = new RegExp(`(?<![-\\w])${name}="(-?[0-9.]+)(?:pt|px)?"`).exec(root);
 	if (found === null) {
 		return undefined;
 	}
@@ -52,8 +58,8 @@ export function clampSvg(svg: string, maxHeight: number): string {
 	}
 	const scale = maxHeight / size.height;
 	const scaled = root[0]
-		.replace(/\bwidth="(-?[0-9.]+)(pt|px)?"/, `width="${size.width * scale}$2"`)
-		.replace(/\bheight="(-?[0-9.]+)(pt|px)?"/, `height="${maxHeight}$2"`);
+		.replace(/(?<![-\w])width="(-?[0-9.]+)(pt|px)?"/, `width="${size.width * scale}$2"`)
+		.replace(/(?<![-\w])height="(-?[0-9.]+)(pt|px)?"/, `height="${maxHeight}$2"`);
 	return scaled + svg.slice(root[0].length);
 }
 

--- a/src/utils/typst/typstSvg.ts
+++ b/src/utils/typst/typstSvg.ts
@@ -1,0 +1,64 @@
+/** The intrinsic size of a compiled image, in points. */
+export interface SvgSize {
+	width: number;
+	height: number;
+}
+
+/**
+ * The root element of a Typst SVG.
+ *
+ * Typst writes `<svg viewBox="..." width="41.236188889pt" height="18.513pt" ...>`,
+ * so the size sits on the root and never on a child. Matching the whole
+ * document would find the width of the first glyph or rectangle instead, and
+ * size the image from that.
+ */
+const ROOT_ELEMENT = /^\s*<svg\b[^>]*>/;
+
+/** One length attribute of the root element, with an optional unit. */
+function rootLength(root: string, name: string): number | undefined {
+	const found = new RegExp(`\\b${name}="(-?[0-9.]+)(?:pt|px)?"`).exec(root);
+	if (found === null) {
+		return undefined;
+	}
+	const value = Number(found[1]);
+	return Number.isFinite(value) ? value : undefined;
+}
+
+/** The intrinsic size the root element declares, or undefined when it has none. */
+export function svgSize(svg: string): SvgSize | undefined {
+	const root = ROOT_ELEMENT.exec(svg);
+	if (root === null) {
+		return undefined;
+	}
+	const width = rootLength(root[0], "width");
+	const height = rootLength(root[0], "height");
+	return width === undefined || height === undefined ? undefined : { width, height };
+}
+
+/**
+ * The same image, scaled down so its height fits a limit.
+ *
+ * The `viewBox` is left alone, so the drawing still fills the element and only
+ * the presented size changes. An image already inside the limit, or one whose
+ * root declares no size, is returned unchanged.
+ */
+export function clampSvg(svg: string, maxHeight: number): string {
+	const size = svgSize(svg);
+	if (size === undefined || size.height <= maxHeight || size.height <= 0) {
+		return svg;
+	}
+	const scale = maxHeight / size.height;
+	const root = ROOT_ELEMENT.exec(svg);
+	if (root === null) {
+		return svg;
+	}
+	const scaled = root[0]
+		.replace(/\bwidth="(-?[0-9.]+)(pt|px)?"/, `width="${size.width * scale}$2"`)
+		.replace(/\bheight="(-?[0-9.]+)(pt|px)?"/, `height="${maxHeight}$2"`);
+	return scaled + svg.slice(root[0].length);
+}
+
+/** The image as a data URI, which is what every surface renders. */
+export function svgDataUri(svg: string): string {
+	return `data:image/svg+xml;base64,${Buffer.from(svg, "utf-8").toString("base64")}`;
+}

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -42,6 +42,28 @@ export function hasUnquotedBacktick(infoString: string): boolean {
 }
 
 /**
+ * An opening code fence, capturing its indent, its run and its info string.
+ *
+ * Exported so that a reader which derives the info string of a block, such as
+ * the Typst block scanner, matches the fence exactly as this module does. Two
+ * copies of the rule drift apart in silence.
+ */
+export const OPENING_FENCE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+
+/**
+ * The closing fence that ends a block opened by the given run.
+ *
+ * A fence closes on the same character, repeated at least as many times, alone
+ * on its line. The character is always a backtick or a tilde, and neither is a
+ * regular expression metacharacter.
+ *
+ * @param fence - The run of the opening fence, as captured by `OPENING_FENCE`.
+ */
+export function closingFenceRegExp(fence: string): RegExp {
+	return new RegExp(`^\\s*${fence[0]}{${fence.length},}\\s*$`);
+}
+
+/**
  * Find all fenced code block body regions in the document text.
  *
  * Recognises both backtick (`` ``` ``) and tilde (`~~~`) fences, with
@@ -82,7 +104,7 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 		}
 
 		// Check for opening fence, optionally indented.
-		const openMatch = /^(\s*)(`{3,}|~{3,})(.*)$/.exec(line);
+		const openMatch = OPENING_FENCE.exec(line);
 		if (openMatch) {
 			// The info string must not contain bare backticks when using backtick
 			// fences (CommonMark spec).  Backticks inside quoted attribute values
@@ -95,8 +117,7 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			// attributes in the header (e.g. {r}, {python}) stay outside.
 			blockStart = offset;
 			// Compile the closing fence regex once per block.
-			// fenceChar is always ` or ~, neither is a regex metacharacter.
-			closingFenceRe = new RegExp(`^\\s*${openMatch[2][0]}{${openMatch[2].length},}\\s*$`);
+			closingFenceRe = closingFenceRegExp(openMatch[2]);
 		}
 	}
 


### PR DESCRIPTION
The pure foundation of the Typst preview. Nothing is registered in `src/extension.ts`, so this changes no behaviour.

Three fence kinds behave differently and must never be conflated. A plain `typst` block is highlighted and never executed. A `{=typst}` block is a Pandoc raw passthrough. A `{typst}` block is an executable cell owned by the typst-render extension, and only that kind carries options.

Block scanning reuses `getCodeBlockRanges` rather than adding a second fence scanner, and the fence patterns move to `yamlPosition` so the two readers cannot drift apart. The scan starts below the front matter: a block scalar can hold a line that looks like a fence, and such a block only closes on a bare fence line, so it swallowed the opening fence of the first real block and took it out of the results.

The option parser is a port of the filter's own Lua pattern, kept bug-compatible. Each quirk has a test naming the behaviour and citing the line it ports, because these are quirks and an upstream fix to any of them is a breaking change here. One deviation is deliberate and documented: Lua splits lines in a way that ends the option run after the first option on a CRLF document, which is unreachable in a render because Pandoc does not recognise a fenced block in a CRLF document at all.

The stderr reader pairs each message with its position, since Typst writes the two on separate lines. Typst also mixes its bases, which was checked against the caret it prints: the line counts from one and the column counts from zero.