### PR TITLE
feat: preview a plain Typst block in a panel

### DIFF
--- a/assets/webview/typstPreview.css
+++ b/assets/webview/typstPreview.css
@@ -44,7 +44,3 @@ body {
 	max-width: 100%;
 	height: auto;
 }
-
-[hidden] {
-	display: none;
-}

--- a/assets/webview/typstPreview.css
+++ b/assets/webview/typstPreview.css
@@ -1,0 +1,50 @@
+/* The Typst preview panel. */
+
+body {
+	margin: 0;
+	padding: 0;
+	/* The editor background follows a theme change with no recompile. */
+	background-color: var(--vscode-editor-background);
+	color: var(--vscode-foreground);
+	font-family: var(--vscode-font-family);
+	font-size: var(--vscode-font-size);
+}
+
+#header {
+	position: sticky;
+	top: 0;
+	padding: 0.4em 0.8em;
+	background-color: var(--vscode-editorWidget-background);
+	border-bottom: 1px solid var(--vscode-editorWidget-border);
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.9em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#error {
+	margin: 0;
+	padding: 0.6em 0.8em;
+	background-color: var(--vscode-inputValidation-errorBackground);
+	border-bottom: 1px solid var(--vscode-inputValidation-errorBorder);
+	color: var(--vscode-errorForeground);
+	font-family: var(--vscode-editor-font-family);
+	font-size: var(--vscode-editor-font-size);
+	white-space: pre-wrap;
+}
+
+#figure {
+	display: flex;
+	justify-content: center;
+	padding: 1em;
+}
+
+#image {
+	max-width: 100%;
+	height: auto;
+}
+
+[hidden] {
+	display: none;
+}

--- a/package.json
+++ b/package.json
@@ -325,6 +325,14 @@
 				"icon": "$(folder)",
 				"category": "Quarto Wizard",
 				"description": "Install extension(s) from a local directory or archive file."
+			},
+			{
+				"command": "quartoWizard.previewTypstBlock",
+				"title": "Preview Typst Block",
+				"shortTitle": "Preview Typst",
+				"icon": "$(preview)",
+				"category": "Quarto Wizard",
+				"description": "Compile the Typst block under the cursor and show it in a panel."
 			}
 		],
 		"submenus": [

--- a/package.json
+++ b/package.json
@@ -491,6 +491,10 @@
 			],
 			"commandPalette": [
 				{
+					"command": "quartoWizard.previewTypstBlock",
+					"when": "editorLangId == quarto"
+				},
+				{
 					"command": "quartoWizard.extensionsInstalled.openSource",
 					"when": "false"
 				},

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"workspaceContains:**/_extension.{yml,yaml}",
 		"workspaceContains:**/_schema.{yml,yaml,json}",
 		"workspaceContains:**/_extensions/**/_snippets.json",
+		"onWebviewPanel:quartoWizard.typstPreview",
 		"onUri"
 	],
 	"main": "./dist/extension",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { registerShortcodeCompletionProvider } from "./providers/shortcodeComple
 import { registerElementAttributeProviders } from "./providers/elementAttributeCompletionProvider";
 import { registerInlineAttributeDiagnostics } from "./providers/inlineAttributeDiagnosticsProvider";
 import { registerSnippetCompletionProvider } from "./providers/snippetCompletionProvider";
+import { registerTypstPreview } from "./providers/typstPreview";
 
 /**
  * This method is called when the extension is activated.
@@ -163,6 +164,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register snippet completion provider for Quarto documents
 	registerSnippetCompletionProvider(context, snippetCache);
+
+	// Register the Typst block preview for Quarto documents
+	registerTypstPreview(context);
 
 	// Register URI handler for browser-based extension installation (e.g., vscode://mcanouil.quarto-wizard/install?repo=owner/repo)
 	context.subscriptions.push(

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
 import { typstBlockAt, type TypstBlock } from "../../utils/typst/typstBlocks";
-import { parseTypstStderr } from "../../utils/typst/typstDiagnostics";
+import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
 import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
 import { TypstPreviewPanel } from "./typstPreviewPanel";
@@ -43,14 +43,32 @@ function assembleSource(block: TypstBlock): AssembledSource {
 	return { source: `${PAGE_SETUP}\n${block.body}`, injectedLines: 1 };
 }
 
-/** The first line of a failure, as it is shown inside the panel. */
-function errorText(stderr: string, injectedLines: number): string {
+/**
+ * The one line a failure shows inside the panel.
+ *
+ * Exported for its tests. The choice of which diagnostic to show carries most
+ * of the behaviour, and it is not reachable through the command.
+ */
+export function errorText(stderr: string, injectedLines: number): string {
 	const diagnostics = parseTypstStderr(stderr, injectedLines);
-	if (diagnostics.length === 0) {
-		return "Typst produced no image and reported nothing.";
+	// A warning can sit above the error that stopped the compile, so the first
+	// diagnostic is not the one to show. Headlining a failure as a warning
+	// misstates why there is no image.
+	const mapped = diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
+	if (mapped) {
+		// The line is counted inside the block, while the panel header counts
+		// document lines, so it says which of the two it means.
+		return `${mapped.severity} at line ${mapped.line + 1}, column ${mapped.column + 1} of the block: ${mapped.message}`;
 	}
-	const first = diagnostics[0];
-	return `${first.severity} at line ${first.line + 1}, column ${first.column + 1}: ${first.message}`;
+
+	// Nothing mapped, which means every diagnostic pointed at another file, such
+	// as an imported one. There is no position to show, but there is still a
+	// message, and reporting none would contradict the missing image.
+	const messages = typstMessages(stderr);
+	const outside = messages.find((message) => message.severity === "error") ?? messages[0];
+	return outside === undefined
+		? "Typst produced no image and reported nothing."
+		: `${outside.severity} outside this block: ${outside.message}`;
 }
 
 /** What the panel shows about the block it is displaying. */
@@ -97,6 +115,9 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	const report = (message: string): void => {
 		logMessage(`Typst preview: ${message}`, "debug");
 		if (panel) {
+			// Reveal it as well. A message written into a panel sitting in a
+			// background tab is a command that appears to do nothing.
+			panel.reveal();
 			panel.showError(message);
 			return;
 		}

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -107,16 +107,15 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	const usePanel = (): TypstPreviewPanel => panel ?? holdPanel(TypstPreviewPanel.create(context.extensionUri));
 
 	/**
-	 * Say why there is nothing to show.
+	 * Put a message in front of the reader.
 	 *
 	 * An open panel takes the message itself, which is both quieter and closer to
-	 * the thing the reader is looking at than a notification would be.
+	 * the thing the reader is looking at than a notification would be. It is
+	 * revealed as well: a message written into a background tab is a command that
+	 * appears to do nothing.
 	 */
-	const report = (message: string): void => {
-		logMessage(`Typst preview: ${message}`, "debug");
+	const show = (message: string): void => {
 		if (panel) {
-			// Reveal it as well. A message written into a panel sitting in a
-			// background tab is a command that appears to do nothing.
 			panel.reveal();
 			panel.showError(message);
 			return;
@@ -124,16 +123,43 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		void showMessageWithLogs(message, "warning");
 	};
 
-	/** Say once that the feature cannot run here at all. */
+	/** Say why there is nothing to show. */
+	const report = (message: string): void => {
+		logMessage(`Typst preview: ${message}`, "debug");
+		show(message);
+	};
+
+	/**
+	 * Say once that the feature cannot run here at all.
+	 *
+	 * The log line is not part of what is said once. The binary probe caches its
+	 * result and logs only on the first attempt, so without this every later
+	 * attempt on an unavailable machine would leave no trace at all, and the log
+	 * would stop being enough to diagnose an inert preview.
+	 */
 	const reportUnavailable = (message: string): void => {
+		logMessage(`Typst preview: ${message}`, "debug");
 		if (reportedUnavailable) {
 			return;
 		}
 		reportedUnavailable = true;
-		report(message);
+		show(message);
 	};
 
-	const preview = async (): Promise<void> => {
+	/**
+	 * Compile the block under the cursor into the panel.
+	 *
+	 * @param asked - Whether the user asked for this. A restore did not, and at
+	 *   that moment the editors are often not back yet, so saying that no block
+	 *   is under the cursor would be an error message on most window reloads.
+	 */
+	const preview = async (asked: boolean): Promise<void> => {
+		const explain = (message: string): void => {
+			if (asked) {
+				report(message);
+			}
+		};
+
 		if (!vscode.workspace.isTrusted) {
 			reportUnavailable("The Typst preview needs a trusted workspace, because it runs the Typst compiler.");
 			return;
@@ -141,21 +167,21 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 
 		const editor = vscode.window.activeTextEditor;
 		if (!editor) {
-			report("Open a Quarto document to preview a Typst block.");
+			explain("Open a Quarto document to preview a Typst block.");
 			return;
 		}
 
 		const document = editor.document;
 		const block = typstBlockAt(document.getText(), document.offsetAt(editor.selection.active));
 		if (block === undefined) {
-			report("Put the cursor inside a Typst block to preview it.");
+			explain("Put the cursor inside a Typst block to preview it.");
 			return;
 		}
 		if (block.kind !== "plain") {
 			// A raw block needs the ones before it, and a cell needs its options
 			// resolved. Compiling either one alone would show an image that the
 			// render does not produce.
-			report(`A \`${block.kind}\` Typst block cannot be previewed yet.`);
+			explain(`A \`${block.kind}\` Typst block cannot be previewed yet.`);
 			return;
 		}
 
@@ -191,7 +217,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		}
 	};
 
-	context.subscriptions.push(vscode.commands.registerCommand("quartoWizard.previewTypstBlock", () => preview()));
+	context.subscriptions.push(vscode.commands.registerCommand("quartoWizard.previewTypstBlock", () => preview(true)));
 
 	// A window reload restores the panel. Recompile into it rather than restoring
 	// a serialised image, which would be stale the moment the document changed.
@@ -203,7 +229,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 					return;
 				}
 				holdPanel(new TypstPreviewPanel(restored, context.extensionUri));
-				await preview();
+				await preview(false);
 			},
 		}),
 	);

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -56,9 +56,16 @@ export function errorText(stderr: string, injectedLines: number): string {
 	// misstates why there is no image.
 	const mapped = diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
 	if (mapped) {
+		if (mapped.line === undefined) {
+			// A package that would not download, or an input Typst could not read.
+			// Naming a position here would point at a character that has nothing to
+			// do with the failure.
+			return `${mapped.severity}: ${mapped.message}`;
+		}
 		// The line is counted inside the block, while the panel header counts
 		// document lines, so it says which of the two it means.
-		return `${mapped.severity} at line ${mapped.line + 1}, column ${mapped.column + 1} of the block: ${mapped.message}`;
+		const column = (mapped.column ?? 0) + 1;
+		return `${mapped.severity} at line ${mapped.line + 1}, column ${column} of the block: ${mapped.message}`;
 	}
 
 	// Nothing mapped, which means every diagnostic pointed at another file, such

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,0 +1,193 @@
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { typstBlockAt, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { parseTypstStderr } from "../../utils/typst/typstDiagnostics";
+import { logMessage, showMessageWithLogs } from "../../utils/log";
+import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
+import { TypstPreviewPanel } from "./typstPreviewPanel";
+
+/**
+ * The page setup every preview compiles with.
+ *
+ * A block is a fragment and not a document, so the page has to shrink to it.
+ * The margin is not decoration: on a `width: auto` page the glyphs of the
+ * outermost characters clip at the edge of the viewBox without it.
+ */
+const PAGE_SETUP = "#set page(width: auto, height: auto, margin: 0.5em)";
+
+/** How many lines {@link PAGE_SETUP} adds above the block body. */
+const INJECTED_LINES = 1;
+
+/** Read the source from stdin, write the image to stdout. */
+const ARGV = ["compile", "--format", "svg", "-", "-"];
+
+/** The first line of a failure, as it is shown inside the panel. */
+function errorText(stderr: string): string {
+	const diagnostics = parseTypstStderr(stderr, INJECTED_LINES);
+	if (diagnostics.length === 0) {
+		return "Typst produced no image and reported nothing.";
+	}
+	const first = diagnostics[0];
+	return `${first.severity} at line ${first.line + 1}, column ${first.column + 1}: ${first.message}`;
+}
+
+/** What the panel shows about the block it is displaying. */
+function headerText(document: vscode.TextDocument, block: TypstBlock): string {
+	return `${path.basename(document.fileName)} · line ${block.fenceLine + 1}`;
+}
+
+/**
+ * Register the Typst block preview.
+ *
+ * The feature is inert unless the workspace is trusted and Quarto ships a Typst
+ * binary. Neither condition is worth a prompt: the extension does many other
+ * things, and a user who never writes a Typst block should never hear about it.
+ */
+export function registerTypstPreview(context: vscode.ExtensionContext): void {
+	let panel: TypstPreviewPanel | undefined;
+	let compiler: TypstCompiler | undefined;
+	let compiling: vscode.CancellationTokenSource | undefined;
+	// One message per session, so a machine that cannot run the preview at all
+	// does not report the same thing on every request.
+	let reportedUnavailable = false;
+
+	/** The one panel, adopting a restored one when the window was reloaded. */
+	const usePanel = (restored?: TypstPreviewPanel): TypstPreviewPanel => {
+		if (panel === undefined) {
+			panel = restored ?? TypstPreviewPanel.create(context.extensionUri);
+			panel.onDidDispose(() => {
+				panel = undefined;
+			});
+		} else if (restored !== undefined && restored !== panel) {
+			restored.dispose();
+		}
+		return panel;
+	};
+
+	/**
+	 * Say why there is nothing to show.
+	 *
+	 * An open panel takes the message itself, which is both quieter and closer to
+	 * the thing the reader is looking at than a notification would be.
+	 */
+	const report = (message: string): void => {
+		logMessage(`Typst preview: ${message}`, "debug");
+		if (panel) {
+			panel.showError(message);
+			return;
+		}
+		void showMessageWithLogs(message, "warning");
+	};
+
+	/** Say once that the feature cannot run here at all. */
+	const reportUnavailable = (message: string): void => {
+		logMessage(`Typst preview: ${message}`, "debug");
+		if (reportedUnavailable) {
+			return;
+		}
+		reportedUnavailable = true;
+		report(message);
+	};
+
+	const preview = async (): Promise<void> => {
+		if (!vscode.workspace.isTrusted) {
+			reportUnavailable("The Typst preview needs a trusted workspace, because it runs the Typst compiler.");
+			return;
+		}
+
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			report("Open a Quarto document to preview a Typst block.");
+			return;
+		}
+
+		const document = editor.document;
+		const block = typstBlockAt(document.getText(), document.offsetAt(editor.selection.active));
+		if (block === undefined) {
+			report("Put the cursor inside a Typst block to preview it.");
+			return;
+		}
+		if (block.kind !== "plain") {
+			// A raw block needs the ones before it, and a cell needs its options
+			// resolved. Compiling either one alone would show an image that the
+			// render does not produce.
+			report(`A \`${block.kind}\` Typst block cannot be previewed yet.`);
+			return;
+		}
+
+		const binary = await resolveTypstBinary();
+		if (binary === undefined) {
+			reportUnavailable("The Typst preview needs the Typst binary that ships inside Quarto, and it was not found.");
+			return;
+		}
+		compiler ??= new TypstCompiler(binary);
+
+		const surface = usePanel();
+		surface.reveal();
+
+		compiling?.cancel();
+		compiling?.dispose();
+		const cancellation = new vscode.CancellationTokenSource();
+		compiling = cancellation;
+
+		try {
+			const result = await compiler.compile(`${PAGE_SETUP}\n${block.body}`, ARGV, cancellation.token);
+			if (result.svg === undefined) {
+				logMessage(`Typst preview: the compiler reported:\n${result.stderr}`, "debug");
+				surface.showError(errorText(result.stderr));
+				return;
+			}
+			if (result.stderr.length > 0) {
+				logMessage(`Typst preview: the compiler warned:\n${result.stderr}`, "debug");
+			}
+			surface.show(result.svg, headerText(document, block));
+		} catch (error) {
+			if (error instanceof vscode.CancellationError) {
+				return;
+			}
+			const message = error instanceof Error ? error.message : String(error);
+			logMessage(`Typst preview: ${message}`, "error");
+			surface.showError(message);
+		} finally {
+			if (compiling === cancellation) {
+				compiling = undefined;
+			}
+			cancellation.dispose();
+		}
+	};
+
+	context.subscriptions.push(vscode.commands.registerCommand("quartoWizard.previewTypstBlock", () => preview()));
+
+	// A window reload restores the panel. Recompile into it rather than restoring
+	// a serialised image, which would be stale the moment the document changed.
+	context.subscriptions.push(
+		vscode.window.registerWebviewPanelSerializer(TypstPreviewPanel.viewType, {
+			deserializeWebviewPanel: async (restored: vscode.WebviewPanel) => {
+				usePanel(new TypstPreviewPanel(restored, context.extensionUri));
+				await preview();
+			},
+		}),
+	);
+
+	// Installing or removing the Quarto extension changes where the binary is, or
+	// whether there is one at all.
+	context.subscriptions.push(
+		vscode.extensions.onDidChange(() => {
+			invalidateTypstBinary();
+			compiler?.dispose();
+			compiler = undefined;
+			reportedUnavailable = false;
+		}),
+	);
+
+	context.subscriptions.push({
+		dispose: () => {
+			compiling?.cancel();
+			compiling?.dispose();
+			compiler?.dispose();
+			panel?.dispose();
+		},
+	});
+
+	logMessage("Typst preview registered.", "debug");
+}

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
+import { getErrorMessage } from "@quarto-wizard/core";
 import { typstBlockAt, type TypstBlock } from "../../utils/typst/typstBlocks";
 import { parseTypstStderr } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
@@ -15,15 +16,36 @@ import { TypstPreviewPanel } from "./typstPreviewPanel";
  */
 const PAGE_SETUP = "#set page(width: auto, height: auto, margin: 0.5em)";
 
-/** How many lines {@link PAGE_SETUP} adds above the block body. */
-const INJECTED_LINES = 1;
-
 /** Read the source from stdin, write the image to stdout. */
 const ARGV = ["compile", "--format", "svg", "-", "-"];
 
+/** One compile request. */
+interface AssembledSource {
+	/** The whole source to send to the compiler. */
+	source: string;
+	/**
+	 * How many lines sit above the block body.
+	 *
+	 * A diagnostic reports a position in the assembled source, so it has to lose
+	 * these before it means anything in the document.
+	 */
+	injectedLines: number;
+}
+
+/**
+ * The source for one block.
+ *
+ * The count travels with the source rather than beside it, because it stops
+ * being a constant as soon as a raw block prepends the blocks before it, or a
+ * cell prepends its resolved options.
+ */
+function assembleSource(block: TypstBlock): AssembledSource {
+	return { source: `${PAGE_SETUP}\n${block.body}`, injectedLines: 1 };
+}
+
 /** The first line of a failure, as it is shown inside the panel. */
-function errorText(stderr: string): string {
-	const diagnostics = parseTypstStderr(stderr, INJECTED_LINES);
+function errorText(stderr: string, injectedLines: number): string {
+	const diagnostics = parseTypstStderr(stderr, injectedLines);
 	if (diagnostics.length === 0) {
 		return "Typst produced no image and reported nothing.";
 	}
@@ -46,23 +68,25 @@ function headerText(document: vscode.TextDocument, block: TypstBlock): string {
 export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	let panel: TypstPreviewPanel | undefined;
 	let compiler: TypstCompiler | undefined;
-	let compiling: vscode.CancellationTokenSource | undefined;
 	// One message per session, so a machine that cannot run the preview at all
 	// does not report the same thing on every request.
 	let reportedUnavailable = false;
+	// The compiler supersedes its own running child, so the caller has nothing to
+	// cancel. This source is never cancelled, and exists only because `compile`
+	// takes a token and the API has no ready-made one that never fires.
+	const uncancelled = new vscode.CancellationTokenSource();
+	context.subscriptions.push(uncancelled);
 
-	/** The one panel, adopting a restored one when the window was reloaded. */
-	const usePanel = (restored?: TypstPreviewPanel): TypstPreviewPanel => {
-		if (panel === undefined) {
-			panel = restored ?? TypstPreviewPanel.create(context.extensionUri);
-			panel.onDidDispose(() => {
-				panel = undefined;
-			});
-		} else if (restored !== undefined && restored !== panel) {
-			restored.dispose();
-		}
-		return panel;
+	/** Keep a panel, and forget it when the user closes it. */
+	const holdPanel = (held: TypstPreviewPanel): TypstPreviewPanel => {
+		panel = held;
+		held.onDidDispose(() => {
+			panel = undefined;
+		});
+		return held;
 	};
+
+	const usePanel = (): TypstPreviewPanel => panel ?? holdPanel(TypstPreviewPanel.create(context.extensionUri));
 
 	/**
 	 * Say why there is nothing to show.
@@ -81,7 +105,6 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 
 	/** Say once that the feature cannot run here at all. */
 	const reportUnavailable = (message: string): void => {
-		logMessage(`Typst preview: ${message}`, "debug");
 		if (reportedUnavailable) {
 			return;
 		}
@@ -125,16 +148,12 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		const surface = usePanel();
 		surface.reveal();
 
-		compiling?.cancel();
-		compiling?.dispose();
-		const cancellation = new vscode.CancellationTokenSource();
-		compiling = cancellation;
-
+		const assembled = assembleSource(block);
 		try {
-			const result = await compiler.compile(`${PAGE_SETUP}\n${block.body}`, ARGV, cancellation.token);
+			const result = await compiler.compile(assembled.source, ARGV, uncancelled.token);
 			if (result.svg === undefined) {
 				logMessage(`Typst preview: the compiler reported:\n${result.stderr}`, "debug");
-				surface.showError(errorText(result.stderr));
+				surface.showError(errorText(result.stderr, assembled.injectedLines));
 				return;
 			}
 			if (result.stderr.length > 0) {
@@ -145,14 +164,9 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			if (error instanceof vscode.CancellationError) {
 				return;
 			}
-			const message = error instanceof Error ? error.message : String(error);
+			const message = getErrorMessage(error);
 			logMessage(`Typst preview: ${message}`, "error");
 			surface.showError(message);
-		} finally {
-			if (compiling === cancellation) {
-				compiling = undefined;
-			}
-			cancellation.dispose();
 		}
 	};
 
@@ -163,7 +177,11 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.window.registerWebviewPanelSerializer(TypstPreviewPanel.viewType, {
 			deserializeWebviewPanel: async (restored: vscode.WebviewPanel) => {
-				usePanel(new TypstPreviewPanel(restored, context.extensionUri));
+				if (panel) {
+					restored.dispose();
+					return;
+				}
+				holdPanel(new TypstPreviewPanel(restored, context.extensionUri));
 				await preview();
 			},
 		}),
@@ -182,8 +200,6 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 
 	context.subscriptions.push({
 		dispose: () => {
-			compiling?.cancel();
-			compiling?.dispose();
 			compiler?.dispose();
 			panel?.dispose();
 		},

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -200,6 +200,7 @@ export class TypstCompiler {
 			// line of a Typst diagnostic starts with one, so the position would be
 			// lost exactly when it is needed.
 			const errorOutput: Buffer[] = [];
+			let errorBytes = 0;
 			let settled = false;
 
 			const timer = setTimeout(
@@ -246,6 +247,14 @@ export class TypstCompiler {
 			});
 
 			child.stderr?.on("data", (chunk: Buffer) => {
+				// Bounded by the same limit as the image. A loop that reports once per
+				// iteration fills this as fast as a runaway document fills the other,
+				// and a cap on one of the two is not a cap. Whole chunks are kept, and
+				// the head is what carries the first diagnostic.
+				if (errorBytes >= maxOutputBytes) {
+					return;
+				}
+				errorBytes += chunk.length;
 				errorOutput.push(chunk);
 			});
 

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -101,10 +101,16 @@ export function invalidateTypstBinary(): void {
 const KILL_GRACE_MS = 2000;
 
 /** How long one compile gets, which also covers a first-use package download. */
-export const DEFAULT_TIMEOUT_MS = 20000;
+const TIMEOUT_MS = 20000;
 
-/** How much output one compile may produce before it is treated as a failure. */
-export const DEFAULT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
+/**
+ * How much output one compile may produce before it is treated as a failure.
+ *
+ * A block is a fragment, so even a page dense with glyph outlines stays well
+ * under this. The limit exists so that a runaway document fails cleanly rather
+ * than growing a buffer until the extension host runs out of memory.
+ */
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 /** The outcome of one compile that Typst itself reported on. */
 export interface TypstCompileResult {
@@ -112,11 +118,6 @@ export interface TypstCompileResult {
 	svg?: string;
 	/** The captured standard error, which carries every diagnostic. */
 	stderr: string;
-}
-
-export interface TypstCompilerOptions {
-	timeoutMs?: number;
-	maxOutputBytes?: number;
 }
 
 /** A compile that never reached Typst, or that was stopped before it finished. */
@@ -159,14 +160,10 @@ function killChild(child: ChildProcess): void {
  * strings, so an argv array with `shell: false` is a hard requirement.
  */
 export class TypstCompiler {
-	private child: ChildProcess | undefined;
 	private abortCurrent: ((error: Error) => void) | undefined;
 	private disposed = false;
 
-	constructor(
-		private readonly binary: string,
-		private readonly options: TypstCompilerOptions = {},
-	) {}
+	constructor(private readonly binary: string) {}
 
 	/**
 	 * Compile one source, superseding whatever was running.
@@ -181,17 +178,8 @@ export class TypstCompiler {
 		}
 		this.stopCurrent();
 
-		const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-		const maxOutputBytes = this.options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
-
 		return new Promise<TypstCompileResult>((resolve, reject) => {
-			let child: ChildProcess;
-			try {
-				child = spawn(this.binary, argv, { shell: false, windowsHide: true });
-			} catch (error) {
-				reject(new TypstCompileFailure(`Failed to start Typst: ${String(error)}.`));
-				return;
-			}
+			const child = spawn(this.binary, argv, { shell: false, windowsHide: true });
 
 			const output: Buffer[] = [];
 			let outputBytes = 0;
@@ -199,8 +187,8 @@ export class TypstCompiler {
 			let settled = false;
 
 			const timer = setTimeout(
-				() => abort(new TypstCompileFailure(`Typst did not finish within ${timeoutMs} ms.`)),
-				timeoutMs,
+				() => abort(new TypstCompileFailure(`Typst did not finish within ${TIMEOUT_MS} ms.`)),
+				TIMEOUT_MS,
 			);
 			const cancellation = token.onCancellationRequested(() => abort(new vscode.CancellationError()));
 
@@ -211,8 +199,7 @@ export class TypstCompiler {
 				settled = true;
 				clearTimeout(timer);
 				cancellation.dispose();
-				if (this.child === child) {
-					this.child = undefined;
+				if (this.abortCurrent === abort) {
 					this.abortCurrent = undefined;
 				}
 				act();
@@ -223,7 +210,6 @@ export class TypstCompiler {
 				settle(() => reject(error));
 			}
 
-			this.child = child;
 			this.abortCurrent = abort;
 
 			// Attach this before writing. Typst closes stdin as soon as it gives up
@@ -236,8 +222,8 @@ export class TypstCompiler {
 
 			child.stdout?.on("data", (chunk: Buffer) => {
 				outputBytes += chunk.length;
-				if (outputBytes > maxOutputBytes) {
-					abort(new TypstCompileFailure(`Typst produced more than ${maxOutputBytes} bytes.`));
+				if (outputBytes > MAX_OUTPUT_BYTES) {
+					abort(new TypstCompileFailure(`Typst produced more than ${MAX_OUTPUT_BYTES} bytes.`));
 					return;
 				}
 				output.push(chunk);

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -120,6 +120,12 @@ export interface TypstCompileResult {
 	stderr: string;
 }
 
+/** Limits a caller can lower, which is how the lifecycle is put under test. */
+export interface TypstCompilerOptions {
+	timeoutMs?: number;
+	maxOutputBytes?: number;
+}
+
 /** A compile that never reached Typst, or that was stopped before it finished. */
 export class TypstCompileFailure extends Error {}
 
@@ -163,7 +169,10 @@ export class TypstCompiler {
 	private abortCurrent: ((error: Error) => void) | undefined;
 	private disposed = false;
 
-	constructor(private readonly binary: string) {}
+	constructor(
+		private readonly binary: string,
+		private readonly options: TypstCompilerOptions = {},
+	) {}
 
 	/**
 	 * Compile one source, superseding whatever was running.
@@ -178,17 +187,24 @@ export class TypstCompiler {
 		}
 		this.stopCurrent();
 
+		const timeoutMs = this.options.timeoutMs ?? TIMEOUT_MS;
+		const maxOutputBytes = this.options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
+
 		return new Promise<TypstCompileResult>((resolve, reject) => {
 			const child = spawn(this.binary, argv, { shell: false, windowsHide: true });
 
 			const output: Buffer[] = [];
 			let outputBytes = 0;
-			let stderr = "";
+			// Kept as bytes and decoded once. Decoding each chunk splits a
+			// multi-byte character that straddles a chunk boundary, and the position
+			// line of a Typst diagnostic starts with one, so the position would be
+			// lost exactly when it is needed.
+			const errorOutput: Buffer[] = [];
 			let settled = false;
 
 			const timer = setTimeout(
-				() => abort(new TypstCompileFailure(`Typst did not finish within ${TIMEOUT_MS} ms.`)),
-				TIMEOUT_MS,
+				() => abort(new TypstCompileFailure(`Typst did not finish within ${timeoutMs} ms.`)),
+				timeoutMs,
 			);
 			const cancellation = token.onCancellationRequested(() => abort(new vscode.CancellationError()));
 
@@ -222,15 +238,15 @@ export class TypstCompiler {
 
 			child.stdout?.on("data", (chunk: Buffer) => {
 				outputBytes += chunk.length;
-				if (outputBytes > MAX_OUTPUT_BYTES) {
-					abort(new TypstCompileFailure(`Typst produced more than ${MAX_OUTPUT_BYTES} bytes.`));
+				if (outputBytes > maxOutputBytes) {
+					abort(new TypstCompileFailure(`Typst produced more than ${maxOutputBytes} bytes.`));
 					return;
 				}
 				output.push(chunk);
 			});
 
 			child.stderr?.on("data", (chunk: Buffer) => {
-				stderr += chunk.toString("utf-8");
+				errorOutput.push(chunk);
 			});
 
 			child.on("error", (error: Error) =>
@@ -240,6 +256,7 @@ export class TypstCompiler {
 			child.on("close", (code: number | null) => {
 				settle(() => {
 					const svg = Buffer.concat(output).toString("utf-8");
+					const stderr = Buffer.concat(errorOutput).toString("utf-8");
 					resolve(code === 0 && svg.length > 0 ? { svg, stderr } : { stderr });
 				});
 			});

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -249,8 +249,13 @@ export class TypstCompiler {
 			child.stderr?.on("data", (chunk: Buffer) => {
 				// Bounded by the same limit as the image. A loop that reports once per
 				// iteration fills this as fast as a runaway document fills the other,
-				// and a cap on one of the two is not a cap. Whole chunks are kept, and
-				// the head is what carries the first diagnostic.
+				// and a cap on one of the two is not a cap.
+				//
+				// Collection stops once the limit is reached, so the total is the
+				// limit plus at most the one chunk that crossed it, which a pipe
+				// bounds on its own. Whole chunks are kept rather than cut to the
+				// byte, because a cut lands mid-character as easily as anywhere else,
+				// and the head is what carries the first diagnostic.
 				if (errorBytes >= maxOutputBytes) {
 					return;
 				}

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -1,0 +1,272 @@
+import * as vscode from "vscode";
+import { spawn, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getQuartoVersionInfo } from "../../services/quartoVersion";
+import { logMessage } from "../../utils/log";
+
+/**
+ * The two inputs binary resolution reads from the machine.
+ *
+ * Everything else about resolution is a path calculation, so injecting these
+ * two makes the whole route testable without a Quarto installation.
+ */
+export interface TypstProbe {
+	/** The Quarto bin directory, or undefined when Quarto is unavailable. */
+	binPath: () => Promise<string | undefined>;
+	/** Whether a candidate path is a file on disk. */
+	exists: (candidate: string) => boolean;
+	platform: NodeJS.Platform;
+	arch: string;
+}
+
+/**
+ * Where Typst sits inside a Quarto installation.
+ *
+ * `getQuartoPath()` returns the bin directory and not the executable, so no
+ * step climbs out of it. Quarto resolves its own Typst as
+ * `<bin>/tools/<arch>/typst`, at `src/core/typst.ts:20` through
+ * `architectureToolsPath` at `src/core/resources.ts:33`, and its packaging
+ * writes the binary to exactly that path, at
+ * `package/src/common/dependencies/typst.ts:23`.
+ *
+ * That holds on every platform, Windows included, which is where Typst differs
+ * from pandoc: pandoc is flat on Windows and Typst is not. Windows carries the
+ * `.exe` suffix, because the same packaging step names the file `typst.exe`
+ * there.
+ */
+export function typstBinaryCandidate(binPath: string, platform: NodeJS.Platform, arch: string): string {
+	const architecture = arch === "arm64" ? "aarch64" : "x86_64";
+	return path.join(binPath, "tools", architecture, platform === "win32" ? "typst.exe" : "typst");
+}
+
+/**
+ * The bundled Typst executable, or undefined when there is none.
+ *
+ * One route and no fallback ladder. The attempt is logged at debug level, so a
+ * user who reports an inert preview can be diagnosed from the log alone.
+ */
+export async function probeTypstBinary(probe: TypstProbe): Promise<string | undefined> {
+	const binPath = await probe.binPath();
+	if (!binPath) {
+		logMessage("Typst preview: Quarto reported no path, so no binary was probed.", "debug");
+		return undefined;
+	}
+
+	const candidate = typstBinaryCandidate(binPath, probe.platform, probe.arch);
+	if (probe.exists(candidate)) {
+		logMessage(`Typst preview: resolved the compiler at ${candidate}.`, "debug");
+		return candidate;
+	}
+	logMessage(`Typst preview: no compiler at ${candidate}.`, "debug");
+	return undefined;
+}
+
+/** The probe that reads the running machine. */
+const machineProbe: TypstProbe = {
+	binPath: async () => {
+		const info = await getQuartoVersionInfo();
+		return info.available ? info.path : undefined;
+	},
+	exists: (candidate: string) => {
+		try {
+			return fs.statSync(candidate).isFile();
+		} catch {
+			return false;
+		}
+	},
+	platform: process.platform,
+	arch: process.arch,
+};
+
+let resolution: Promise<string | undefined> | undefined;
+
+/**
+ * The bundled Typst executable, resolved once per session.
+ *
+ * The result is cached because the probe runs on every preview request, and it
+ * activates the Quarto extension to read its API.
+ */
+export async function resolveTypstBinary(): Promise<string | undefined> {
+	resolution ??= probeTypstBinary(machineProbe);
+	return resolution;
+}
+
+/** Forget the resolved binary, so the next request probes again. */
+export function invalidateTypstBinary(): void {
+	resolution = undefined;
+}
+
+/** How long a killed child gets to exit before it is killed again, harder. */
+const KILL_GRACE_MS = 2000;
+
+/** How long one compile gets, which also covers a first-use package download. */
+export const DEFAULT_TIMEOUT_MS = 20000;
+
+/** How much output one compile may produce before it is treated as a failure. */
+export const DEFAULT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
+
+/** The outcome of one compile that Typst itself reported on. */
+export interface TypstCompileResult {
+	/** The image, absent when Typst produced none. */
+	svg?: string;
+	/** The captured standard error, which carries every diagnostic. */
+	stderr: string;
+}
+
+export interface TypstCompilerOptions {
+	timeoutMs?: number;
+	maxOutputBytes?: number;
+}
+
+/** A compile that never reached Typst, or that was stopped before it finished. */
+export class TypstCompileFailure extends Error {}
+
+/** Whether a child has already gone. */
+function hasExited(child: ChildProcess): boolean {
+	return child.exitCode !== null || child.signalCode !== null;
+}
+
+/**
+ * Stop a child, and make sure it actually stops.
+ *
+ * Typst can be inside a package download or a runaway loop, where a polite
+ * signal is ignored, so the hard signal follows on a timer.
+ */
+function killChild(child: ChildProcess): void {
+	if (hasExited(child)) {
+		return;
+	}
+	child.kill("SIGTERM");
+	const grace = setTimeout(() => {
+		if (!hasExited(child)) {
+			child.kill("SIGKILL");
+		}
+	}, KILL_GRACE_MS);
+	grace.unref();
+	child.once("close", () => clearTimeout(grace));
+}
+
+/**
+ * One Typst process at a time, over stdin and stdout.
+ *
+ * `spawn` rather than `execFile`, because `execFile` buffers stdout behind a
+ * 1 MiB `maxBuffer` that Typst glyph outlines routinely exceed, and raising it
+ * to `Infinity` removes the safety valve without replacing it. Accumulating the
+ * output here keeps a running total, so an oversized image is a clean error.
+ *
+ * Never `exec` and never a shell: the arguments carry workspace-controlled
+ * strings, so an argv array with `shell: false` is a hard requirement.
+ */
+export class TypstCompiler {
+	private child: ChildProcess | undefined;
+	private abortCurrent: ((error: Error) => void) | undefined;
+	private disposed = false;
+
+	constructor(
+		private readonly binary: string,
+		private readonly options: TypstCompilerOptions = {},
+	) {}
+
+	/**
+	 * Compile one source, superseding whatever was running.
+	 *
+	 * Resolves for any run Typst finished, whether or not it produced an image,
+	 * because a failed compile is a result the caller renders. Rejects when the
+	 * run was cancelled, superseded, timed out, oversized, or never started.
+	 */
+	compile(source: string, argv: string[], token: vscode.CancellationToken): Promise<TypstCompileResult> {
+		if (this.disposed) {
+			return Promise.reject(new TypstCompileFailure("The Typst compiler is disposed."));
+		}
+		this.stopCurrent();
+
+		const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		const maxOutputBytes = this.options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+
+		return new Promise<TypstCompileResult>((resolve, reject) => {
+			let child: ChildProcess;
+			try {
+				child = spawn(this.binary, argv, { shell: false, windowsHide: true });
+			} catch (error) {
+				reject(new TypstCompileFailure(`Failed to start Typst: ${String(error)}.`));
+				return;
+			}
+
+			const output: Buffer[] = [];
+			let outputBytes = 0;
+			let stderr = "";
+			let settled = false;
+
+			const timer = setTimeout(
+				() => abort(new TypstCompileFailure(`Typst did not finish within ${timeoutMs} ms.`)),
+				timeoutMs,
+			);
+			const cancellation = token.onCancellationRequested(() => abort(new vscode.CancellationError()));
+
+			const settle = (act: () => void) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				cancellation.dispose();
+				if (this.child === child) {
+					this.child = undefined;
+					this.abortCurrent = undefined;
+				}
+				act();
+			};
+
+			function abort(error: Error): void {
+				killChild(child);
+				settle(() => reject(error));
+			}
+
+			this.child = child;
+			this.abortCurrent = abort;
+
+			// Attach this before writing. Typst closes stdin as soon as it gives up
+			// on the source, which is the common case while typing, and an unhandled
+			// EPIPE takes the extension host down with it.
+			child.stdin?.on("error", (error: Error) => {
+				logMessage(`Typst preview: the compiler closed its input early: ${error.message}.`, "debug");
+			});
+			child.stdin?.end(source);
+
+			child.stdout?.on("data", (chunk: Buffer) => {
+				outputBytes += chunk.length;
+				if (outputBytes > maxOutputBytes) {
+					abort(new TypstCompileFailure(`Typst produced more than ${maxOutputBytes} bytes.`));
+					return;
+				}
+				output.push(chunk);
+			});
+
+			child.stderr?.on("data", (chunk: Buffer) => {
+				stderr += chunk.toString("utf-8");
+			});
+
+			child.on("error", (error: Error) =>
+				settle(() => reject(new TypstCompileFailure(`Failed to start Typst: ${error.message}.`))),
+			);
+
+			child.on("close", (code: number | null) => {
+				settle(() => {
+					const svg = Buffer.concat(output).toString("utf-8");
+					resolve(code === 0 && svg.length > 0 ? { svg, stderr } : { stderr });
+				});
+			});
+		});
+	}
+
+	/** Stop the running compile, if there is one. */
+	private stopCurrent(): void {
+		this.abortCurrent?.(new vscode.CancellationError());
+	}
+
+	dispose(): void {
+		this.disposed = true;
+		this.stopCurrent();
+	}
+}

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -30,14 +30,19 @@ export class TypstPreviewPanel {
 	/** Whether the page has reported that it is listening. */
 	private ready = false;
 	/**
-	 * The update that arrived before the page was listening.
+	 * The updates that arrived before the page was listening.
 	 *
 	 * The page is loaded asynchronously, and the first compile usually finishes
-	 * first, so without this queue the first image is posted into nothing.
+	 * first, so without this queue the first image is posted into nothing. The
+	 * two kinds are held apart, because an image and the error over it are not
+	 * alternatives: a single slot would drop the image and show a panel that is
+	 * empty behind its error.
 	 */
-	private pending: PreviewMessage | undefined;
+	private pendingImage: PreviewMessage | undefined;
+	private pendingError: PreviewMessage | undefined;
 	private readonly disposables: vscode.Disposable[] = [];
 	private readonly onDidDisposeEmitter = new vscode.EventEmitter<void>();
+	private closed = false;
 
 	/** Fires when the user closes the panel. */
 	readonly onDidDispose = this.onDidDisposeEmitter.event;
@@ -69,17 +74,23 @@ export class TypstPreviewPanel {
 
 		this.disposables.push(
 			panel.webview.onDidReceiveMessage((message: { type?: string }) => {
-				if (message?.type === "initialized") {
-					this.ready = true;
-					if (this.pending) {
-						void panel.webview.postMessage(this.pending);
-						this.pending = undefined;
+				if (message?.type !== "initialized") {
+					return;
+				}
+				this.ready = true;
+				// The image goes first, so the error lands on top of it and not
+				// underneath.
+				for (const queued of [this.pendingImage, this.pendingError]) {
+					if (queued) {
+						void panel.webview.postMessage(queued);
 					}
 				}
+				this.pendingImage = undefined;
+				this.pendingError = undefined;
 			}),
 		);
 
-		this.disposables.push(panel.onDidDispose(() => this.onDidDisposeEmitter.fire()));
+		this.disposables.push(panel.onDidDispose(() => this.handleClosed()));
 	}
 
 	/** Show a compiled image, and describe where it came from. */
@@ -104,16 +115,35 @@ export class TypstPreviewPanel {
 	}
 
 	dispose(): void {
+		// Closing the panel raises `onDidDispose`, so the clean-up runs there and
+		// covers the user closing the tab as well, which never reaches this method.
 		this.panel.dispose();
+	}
+
+	/** Clean up once, whether the panel was closed by the user or by us. */
+	private handleClosed(): void {
+		if (this.closed) {
+			return;
+		}
+		this.closed = true;
+		this.onDidDisposeEmitter.fire();
 		this.onDidDisposeEmitter.dispose();
 		for (const disposable of this.disposables) {
 			disposable.dispose();
 		}
+		this.disposables.length = 0;
 	}
 
 	private post(message: PreviewMessage): void {
 		if (!this.ready) {
-			this.pending = message;
+			if (message.type === "image") {
+				// A compile that succeeded answers the failure before it, so the
+				// queued error is stale and must not replay over the new image.
+				this.pendingImage = message;
+				this.pendingError = undefined;
+			} else {
+				this.pendingError = message;
+			}
 			return;
 		}
 		void this.panel.webview.postMessage(message);

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -5,13 +5,15 @@ import { svgDataUri } from "../../utils/typst/typstSvg";
 /** What the host sends to the page. */
 type PreviewMessage = { type: "image"; uri: string; header: string } | { type: "error"; message: string };
 
-/** The webview options, which are also needed when a panel is restored. */
-function webviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions & vscode.WebviewPanelOptions {
+/**
+ * The webview options, which a restored panel needs set again.
+ *
+ * Panel options such as `retainContextWhenHidden` are not webview options and
+ * cannot be set here, so they are passed where the panel itself is created.
+ */
+function webviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions {
 	return {
 		enableScripts: true,
-		// The panel keeps its image while it is in a background tab, so returning
-		// to it does not need a recompile.
-		retainContextWhenHidden: true,
 		localResourceRoots: [vscode.Uri.joinPath(extensionUri, "assets", "webview")],
 	};
 }
@@ -46,7 +48,12 @@ export class TypstPreviewPanel {
 			TypstPreviewPanel.viewType,
 			"Typst Preview",
 			{ viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
-			webviewOptions(extensionUri),
+			{
+				...webviewOptions(extensionUri),
+				// The panel keeps its image while it is in a background tab, so
+				// returning to it does not need a recompile.
+				retainContextWhenHidden: true,
+			},
 		);
 		return new TypstPreviewPanel(panel, extensionUri);
 	}

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -1,0 +1,167 @@
+import * as vscode from "vscode";
+import { randomBytes } from "node:crypto";
+import { svgDataUri } from "../../utils/typst/typstSvg";
+
+/** What the host sends to the page. */
+type PreviewMessage = { type: "image"; uri: string; header: string } | { type: "error"; message: string };
+
+/** The webview options, which are also needed when a panel is restored. */
+function webviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions & vscode.WebviewPanelOptions {
+	return {
+		enableScripts: true,
+		// The panel keeps its image while it is in a background tab, so returning
+		// to it does not need a recompile.
+		retainContextWhenHidden: true,
+		localResourceRoots: [vscode.Uri.joinPath(extensionUri, "assets", "webview")],
+	};
+}
+
+/**
+ * The panel that shows one compiled Typst block.
+ *
+ * The page is set once and every update travels by `postMessage`, so the image
+ * is replaced without rebuilding the document and losing the scroll position.
+ */
+export class TypstPreviewPanel {
+	static readonly viewType = "quartoWizard.typstPreview";
+
+	/** Whether the page has reported that it is listening. */
+	private ready = false;
+	/**
+	 * The update that arrived before the page was listening.
+	 *
+	 * The page is loaded asynchronously, and the first compile usually finishes
+	 * first, so without this queue the first image is posted into nothing.
+	 */
+	private pending: PreviewMessage | undefined;
+	private readonly disposables: vscode.Disposable[] = [];
+	private readonly onDidDisposeEmitter = new vscode.EventEmitter<void>();
+
+	/** Fires when the user closes the panel. */
+	readonly onDidDispose = this.onDidDisposeEmitter.event;
+
+	/** A new panel, beside the editor and without taking the focus. */
+	static create(extensionUri: vscode.Uri): TypstPreviewPanel {
+		const panel = vscode.window.createWebviewPanel(
+			TypstPreviewPanel.viewType,
+			"Typst Preview",
+			{ viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+			webviewOptions(extensionUri),
+		);
+		return new TypstPreviewPanel(panel, extensionUri);
+	}
+
+	constructor(
+		private readonly panel: vscode.WebviewPanel,
+		extensionUri: vscode.Uri,
+	) {
+		// A restored panel arrives with the options it was serialised with, which
+		// do not include the resource roots, so they are set again here.
+		panel.webview.options = webviewOptions(extensionUri);
+		panel.webview.html = this.html(panel.webview, extensionUri);
+
+		this.disposables.push(
+			panel.webview.onDidReceiveMessage((message: { type?: string }) => {
+				if (message?.type === "initialized") {
+					this.ready = true;
+					if (this.pending) {
+						void panel.webview.postMessage(this.pending);
+						this.pending = undefined;
+					}
+				}
+			}),
+		);
+
+		this.disposables.push(panel.onDidDispose(() => this.onDidDisposeEmitter.fire()));
+	}
+
+	/** Show a compiled image, and describe where it came from. */
+	show(svg: string, header: string): void {
+		this.post({ type: "image", uri: svgDataUri(svg), header });
+	}
+
+	/**
+	 * Report a failure, keeping the last image behind it.
+	 *
+	 * A parse error is the normal state of a block halfway through an edit, so
+	 * clearing the image would make the panel flash empty on almost every
+	 * keystroke.
+	 */
+	showError(message: string): void {
+		this.post({ type: "error", message });
+	}
+
+	/** Bring the panel back to the front. */
+	reveal(): void {
+		this.panel.reveal(vscode.ViewColumn.Beside, true);
+	}
+
+	dispose(): void {
+		this.panel.dispose();
+		this.onDidDisposeEmitter.dispose();
+		for (const disposable of this.disposables) {
+			disposable.dispose();
+		}
+	}
+
+	private post(message: PreviewMessage): void {
+		if (!this.ready) {
+			this.pending = message;
+			return;
+		}
+		void this.panel.webview.postMessage(message);
+	}
+
+	private html(webview: vscode.Webview, extensionUri: vscode.Uri): string {
+		// A fresh nonce per page, so the one inline script is the only script the
+		// policy admits.
+		const nonce = randomBytes(16).toString("base64");
+		const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, "assets", "webview", "typstPreview.css"));
+		const policy = [
+			"default-src 'none'",
+			`img-src ${webview.cspSource} data:`,
+			`style-src ${webview.cspSource}`,
+			`script-src 'nonce-${nonce}'`,
+		].join("; ");
+
+		// The image is rendered into an `img` element and never into the document.
+		// An image is an inert, script-disabled context, and the source of this one
+		// is workspace controlled.
+		return `<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="Content-Security-Policy" content="${policy}" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link href="${styleUri}" rel="stylesheet" />
+		<title>Typst Preview</title>
+	</head>
+	<body>
+		<div id="header"></div>
+		<pre id="error" hidden></pre>
+		<div id="figure"><img id="image" alt="The compiled Typst block." hidden /></div>
+		<script nonce="${nonce}">
+			const host = acquireVsCodeApi();
+			const header = document.getElementById("header");
+			const error = document.getElementById("error");
+			const image = document.getElementById("image");
+
+			window.addEventListener("message", (event) => {
+				const message = event.data;
+				if (message.type === "image") {
+					image.src = message.uri;
+					image.hidden = false;
+					header.textContent = message.header;
+					error.hidden = true;
+				} else if (message.type === "error") {
+					error.textContent = message.message;
+					error.hidden = false;
+				}
+			});
+
+			host.postMessage({ type: "initialized" });
+		</script>
+	</body>
+</html>`;
+	}
+}

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -111,6 +111,9 @@ export class TypstPreviewPanel {
 
 	/** Bring the panel back to the front. */
 	reveal(): void {
+		if (this.closed) {
+			return;
+		}
 		this.panel.reveal(vscode.ViewColumn.Beside, true);
 	}
 
@@ -135,6 +138,13 @@ export class TypstPreviewPanel {
 	}
 
 	private post(message: PreviewMessage): void {
+		if (this.closed) {
+			// A compile can outlive the panel: it runs for up to the timeout, and
+			// the user can close the tab meanwhile. The result is stale, and posting
+			// to a disposed webview throws, which would turn a discarded result into
+			// a failed command.
+			return;
+		}
 		if (!this.ready) {
 			if (message.type === "image") {
 				// A compile that succeeded answers the failure before it, so the

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -1,0 +1,74 @@
+import * as assert from "assert";
+import * as path from "node:path";
+import { typstBinaryCandidate, probeTypstBinary, type TypstProbe } from "../../providers/typstPreview/typstCompiler";
+
+const BIN = path.join("/opt", "quarto", "bin");
+
+/**
+ * A probe whose only real input is the set of paths that exist.
+ *
+ * Resolution is pure apart from the two calls injected here, so a test can
+ * describe a whole platform in one object.
+ */
+function probe(overrides: Partial<TypstProbe> & { present?: string[] } = {}): TypstProbe {
+	const present = new Set(overrides.present ?? []);
+	return {
+		binPath: overrides.binPath ?? (async () => BIN),
+		exists: overrides.exists ?? ((candidate: string) => present.has(candidate)),
+		platform: overrides.platform ?? "darwin",
+		arch: overrides.arch ?? "arm64",
+	};
+}
+
+suite("Typst Compiler Test Suite", () => {
+	suite("typstBinaryCandidate", () => {
+		test("Should map arm64 to aarch64", () => {
+			assert.strictEqual(typstBinaryCandidate(BIN, "darwin", "arm64"), path.join(BIN, "tools", "aarch64", "typst"));
+		});
+
+		test("Should map every other architecture to x86_64", () => {
+			assert.strictEqual(typstBinaryCandidate(BIN, "linux", "x64"), path.join(BIN, "tools", "x86_64", "typst"));
+		});
+
+		test("Should use the architecture directory on Windows as well", () => {
+			// Typst is not pandoc. Quarto resolves pandoc flat on Windows, and Typst
+			// through the architecture directory on every platform, at
+			// `src/core/typst.ts:20`. The packaging step writes it there too.
+			assert.strictEqual(typstBinaryCandidate(BIN, "win32", "x64"), path.join(BIN, "tools", "x86_64", "typst.exe"));
+		});
+	});
+
+	suite("probeTypstBinary", () => {
+		test("Should return the candidate when it is present", async () => {
+			const candidate = path.join(BIN, "tools", "aarch64", "typst");
+			assert.strictEqual(await probeTypstBinary(probe({ present: [candidate] })), candidate);
+		});
+
+		test("Should return undefined when the candidate is absent", async () => {
+			// There is no fallback route, so a layout Quarto does not produce leaves
+			// the feature inert rather than reaching for a binary somewhere else.
+			assert.strictEqual(await probeTypstBinary(probe({ present: [path.join(BIN, "tools", "typst")] })), undefined);
+		});
+
+		test("Should return undefined when Quarto is unavailable", async () => {
+			// No Quarto extension, no API, or an API that reports unavailable. The
+			// feature is inert, and reading it must not throw.
+			const found = await probeTypstBinary(probe({ binPath: async () => undefined, present: [] }));
+			assert.strictEqual(found, undefined);
+		});
+
+		test("Should probe exactly one path", async () => {
+			const attempted: string[] = [];
+			const found = await probeTypstBinary(
+				probe({
+					exists: (candidate: string) => {
+						attempted.push(candidate);
+						return false;
+					},
+				}),
+			);
+			assert.strictEqual(found, undefined);
+			assert.deepStrictEqual(attempted, [path.join(BIN, "tools", "aarch64", "typst")]);
+		});
+	});
+});

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -181,15 +181,21 @@ suite("Typst Compiler Test Suite", () => {
 			// iteration fills standard error just as fast. The run still finishes,
 			// because the diagnostics are not the product and the head carries the
 			// first one.
+			//
+			// The child writes four megabytes. The bound asserted here is the limit
+			// plus the one chunk that crosses it, and a chunk is bounded by the pipe,
+			// so how the writes happen to arrive cannot decide the outcome. Asserting
+			// the limit itself would fail wherever the whole stream lands in a single
+			// chunk, which is what the runner does and a developer machine does not.
 			const compiler = new TypstCompiler(RUNTIME, { maxOutputBytes: 64 });
 			try {
 				const result = await compiler.compile(
 					"",
-					run("for (let i = 0; i < 40; i++) { process.stderr.write('error: '.repeat(8) + '\\n'); }"),
+					run("for (let i = 0; i < 4096; i++) { process.stderr.write('error: '.repeat(146) + '\\n'); }"),
 					never,
 				);
-				assert.ok(result.stderr.length > 0, "the head of the output is kept");
-				assert.ok(result.stderr.length < 2240, `bounded, got ${result.stderr.length}`);
+				assert.ok(result.stderr.startsWith("error: "), "the head of the output is kept");
+				assert.ok(result.stderr.length < 1024 * 1024, `bounded, got ${result.stderr.length}`);
 			} finally {
 				compiler.dispose();
 			}

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -176,6 +176,25 @@ suite("Typst Compiler Test Suite", () => {
 			}
 		});
 
+		test("Should stop collecting standard error past the limit", async () => {
+			// A cap on the image alone is not a cap: a loop that reports once per
+			// iteration fills standard error just as fast. The run still finishes,
+			// because the diagnostics are not the product and the head carries the
+			// first one.
+			const compiler = new TypstCompiler(RUNTIME, { maxOutputBytes: 64 });
+			try {
+				const result = await compiler.compile(
+					"",
+					run("for (let i = 0; i < 40; i++) { process.stderr.write('error: '.repeat(8) + '\\n'); }"),
+					never,
+				);
+				assert.ok(result.stderr.length > 0, "the head of the output is kept");
+				assert.ok(result.stderr.length < 2240, `bounded, got ${result.stderr.length}`);
+			} finally {
+				compiler.dispose();
+			}
+		});
+
 		test("Should reject the previous run when a second one supersedes it", async () => {
 			const compiler = new TypstCompiler(RUNTIME);
 			try {

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -1,8 +1,39 @@
 import * as assert from "assert";
+import * as vscode from "vscode";
 import * as path from "node:path";
-import { typstBinaryCandidate, probeTypstBinary, type TypstProbe } from "../../providers/typstPreview/typstCompiler";
+import {
+	typstBinaryCandidate,
+	probeTypstBinary,
+	TypstCompiler,
+	TypstCompileFailure,
+	type TypstProbe,
+} from "../../providers/typstPreview/typstCompiler";
 
 const BIN = path.join("/opt", "quarto", "bin");
+
+/**
+ * A stand-in for the compiler binary.
+ *
+ * The lifecycle of `compile` is about processes and not about Typst, so these
+ * tests drive it with this runtime instead. Continuous integration has no Quarto
+ * and therefore no Typst, so a test that needed the real binary could never run
+ * there, and this is the code most worth covering in the whole slice.
+ */
+const RUNTIME = process.execPath;
+
+/** Arguments that run one expression in a child process. */
+function run(source: string): string[] {
+	return ["-e", source];
+}
+
+/** A token that is already cancelled. */
+function cancelled(): vscode.CancellationToken {
+	const source = new vscode.CancellationTokenSource();
+	source.cancel();
+	return source.token;
+}
+
+const never = new vscode.CancellationTokenSource().token;
 
 /**
  * A probe whose only real input is the set of paths that exist.
@@ -65,6 +96,136 @@ suite("Typst Compiler Test Suite", () => {
 			);
 			assert.strictEqual(found, undefined);
 			assert.deepStrictEqual(attempted, [path.join(BIN, "tools", "aarch64", "typst")]);
+		});
+	});
+
+	suite("TypstCompiler.compile", () => {
+		test("Should resolve with the output of a run that produced one", async () => {
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				const result = await compiler.compile("", run("process.stdout.write('<svg/>')"), never);
+				assert.strictEqual(result.svg, "<svg/>");
+				assert.strictEqual(result.stderr, "");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should resolve without an image when the run failed", async () => {
+			// A failed compile is a result the caller renders, not an exception.
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				const result = await compiler.compile("", run("process.stderr.write('error: no'); process.exit(1)"), never);
+				assert.strictEqual(result.svg, undefined);
+				assert.strictEqual(result.stderr, "error: no");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should write the source to standard input", async () => {
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				const result = await compiler.compile(
+					"the source",
+					run("process.stdin.on('data', (d) => process.stdout.write(d))"),
+					never,
+				);
+				assert.strictEqual(result.svg, "the source");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should keep a multi-byte character split across two chunks", async () => {
+			// Typst writes its position line starting with `┌─`. Decoding each chunk
+			// as it arrives would cut that character in half and lose the position.
+			const compiler = new TypstCompiler(RUNTIME);
+			const halves =
+				"const b = Buffer.from('┌─ <stdin>:1:0'); process.stderr.write(b.subarray(0, 2)); setTimeout(() => { process.stderr.write(b.subarray(2)); process.exit(1); }, 20)";
+			try {
+				const result = await compiler.compile("", run(halves), never);
+				assert.strictEqual(result.stderr, "┌─ <stdin>:1:0");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should reject when the run outlives the timeout", async () => {
+			const compiler = new TypstCompiler(RUNTIME, { timeoutMs: 100 });
+			try {
+				await assert.rejects(
+					compiler.compile("", run("setTimeout(() => {}, 10000)"), never),
+					(error: unknown) =>
+						error instanceof TypstCompileFailure && /did not finish within 100 ms/.test(String(error)),
+				);
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should reject when the run produces more than the limit", async () => {
+			const compiler = new TypstCompiler(RUNTIME, { maxOutputBytes: 64 });
+			try {
+				await assert.rejects(
+					compiler.compile("", run("process.stdout.write('x'.repeat(4096))"), never),
+					(error: unknown) => error instanceof TypstCompileFailure && /more than 64 bytes/.test(String(error)),
+				);
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should reject the previous run when a second one supersedes it", async () => {
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				const first = compiler.compile("", run("setTimeout(() => {}, 10000)"), never);
+				const second = compiler.compile("", run("process.stdout.write('<svg/>')"), never);
+				await assert.rejects(first, (error: unknown) => error instanceof vscode.CancellationError);
+				assert.strictEqual((await second).svg, "<svg/>");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should reject when the token is cancelled", async () => {
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				await assert.rejects(
+					compiler.compile("", run("setTimeout(() => {}, 10000)"), cancelled()),
+					(error: unknown) => error instanceof vscode.CancellationError,
+				);
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should reject when the binary is not there", async () => {
+			const compiler = new TypstCompiler(path.join(BIN, "tools", "aarch64", "typst"));
+			try {
+				await assert.rejects(
+					compiler.compile("", [], never),
+					(error: unknown) => error instanceof TypstCompileFailure && /Failed to start Typst/.test(String(error)),
+				);
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should refuse to compile once disposed", async () => {
+			const compiler = new TypstCompiler(RUNTIME);
+			compiler.dispose();
+			await assert.rejects(
+				compiler.compile("", run("process.stdout.write('<svg/>')"), never),
+				(error: unknown) => error instanceof TypstCompileFailure && /disposed/.test(String(error)),
+			);
+		});
+
+		test("Should stop the running child when disposed", async () => {
+			const compiler = new TypstCompiler(RUNTIME);
+			const running = compiler.compile("", run("setTimeout(() => {}, 10000)"), never);
+			compiler.dispose();
+			await assert.rejects(running, (error: unknown) => error instanceof vscode.CancellationError);
 		});
 	});
 });

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -44,12 +44,6 @@ suite("Typst Compiler Test Suite", () => {
 			assert.strictEqual(await probeTypstBinary(probe({ present: [candidate] })), candidate);
 		});
 
-		test("Should return undefined when the candidate is absent", async () => {
-			// There is no fallback route, so a layout Quarto does not produce leaves
-			// the feature inert rather than reaching for a binary somewhere else.
-			assert.strictEqual(await probeTypstBinary(probe({ present: [path.join(BIN, "tools", "typst")] })), undefined);
-		});
-
 		test("Should return undefined when Quarto is unavailable", async () => {
 			// No Quarto extension, no API, or an API that reports unavailable. The
 			// feature is inert, and reading it must not throw.
@@ -57,7 +51,9 @@ suite("Typst Compiler Test Suite", () => {
 			assert.strictEqual(found, undefined);
 		});
 
-		test("Should probe exactly one path", async () => {
+		test("Should probe exactly one path, and give up when it is absent", async () => {
+			// There is no fallback route, so a layout Quarto does not produce leaves
+			// the feature inert rather than reaching for a binary somewhere else.
 			const attempted: string[] = [];
 			const found = await probeTypstBinary(
 				probe({

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -70,13 +70,15 @@ suite("Typst Diagnostics Test Suite", () => {
 		assert.deepStrictEqual(parseTypstStderr(stderr, 0), []);
 	});
 
-	test("Should keep a diagnostic that carries no position", () => {
+	test("Should keep a diagnostic that carries no position, and give it none", () => {
 		// A failure to read the input or to fetch a package has nothing to point
 		// at. Dropping it leaves a caller that counts diagnostics reporting a
-		// clean block for a compile that produced no image at all.
+		// clean block for a compile that produced no image at all. Giving it the
+		// start of the body instead is worse than saying nothing: the caller then
+		// asserts a position, and marks a character that is not at fault.
 		const stderr = "error: failed to download package @preview/example:0.1.0\n";
 		assert.deepStrictEqual(parseTypstStderr(stderr, 0), [
-			{ line: 0, column: 0, message: "failed to download package @preview/example:0.1.0", severity: "error" },
+			{ message: "failed to download package @preview/example:0.1.0", severity: "error" },
 		]);
 	});
 

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { parseTypstStderr } from "../../utils/typst/typstDiagnostics";
+import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 
 // Both samples below are the real output of
 // `typst compile --format svg - -`, captured from the binary that ships inside
@@ -83,5 +83,28 @@ suite("Typst Diagnostics Test Suite", () => {
 	test("Should return nothing for output that holds no diagnostic", () => {
 		assert.deepStrictEqual(parseTypstStderr("", 0), []);
 		assert.deepStrictEqual(parseTypstStderr("<svg></svg>", 0), []);
+	});
+
+	suite("typstMessages", () => {
+		test("Should read a heading that parseTypstStderr drops", () => {
+			// The position names another file, so there is nothing in the block to
+			// mark and `parseTypstStderr` reports nothing. The message survives here,
+			// which is what lets a caller avoid claiming a failed compile was silent.
+			const stderr = ["error: file not found", "  ┌─ preamble.typ:4:2", "  │", "4 │ #x", ""].join("\n");
+			assert.deepStrictEqual(parseTypstStderr(stderr, 0), []);
+			assert.deepStrictEqual(typstMessages(stderr), [{ severity: "error", message: "file not found" }]);
+		});
+
+		test("Should read every heading in order", () => {
+			const stderr = "warning: unused\n  ┌─ <stdin>:1:0\nerror: expected expression\n  ┌─ <stdin>:2:4\n";
+			assert.deepStrictEqual(typstMessages(stderr), [
+				{ severity: "warning", message: "unused" },
+				{ severity: "error", message: "expected expression" },
+			]);
+		});
+
+		test("Should return nothing for output that holds no heading", () => {
+			assert.deepStrictEqual(typstMessages("<svg></svg>"), []);
+		});
 	});
 });

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -29,6 +29,14 @@ suite("Typst Preview Messages Test Suite", () => {
 			);
 		});
 
+		test("Should claim no position when Typst gave none", () => {
+			// A package that would not download is not about a place in the block.
+			// Reporting "line 1, column 1" would assert a position that does not
+			// exist and mark a character that is not at fault.
+			const stderr = "error: failed to download package @preview/example:0.1.0\n";
+			assert.strictEqual(errorText(stderr, 1), "error: failed to download package @preview/example:0.1.0");
+		});
+
 		test("Should report a failure that points at another file", () => {
 			// Every diagnostic is dropped by the mapping, because none of them names
 			// a position in this block. Reporting nothing would contradict both the

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -1,0 +1,44 @@
+import * as assert from "assert";
+import { errorText } from "../../providers/typstPreview";
+
+/** One diagnostic as Typst writes it, on the two lines it uses. */
+function diagnostic(severity: string, message: string, line: number, column: number, file = "<stdin>"): string {
+	return `${severity}: ${message}\n  ┌─ ${file}:${line}:${column}\n  │\n`;
+}
+
+suite("Typst Preview Messages Test Suite", () => {
+	suite("errorText", () => {
+		test("Should say which line count it is reporting", () => {
+			// The panel header counts document lines, so a bare "line 2" reads as a
+			// document line and points at the wrong text.
+			const text = errorText(diagnostic("error", "expected expression", 2, 4), 1);
+			assert.strictEqual(text, "error at line 1, column 5 of the block: expected expression");
+		});
+
+		test("Should show the error rather than a warning above it", () => {
+			// Headlining a failed compile as a warning misstates why no image came
+			// back, and Typst puts its warnings first.
+			const stderr = diagnostic("warning", "unused variable", 2, 0) + diagnostic("error", "unknown variable", 3, 6);
+			assert.strictEqual(errorText(stderr, 1), "error at line 2, column 7 of the block: unknown variable");
+		});
+
+		test("Should fall back to the only warning when there is no error", () => {
+			assert.strictEqual(
+				errorText(diagnostic("warning", "unused variable", 2, 0), 1),
+				"warning at line 1, column 1 of the block: unused variable",
+			);
+		});
+
+		test("Should report a failure that points at another file", () => {
+			// Every diagnostic is dropped by the mapping, because none of them names
+			// a position in this block. Reporting nothing would contradict both the
+			// log and the missing image.
+			const stderr = diagnostic("error", "file not found", 4, 2, "preamble.typ");
+			assert.strictEqual(errorText(stderr, 1), "error outside this block: file not found");
+		});
+
+		test("Should say so when the compiler reported nothing at all", () => {
+			assert.strictEqual(errorText("", 1), "Typst produced no image and reported nothing.");
+		});
+	});
+});

--- a/src/test/suite/typstPreviewPanel.test.ts
+++ b/src/test/suite/typstPreviewPanel.test.ts
@@ -1,0 +1,35 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { TypstPreviewPanel } from "../../providers/typstPreview/typstPreviewPanel";
+
+/** The installed copy of this extension, which owns the webview assets. */
+function extensionUri(): vscode.Uri {
+	const extension = vscode.extensions.getExtension("mcanouil.quarto-wizard");
+	assert.ok(extension, "the extension under test must be present");
+	return extension.extensionUri;
+}
+
+suite("Typst Preview Panel Test Suite", () => {
+	test("Should report that it was closed, once", () => {
+		const panel = TypstPreviewPanel.create(extensionUri());
+		let closed = 0;
+		panel.onDidDispose(() => {
+			closed++;
+		});
+		panel.dispose();
+		panel.dispose();
+		assert.strictEqual(closed, 1);
+	});
+
+	test("Should ignore an update that arrives after it was closed", () => {
+		// A compile runs for up to the timeout and the user can close the tab
+		// meanwhile. Posting to a disposed webview throws, and the throw would
+		// travel out of the command as a rejected promise rather than being the
+		// stale result it is.
+		const panel = TypstPreviewPanel.create(extensionUri());
+		panel.dispose();
+		assert.doesNotThrow(() => panel.show("<svg/>", "header"));
+		assert.doesNotThrow(() => panel.showError("error at line 1"));
+		assert.doesNotThrow(() => panel.reveal());
+	});
+});

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -4,10 +4,17 @@
  * Both fields are zero-based, which is what a VS Code position takes.
  */
 export interface TypstDiagnostic {
-	/** Zero-based line within the block body. */
-	line: number;
+	/**
+	 * Zero-based line within the block body.
+	 *
+	 * Absent when Typst reported no position at all, which happens when the
+	 * failure is not about a place in the source: a package that would not
+	 * download, or an input it could not read. The two position fields are
+	 * always both present or both absent.
+	 */
+	line?: number;
 	/** Zero-based column. */
-	column: number;
+	column?: number;
 	/** The message, without its severity prefix. */
 	message: string;
 	severity: "error" | "warning";
@@ -79,8 +86,10 @@ export function parseTypstStderr(stderr: string, injectedLines: number): TypstDi
 		if (position === null) {
 			// A failure to read the input, or to fetch a package, has nothing to
 			// point at. It still has to be reported: a caller that counts
-			// diagnostics would otherwise call a failed compile a clean block.
-			diagnostics.push({ line: 0, column: 0, message: heading[2], severity });
+			// diagnostics would otherwise call a failed compile a clean block. It is
+			// reported without a position, because giving it the start of the body
+			// would mark a character that has nothing to do with the failure.
+			diagnostics.push({ message: heading[2], severity });
 			continue;
 		}
 

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -27,6 +27,26 @@ const HEADING = /^(error|warning): (.+)$/;
 const POSITION = /^\s*┌─\s*(\S+):(\d+):(\d+)/;
 
 /**
+ * Every heading Typst wrote, with no position and no mapping.
+ *
+ * `parseTypstStderr` skips a diagnostic that names a file other than `<stdin>`,
+ * because there is nothing in the block to mark. That can leave a failed
+ * compile with no mapped diagnostic at all, and a caller which then says
+ * nothing was reported contradicts both the log and the fact that no image
+ * came back. Reading the headings gives it something true to say.
+ */
+export function typstMessages(stderr: string): { severity: "error" | "warning"; message: string }[] {
+	const messages: { severity: "error" | "warning"; message: string }[] = [];
+	for (const line of stderr.split(/\r?\n/)) {
+		const heading = HEADING.exec(line);
+		if (heading !== null) {
+			messages.push({ severity: heading[1] as "error" | "warning", message: heading[2] });
+		}
+	}
+	return messages;
+}
+
+/**
  * Every diagnostic in a Typst run, mapped onto the block body.
  *
  * Typst writes the message and the position on separate lines:


### PR DESCRIPTION
A `Quarto Wizard: Preview Typst Block` command compiles the plain ```` ```typst ```` block under the cursor and shows it in a webview panel beside the editor. This is the first slice of the Typst preview: a raw `{=typst}` block needs the blocks before it and a `{typst}` cell needs its options resolved, so both report that they are not previewed yet rather than showing an image the render would not produce.

This is the first `child_process` in the repository.

The binary is the Typst that ships inside Quarto, resolved by one route with no fallback ladder. `getQuartoPath()` returns the bin directory, so the probe is `<bin>/tools/<arch>/typst`, with `.exe` on Windows. That is not the pandoc rule: Quarto resolves pandoc flat on Windows and Typst through the architecture directory on every platform, at `src/core/typst.ts:20` in `quarto-cli`, and its packaging writes the binary to exactly that path. Probing flat first would have missed on every platform, and skipping the architecture directory on Windows would have left the feature permanently inert there.

The compiler uses `spawn` with an argv array and `shell: false`, never `exec` and never a shell, because the arguments carry workspace-controlled strings. It uses `spawn` rather than `execFile` because the 1 MiB `maxBuffer` of `execFile` is routinely exceeded by Typst glyph outlines, and raising it to `Infinity` removes the safety valve without replacing it. Output is accumulated with a running total against an 8 MiB limit, on both streams. One child runs at a time, superseded with `SIGTERM` and a two second `SIGKILL` timer. The stdin error handler is attached before the write, because Typst closes stdin on the first parse error, which is the common case while typing, and an unhandled `EPIPE` takes the extension host down.

The panel renders into an `img` element with a `data:` URI and never into the document, since an image is an inert, script-disabled context and the source is workspace controlled. The content security policy admits one nonced inline script and no other. The page is set once and updates travel by `postMessage`, with the page reporting when it is listening so the first update is never dropped. A serializer recompiles after a window reload rather than restoring a stale image.

The feature is inert when the workspace is untrusted or the binary is absent: one debug line per attempt, one message per session, and no surface offered. Continuous integration never spawns Typst, because a runner has no Quarto extension and `getQuartoVersionInfo()` reports unavailable there. The compiler lifecycle is covered by tests driven with `process.execPath` instead, so timeout, output limit, supersession, cancellation, a missing binary and both dispose paths run on every platform.