### PR TITLE
fix: cap fence indent and read blockquote fences

### DIFF
--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -45,6 +45,22 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
 		});
 
+		test("Should ignore a fence indented by four spaces at the top level", () => {
+			// Four spaces at the top level is an indented code block, so this is a
+			// documented example of a Typst block and not one. Compiling it would
+			// run source the author wrote to be read.
+			const text = "before\n\n    ```typst\n    #a\n    ```\n";
+			assert.deepStrictEqual(findTypstBlocks(text), []);
+		});
+
+		test("Should remove the blockquote marker from every body line", () => {
+			// Typst is whitespace sensitive and knows nothing about Markdown, so a
+			// marker left on a body line is a syntax error in the compiled source.
+			const found = findTypstBlocks("> ```typst\n> #let a = 1\n> #a\n> ```\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
+		});
+
 		test("Should read an unclosed block to the end of the text", () => {
 			const found = findTypstBlocks("```typst\n#let a = 1\n");
 			assert.strictEqual(found.length, 1);

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -61,6 +61,31 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
 		});
 
+		test("Should remove the fence indent by column, not by character", () => {
+			// The fence is indented by one tab, which is four columns. A body line
+			// indented by a tab keeps whatever follows it, so four spaces of Typst
+			// indent survive. Counting characters instead would eat the tab and
+			// three of those spaces.
+			const found = findTypstBlocks("1. Step\n\n\t```typst\n\t    #x\n\t```\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "    #x\n");
+		});
+
+		test("Should read a blockquoted cell with its options", () => {
+			// The option reader sees the body after the markers are removed, which is
+			// the one path where the two rules meet.
+			const found = findTypstBlocks("> ```{typst}\n> //| width: 3\n> #x\n> ```\n");
+			assert.strictEqual(found.length, 1);
+			assert.deepStrictEqual(found[0].options, { width: "3" });
+			assert.strictEqual(found[0].code, "#x\n");
+		});
+
+		test("Should keep CRLF line endings in a blockquoted block", () => {
+			const found = findTypstBlocks("> ```typst\r\n> #a\r\n> ```\r\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "#a\r\n");
+		});
+
 		test("Should keep a marker the blockquote itself does not consume", () => {
 			// The fence sits one quote deep, so Pandoc hands Typst the body with one
 			// marker removed and the second one intact. Removing both would delete a

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -61,6 +61,15 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
 		});
 
+		test("Should keep a marker the blockquote itself does not consume", () => {
+			// The fence sits one quote deep, so Pandoc hands Typst the body with one
+			// marker removed and the second one intact. Removing both would delete a
+			// character the author wrote.
+			const found = findTypstBlocks("> ```typst\n> > #x\n> ```\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "> #x\n");
+		});
+
 		test("Should read an unclosed block to the end of the text", () => {
 			const found = findTypstBlocks("```typst\n#let a = 1\n");
 			assert.strictEqual(found.length, 1);

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -499,6 +499,45 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "> > x = 1\n> > ~~~");
 		});
 
+		test("should not close a top-level block on a quoted fence line", () => {
+			// Inside a fenced block every line is content, and container parsing does
+			// not resume until the block closes. Stripping the marker first and then
+			// testing for a closing fence closes the block on its own content.
+			const text = "```\n> ```\nstill code\n```\nafter";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.slice(ranges[0].start, ranges[0].end).includes("still code"));
+		});
+
+		test("should not close a quoted block on a more deeply quoted fence line", () => {
+			const text = "> ```\n> > ```\n> still code\n> ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.slice(ranges[0].start, ranges[0].end).includes("still code"));
+		});
+
+		test("should detect a blockquoted fence with CRLF line endings", () => {
+			const text = "> ```{r}\r\n> x <- 1\r\n> ```\r\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "> x <- 1\r\n> ```\r");
+		});
+
+		test("should detect a tab-indented fence inside a list item", () => {
+			// A tab advances to the next multiple of four, so this fence sits at
+			// column four, one past the content column of `1. `. It is live, and
+			// losing it is the failure direction this reader is meant to avoid.
+			const text = "1. Step one\n\n\t```{r}\n\tx = 1\n\t```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
+		test("should not treat a tab-indented fence at the top level as a fence", () => {
+			const text = "before\n\n\t```{r}\n\tx = 1\n\t```\n";
+			assert.deepStrictEqual(getCodeBlockRanges(text), []);
+		});
+
 		test("should end a blockquoted block where the quote ends", () => {
 			// A line without the marker ends the blockquote, and the code block goes
 			// with it. Lazy continuation applies to a paragraph and not to the

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -533,6 +533,23 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
 		});
 
+		test("should open a container for a list item with nothing on its line", () => {
+			// `1.` alone is a valid empty item, and its content starts one column
+			// past the marker. Reading it as ordinary prose drops the allowance and
+			// loses the fence indented under it.
+			const text = "1.\n\n    ```{r}\n    x = 1\n    ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
+		test("should open a container for a list item written with a tab", () => {
+			const text = "-\titem\n\n    ```{r}\n    x = 1\n    ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
 		test("should not treat a tab-indented fence at the top level as a fence", () => {
 			const text = "before\n\n\t```{r}\n\tx = 1\n\t```\n";
 			assert.deepStrictEqual(getCodeBlockRanges(text), []);

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -543,6 +543,25 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
 		});
 
+		test("should open a container for an empty item with trailing whitespace", () => {
+			// An editor leaves a space after the marker as a matter of course, so
+			// this shape is at least as common as the bare marker.
+			const text = "1. \n\n    ```{r}\n    x = 1\n    ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
+		test("should keep the list indent across a lazy continuation line", () => {
+			// The second line continues the paragraph of the item, so the item is
+			// still open and the fence under it is live. Reading the continuation as
+			// a new block at the margin closes the item and loses the fence.
+			const text = "1. Step\ncontinuation\n\n    ```{r}\n    x = 1\n    ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
 		test("should open a container for a list item written with a tab", () => {
 			const text = "-\titem\n\n    ```{r}\n    x = 1\n    ```\n";
 			const ranges = getCodeBlockRanges(text);

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -451,6 +451,63 @@ suite("YAML Position Utils Test Suite", () => {
 			const body = text.substring(ranges[0].start, ranges[0].end);
 			assert.ok(body.includes("x = 1"));
 		});
+
+		test("should not treat a four-space indented fence at the top level as a fence", () => {
+			// Four spaces at the top level is an indented code block, so the fence is
+			// literal text. Treating it as live is how a documented example of a
+			// fence ends up linted, and compiled, as if it were code.
+			const text = "before\n\n    ```{r}\n    x = 1\n    ```\n\nafter";
+			assert.deepStrictEqual(getCodeBlockRanges(text), []);
+		});
+
+		test("should detect a three-space indented fence at the top level", () => {
+			const text = "before\n\n   ```{r}\n   x = 1\n   ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
+		test("should detect a four-space indented fence inside an ordered list item", () => {
+			// `1. ` opens an item whose content starts at column three, so a fence at
+			// column four is indented by one relative to the item and is live. This
+			// is the ordinary shape of a Quarto document, so the indent limit is
+			// measured against the open item and not against the document.
+			const text = "1. Step one\n\n    ```{r}\n    x = 1\n    ```\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.ok(text.substring(ranges[0].start, ranges[0].end).includes("x = 1"));
+		});
+
+		test("should stop allowing the list indent after the list ends", () => {
+			const text = "- item\n\nback at the margin\n\n    ```{r}\n    x = 1\n    ```\n";
+			assert.deepStrictEqual(getCodeBlockRanges(text), []);
+		});
+
+		test("should detect a fenced code block inside a blockquote", () => {
+			// Pandoc reads this as a real code block, and every reader built on this
+			// function used to skip it entirely.
+			const text = "> ```{r}\n> x <- 1\n> ```\nafter";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "> x <- 1\n> ```");
+		});
+
+		test("should detect a fenced code block inside a nested blockquote", () => {
+			const text = "> > ~~~python\n> > x = 1\n> > ~~~\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "> > x = 1\n> > ~~~");
+		});
+
+		test("should end a blockquoted block where the quote ends", () => {
+			// A line without the marker ends the blockquote, and the code block goes
+			// with it. Lazy continuation applies to a paragraph and not to the
+			// content of a code block.
+			const text = "> ```\n> code\nafter\n";
+			const ranges = getCodeBlockRanges(text);
+			assert.strictEqual(ranges.length, 1);
+			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "> code");
+		});
 	});
 
 	suite("isInCodeBlockRange", () => {

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -5,6 +5,7 @@ import {
 	closingFenceRegExp,
 	stripBlockquoteMarkers,
 	stripCarriageReturn,
+	removeIndentColumns,
 } from "../yamlPosition";
 
 /**
@@ -110,12 +111,12 @@ function blockBody(
 	const lastLine = stripCarriageReturn(slice.slice(lastNewline + 1));
 	const body = closing.test(unquote(lastLine)) ? slice.slice(0, lastNewline + 1) : slice;
 
-	// Spaces and tabs only. A carriage return is part of the line ending on a
-	// CRLF document, and stripping it here would corrupt the source.
-	const leading = new RegExp(`^[ \\t]{0,${indent}}`);
+	// The indent comes off by column, because the fence owns a number of columns
+	// and not a number of characters. A carriage return is part of the line
+	// ending on a CRLF document, and is left alone.
 	return body
 		.split("\n")
-		.map((line) => unquote(line).replace(leading, ""))
+		.map((line) => removeIndentColumns(unquote(line), indent))
 		.join("\n");
 }
 

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -1,4 +1,10 @@
-import { getCodeBlockRanges, getYamlFrontMatterRange, OPENING_FENCE, closingFenceRegExp } from "../yamlPosition";
+import {
+	getCodeBlockRanges,
+	getYamlFrontMatterRange,
+	parseOpeningFence,
+	closingFenceRegExp,
+	stripBlockquoteMarkers,
+} from "../yamlPosition";
 
 /**
  * The three fence kinds that carry Typst source in a Quarto document.
@@ -38,7 +44,7 @@ export interface TypstBlock {
 	fenceStart: number;
 	/** Zero-based line number of the opening fence. */
 	fenceLine: number;
-	/** Indent of the opening fence, in characters. */
+	/** Indent of the opening fence, measured after any blockquote markers. */
 	indent: number;
 }
 
@@ -76,23 +82,32 @@ function classifyInfoString(info: string): TypstBlockKind | undefined {
 }
 
 /**
- * The body of a block, without its closing fence and without the fence indent.
+ * The body of a block, without its closing fence, its blockquote markers or the
+ * fence indent.
  *
- * Typst is whitespace sensitive, so an indented fence must not leave its indent
- * on every line of the compiled source.
+ * Typst is whitespace sensitive and knows nothing about Markdown, so neither an
+ * indent nor a quote marker may survive into the compiled source.
  */
-function blockBody(text: string, bodyStart: number, bodyEnd: number, fence: string, indent: number): string {
+function blockBody(
+	text: string,
+	bodyStart: number,
+	bodyEnd: number,
+	fence: string,
+	indent: number,
+	quoted: boolean,
+): string {
 	// Cut at the start of the closing fence line rather than dropping that line
 	// after a split, which would take the newline of the line above with it and
 	// glue the last body line to whatever follows it.
 	const slice = text.slice(bodyStart, bodyEnd);
 	const lastNewline = slice.lastIndexOf("\n");
 	const closing = closingFenceRegExp(fence);
-	const body = closing.test(stripCarriageReturn(slice.slice(lastNewline + 1)))
+	const lastLine = stripCarriageReturn(slice.slice(lastNewline + 1));
+	const body = closing.test(quoted ? stripBlockquoteMarkers(lastLine).content : lastLine)
 		? slice.slice(0, lastNewline + 1)
 		: slice;
 
-	if (indent === 0) {
+	if (indent === 0 && !quoted) {
 		return body;
 	}
 	// Spaces and tabs only. A carriage return is part of the line ending on a
@@ -100,7 +115,7 @@ function blockBody(text: string, bodyStart: number, bodyEnd: number, fence: stri
 	const leading = new RegExp(`^[ \\t]{0,${indent}}`);
 	return body
 		.split("\n")
-		.map((line) => line.replace(leading, ""))
+		.map((line) => (quoted ? stripBlockquoteMarkers(line).content : line).replace(leading, ""))
 		.join("\n");
 }
 
@@ -223,12 +238,13 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 
 	for (const range of getCodeBlockRanges(source)) {
 		const fence = fenceLineRange(source, range.start);
-		const opening = OPENING_FENCE.exec(stripCarriageReturn(source.slice(fence.start, fence.end)));
-		if (opening === null) {
+		const quoted = stripBlockquoteMarkers(stripCarriageReturn(source.slice(fence.start, fence.end)));
+		const opening = parseOpeningFence(quoted.content);
+		if (opening === undefined) {
 			continue;
 		}
 
-		const kind = classifyInfoString(opening[3]);
+		const kind = classifyInfoString(opening.info);
 		if (kind === undefined) {
 			continue;
 		}
@@ -239,8 +255,8 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			}
 		}
 
-		const indent = opening[1].length;
-		const body = blockBody(source, range.start, range.end, opening[2], indent);
+		const indent = opening.indent;
+		const body = blockBody(source, range.start, range.end, opening.fence, indent, quoted.depth > 0);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
 		// ordinary Typst comment, so the body passes through untouched.
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -90,12 +90,16 @@ function blockBody(
 	bodyEnd: number,
 	fence: string,
 	indent: number,
-	quoted: boolean,
+	quoteDepth: number,
 ): string {
-	// Chosen once. Whether the block sits in a blockquote is a property of the
-	// fence, not of each line, so testing it per line says the same thing many
-	// times and invites the two uses below to drift apart.
-	const unquote = quoted ? (line: string) => stripBlockquoteMarkers(line).content : (line: string) => line;
+	// Chosen once. How deep the block sits is a property of the fence, not of
+	// each line, so testing it per line says the same thing many times and
+	// invites the two uses below to drift apart.
+	//
+	// At most the depth of the fence is removed. A marker beyond that is content:
+	// one quote deep, the line `> > #x` reaches Typst as the text `> #x`.
+	const unquote =
+		quoteDepth > 0 ? (line: string) => stripBlockquoteMarkers(line, quoteDepth).content : (line: string) => line;
 
 	// Cut at the start of the closing fence line rather than dropping that line
 	// after a split, which would take the newline of the line above with it and
@@ -251,7 +255,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			}
 		}
 
-		const body = blockBody(source, range.start, range.end, opening.fence, opening.indent, fenceLineText.depth > 0);
+		const body = blockBody(source, range.start, range.end, opening.fence, opening.indent, fenceLineText.depth);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
 		// ordinary Typst comment, so the body passes through untouched.
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -4,6 +4,7 @@ import {
 	parseOpeningFence,
 	closingFenceRegExp,
 	stripBlockquoteMarkers,
+	stripCarriageReturn,
 } from "../yamlPosition";
 
 /**
@@ -46,11 +47,6 @@ export interface TypstBlock {
 	fenceLine: number;
 	/** Indent of the opening fence, measured after any blockquote markers. */
 	indent: number;
-}
-
-/** Drop a trailing carriage return left by a CRLF document. */
-function stripCarriageReturn(line: string): string {
-	return line.endsWith("\r") ? line.slice(0, -1) : line;
 }
 
 /**
@@ -96,6 +92,11 @@ function blockBody(
 	indent: number,
 	quoted: boolean,
 ): string {
+	// Chosen once. Whether the block sits in a blockquote is a property of the
+	// fence, not of each line, so testing it per line says the same thing many
+	// times and invites the two uses below to drift apart.
+	const unquote = quoted ? (line: string) => stripBlockquoteMarkers(line).content : (line: string) => line;
+
 	// Cut at the start of the closing fence line rather than dropping that line
 	// after a split, which would take the newline of the line above with it and
 	// glue the last body line to whatever follows it.
@@ -103,19 +104,14 @@ function blockBody(
 	const lastNewline = slice.lastIndexOf("\n");
 	const closing = closingFenceRegExp(fence);
 	const lastLine = stripCarriageReturn(slice.slice(lastNewline + 1));
-	const body = closing.test(quoted ? stripBlockquoteMarkers(lastLine).content : lastLine)
-		? slice.slice(0, lastNewline + 1)
-		: slice;
+	const body = closing.test(unquote(lastLine)) ? slice.slice(0, lastNewline + 1) : slice;
 
-	if (indent === 0 && !quoted) {
-		return body;
-	}
 	// Spaces and tabs only. A carriage return is part of the line ending on a
 	// CRLF document, and stripping it here would corrupt the source.
 	const leading = new RegExp(`^[ \\t]{0,${indent}}`);
 	return body
 		.split("\n")
-		.map((line) => (quoted ? stripBlockquoteMarkers(line).content : line).replace(leading, ""))
+		.map((line) => unquote(line).replace(leading, ""))
 		.join("\n");
 }
 
@@ -238,8 +234,8 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 
 	for (const range of getCodeBlockRanges(source)) {
 		const fence = fenceLineRange(source, range.start);
-		const quoted = stripBlockquoteMarkers(stripCarriageReturn(source.slice(fence.start, fence.end)));
-		const opening = parseOpeningFence(quoted.content);
+		const fenceLineText = stripBlockquoteMarkers(stripCarriageReturn(source.slice(fence.start, fence.end)));
+		const opening = parseOpeningFence(fenceLineText.content);
 		if (opening === undefined) {
 			continue;
 		}
@@ -255,8 +251,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			}
 		}
 
-		const indent = opening.indent;
-		const body = blockBody(source, range.start, range.end, opening.fence, indent, quoted.depth > 0);
+		const body = blockBody(source, range.start, range.end, opening.fence, opening.indent, fenceLineText.depth > 0);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
 		// ordinary Typst comment, so the body passes through untouched.
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };
@@ -271,7 +266,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			bodyEnd: range.end + from,
 			fenceStart: fence.start + from,
 			fenceLine: line,
-			indent,
+			indent: opening.indent,
 		});
 	}
 

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -58,8 +58,69 @@ const MAX_FENCE_INDENT = 3;
  */
 const BLOCKQUOTE_MARKERS = /^(?: {0,3}>[ \t]?)+/;
 
-/** A list item marker, which opens a container whose content is indented. */
-const LIST_ITEM = /^( *)([-+*]|\d{1,9}[.)])( +)\S/;
+/**
+ * A list item marker, which opens a container whose content is indented.
+ *
+ * The match runs to the first character of the content, so its length is the
+ * column that content starts at.
+ */
+const LIST_ITEM = /^ *([-+*]|\d{1,9}[.)]) +(?=\S)/;
+
+/** Space, tab, `>`, and the marker characters a list item can start with. */
+const SPACE = 32;
+const TAB = 9;
+const GREATER_THAN = 62;
+const LIST_MARKERS = new Set(["-", "+", "*", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
+
+/**
+ * Whether a line can carry a blockquote marker at all.
+ *
+ * A marker takes at most three spaces and then a `>`, so four characters settle
+ * it. This runs on every line of every document, including every line inside
+ * every code block, which is why it is worth answering without a match object.
+ */
+function mayBeQuoted(line: string): boolean {
+	for (let index = 0; index < 4 && index < line.length; index++) {
+		const code = line.charCodeAt(index);
+		if (code === GREATER_THAN) {
+			return true;
+		}
+		if (code !== SPACE) {
+			return false;
+		}
+	}
+	return false;
+}
+
+/**
+ * How many spaces a line starts with.
+ *
+ * Spaces only, matching `OPENING_FENCE`: a tab counts as four columns, so a tab
+ * is never part of a fence indent.
+ */
+function leadingSpaces(content: string): number {
+	let index = 0;
+	while (index < content.length && content.charCodeAt(index) === SPACE) {
+		index++;
+	}
+	return index;
+}
+
+/** Whether a line holds nothing but whitespace, from a known offset onwards. */
+function isBlankFrom(content: string, from: number): boolean {
+	for (let index = from; index < content.length; index++) {
+		const code = content.charCodeAt(index);
+		if (code !== SPACE && code !== TAB) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/** Drop a trailing carriage return left by a CRLF document. */
+export function stripCarriageReturn(line: string): string {
+	return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
 
 /**
  * An opening code fence, on a line already stripped of blockquote markers.
@@ -85,11 +146,20 @@ export interface QuotedLine {
  * them.
  */
 export function stripBlockquoteMarkers(line: string): QuotedLine {
+	if (!mayBeQuoted(line)) {
+		return { content: line, depth: 0 };
+	}
 	const found = BLOCKQUOTE_MARKERS.exec(line);
 	if (found === null) {
 		return { content: line, depth: 0 };
 	}
-	return { content: line.slice(found[0].length), depth: found[0].split(">").length - 1 };
+	let depth = 0;
+	for (let index = 0; index < found[0].length; index++) {
+		if (found[0].charCodeAt(index) === GREATER_THAN) {
+			depth++;
+		}
+	}
+	return { content: line.slice(found[0].length), depth };
 }
 
 /** An opening fence, as read from one line. */
@@ -162,19 +232,18 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 	let inBlock = false;
 	let blockStart = 0;
 	let blockDepth = 0;
-	let previousLineEnd = 0;
 	let closingFenceRe: RegExp | undefined;
-	// The content column of the innermost open list item. A fence is measured
-	// against this and not against the document, because a fence indented four
-	// spaces inside a list item is live while the same fence at the margin is
-	// literal text. The value is only ever lowered by a line that dedents past
-	// it, so an unclosed item makes the reader accept too much rather than lose
-	// a real block.
+	// The content column of the innermost open container, as far as one scan can
+	// tell. A fence is measured against this and not against the document,
+	// because a fence indented four spaces inside a list item is live while the
+	// same fence at the margin is literal text. The value is only ever lowered by
+	// a line that dedents past it, so an unclosed container makes the reader
+	// accept too much rather than lose a real block.
 	let containerIndent = 0;
 
 	for (let i = 0; i < lines.length; i++) {
 		const rawLine = lines[i];
-		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+		const line = stripCarriageReturn(rawLine);
 		const lineStart = offset;
 		const lineEnd = lineStart + rawLine.length;
 		// Advance offset past the newline for the next iteration.
@@ -191,29 +260,23 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 					ranges.push({ start: blockStart, end: lineEnd });
 					inBlock = false;
 				}
-				previousLineEnd = lineEnd;
 				continue;
 			}
 			// The blockquote ended, and the code block inside it ends with it. Lazy
 			// continuation carries a paragraph across such a line, never the content
 			// of a code block. The line itself is not part of the block, so it falls
-			// through and can open the next one.
-			ranges.push({ start: blockStart, end: Math.max(blockStart, previousLineEnd) });
+			// through and can open the next one. The block ends at the end of the
+			// line above, which is one character back from the start of this one.
+			ranges.push({ start: blockStart, end: Math.max(blockStart, lineStart - 1) });
 			inBlock = false;
 		}
 
-		previousLineEnd = lineEnd;
-
-		if (content.trim() !== "") {
-			const item = LIST_ITEM.exec(content);
-			if (item) {
-				containerIndent = item[1].length + item[2].length + item[3].length;
-			} else {
-				const indent = content.length - content.trimStart().length;
-				if (indent < containerIndent) {
-					containerIndent = indent;
-				}
-			}
+		const indent = leadingSpaces(content);
+		if (!isBlankFrom(content, indent)) {
+			// The marker test comes first, because a list item both opens a
+			// container and sits at the indent of the one around it.
+			const item = LIST_MARKERS.has(content[indent]) ? LIST_ITEM.exec(content) : null;
+			containerIndent = item ? item[0].length : Math.min(containerIndent, indent);
 		}
 
 		const opening = parseOpeningFence(content);

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -63,9 +63,10 @@ const BLOCKQUOTE_MARKER = /^ {0,3}>[ \t]?/;
  *
  * The match runs to the first character of the content, so its length gives the
  * column that content starts at. An item with nothing on its line is still an
- * item, and its content column is one past the marker.
+ * item, and its content column is one past the marker, which is why the marker
+ * is captured separately: trailing whitespace after it is not content.
  */
-const LIST_ITEM = /^ *([-+*]|\d{1,9}[.)])(?:[ \t]+(?=\S)|$)/;
+const LIST_ITEM = /^( *)([-+*]|\d{1,9}[.)])(?:[ \t]+(?=\S)|[ \t]*$)/;
 
 /** Space, tab, `>`, and the marker characters a list item can start with. */
 const SPACE = 32;
@@ -284,10 +285,19 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 	// The content column of the innermost open container, as far as one scan can
 	// tell. A fence is measured against this and not against the document,
 	// because a fence indented four spaces inside a list item is live while the
-	// same fence at the margin is literal text. The value is only ever lowered by
-	// a line that dedents past it, so an unclosed container makes the reader
-	// accept too much rather than lose a real block.
+	// same fence at the margin is literal text.
+	//
+	// This is an approximation of container parsing and not the real thing. It
+	// is lowered only by a line that both starts a block and dedents past it, so
+	// it errs towards accepting a fence rather than losing one. The known gap
+	// runs the other way: a tab stop is counted from the start of the quoted
+	// content rather than from the start of the line, so a tab-indented fence
+	// inside a blockquote is charged four columns instead of the two it takes,
+	// and is not read as a fence.
 	let containerIndent = 0;
+	// Whether the line above was blank, which is what makes the line below it
+	// the start of a block rather than a continuation of the one above.
+	let previousBlank = true;
 
 	for (let i = 0; i < lines.length; i++) {
 		const rawLine = lines[i];
@@ -331,15 +341,22 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			// The marker test comes first, because a list item both opens a
 			// container and sits at the indent of the one around it.
 			const item = LIST_MARKERS.has(content[contentStart]) ? LIST_ITEM.exec(content) : null;
-			if (item === null) {
-				containerIndent = Math.min(containerIndent, columnAt(content, contentStart));
-			} else {
+			if (item !== null) {
 				// An item with nothing after its marker matched to the end of the
-				// line, and its content starts in the column after it.
+				// line, and its content starts in the column after the marker rather
+				// than after the whitespace that follows it.
 				const empty = item[0].length === content.length;
-				containerIndent = columnAt(content, item[0].length) + (empty ? 1 : 0);
+				const markerEnd = item[1].length + item[2].length;
+				containerIndent = empty ? columnAt(content, markerEnd) + 1 : columnAt(content, item[0].length);
+			} else if (previousBlank) {
+				// Only a line that starts a block can close a container. A line that
+				// continues the paragraph of an open item is written at the margin as
+				// often as not, and lowering the allowance for it would lose a fence
+				// the item still holds open.
+				containerIndent = Math.min(containerIndent, columnAt(content, contentStart));
 			}
 		}
+		previousBlank = contentStart === content.length;
 
 		const opening = parseOpeningFence(content);
 		if (opening && opening.indent <= containerIndent + MAX_FENCE_INDENT) {

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -51,12 +51,12 @@ export function hasUnquotedBacktick(infoString: string): boolean {
 const MAX_FENCE_INDENT = 3;
 
 /**
- * The blockquote markers a line starts with.
+ * One blockquote marker: up to three spaces, a `>`, and one optional space.
  *
- * Each marker takes up to three spaces, a `>`, and one optional space. The run
- * repeats for a nested quote.
+ * Matched one at a time rather than as a run, because a reader sometimes has to
+ * remove a fixed number of them and leave the rest as content.
  */
-const BLOCKQUOTE_MARKERS = /^(?: {0,3}>[ \t]?)+/;
+const BLOCKQUOTE_MARKER = /^ {0,3}>[ \t]?/;
 
 /**
  * A list item marker, which opens a container whose content is indented.
@@ -92,29 +92,39 @@ function mayBeQuoted(line: string): boolean {
 	return false;
 }
 
+/** How far a tab advances: to the next multiple of four, per CommonMark. */
+const TAB_WIDTH = 4;
+
 /**
- * How many spaces a line starts with.
+ * The index of the first character that is neither a space nor a tab.
  *
- * Spaces only, matching `OPENING_FENCE`: a tab counts as four columns, so a tab
- * is never part of a fence indent.
+ * Equal to the length of the line when it holds nothing else, which is what
+ * makes it the blank test as well.
  */
-function leadingSpaces(content: string): number {
+function firstNonWhitespace(content: string): number {
 	let index = 0;
-	while (index < content.length && content.charCodeAt(index) === SPACE) {
+	while (index < content.length) {
+		const code = content.charCodeAt(index);
+		if (code !== SPACE && code !== TAB) {
+			return index;
+		}
 		index++;
 	}
 	return index;
 }
 
-/** Whether a line holds nothing but whitespace, from a known offset onwards. */
-function isBlankFrom(content: string, from: number): boolean {
-	for (let index = from; index < content.length; index++) {
-		const code = content.charCodeAt(index);
-		if (code !== SPACE && code !== TAB) {
-			return false;
-		}
+/**
+ * The column an index sits at, counting a tab to the next tab stop.
+ *
+ * Indentation is compared in columns rather than characters, because one tab
+ * and four spaces put the following text in the same place.
+ */
+function columnAt(content: string, index: number): number {
+	let column = 0;
+	for (let i = 0; i < index; i++) {
+		column += content.charCodeAt(i) === TAB ? TAB_WIDTH - (column % TAB_WIDTH) : 1;
 	}
-	return true;
+	return column;
 }
 
 /** Drop a trailing carriage return left by a CRLF document. */
@@ -125,16 +135,18 @@ export function stripCarriageReturn(line: string): string {
 /**
  * An opening code fence, on a line already stripped of blockquote markers.
  *
- * The indent is spaces only. A tab counts as four columns, so a tab-indented
- * fence is inside an indented code block and is not a fence at all.
+ * The indent is measured in columns and not in characters, because a tab
+ * advances to the next multiple of four. A tab at the margin therefore opens an
+ * indented code block, while the same tab inside a list item is one column of
+ * indent and leaves the fence live.
  */
-const OPENING_FENCE = /^( *)(`{3,}|~{3,})(.*)$/;
+const OPENING_FENCE = /^([ \t]*)(`{3,}|~{3,})(.*)$/;
 
 /** A line with its blockquote markers taken off. */
 export interface QuotedLine {
-	/** The line without the markers. */
+	/** The line without the markers that were removed. */
 	content: string;
-	/** How many markers the line carried, so how deep the quote is. */
+	/** How many markers were removed. */
 	depth: number;
 }
 
@@ -144,22 +156,26 @@ export interface QuotedLine {
  * A fence inside a blockquote is a real code block for Pandoc, and the markers
  * are structure rather than content, so every fence rule reads the line without
  * them.
+ *
+ * @param limit - How many markers to remove at most. A reader inside a quoted
+ *   block passes the depth of that block, because a marker beyond it belongs to
+ *   the content: at one quote deep, `> > #x` is the text `> #x`.
  */
-export function stripBlockquoteMarkers(line: string): QuotedLine {
-	if (!mayBeQuoted(line)) {
+export function stripBlockquoteMarkers(line: string, limit = Number.POSITIVE_INFINITY): QuotedLine {
+	if (limit <= 0 || !mayBeQuoted(line)) {
 		return { content: line, depth: 0 };
 	}
-	const found = BLOCKQUOTE_MARKERS.exec(line);
-	if (found === null) {
-		return { content: line, depth: 0 };
-	}
+	let content = line;
 	let depth = 0;
-	for (let index = 0; index < found[0].length; index++) {
-		if (found[0].charCodeAt(index) === GREATER_THAN) {
-			depth++;
+	while (depth < limit) {
+		const found = BLOCKQUOTE_MARKER.exec(content);
+		if (found === null) {
+			break;
 		}
+		content = content.slice(found[0].length);
+		depth++;
 	}
-	return { content: line.slice(found[0].length), depth };
+	return { content, depth };
 }
 
 /** An opening fence, as read from one line. */
@@ -195,7 +211,7 @@ export function parseOpeningFence(content: string): OpeningFence | undefined {
 	if (found[2][0] === "`" && hasUnquotedBacktick(found[3])) {
 		return undefined;
 	}
-	return { indent: found[1].length, fence: found[2], info: found[3] };
+	return { indent: columnAt(found[1], found[1].length), fence: found[2], info: found[3] };
 }
 
 /**
@@ -252,7 +268,14 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 		const { content, depth } = stripBlockquoteMarkers(line);
 
 		if (inBlock) {
-			if (depth >= blockDepth) {
+			if (depth > blockDepth) {
+				// A line quoted more deeply than the block is content. Inside a fenced
+				// block the container parsing stops, so the extra marker is text the
+				// author wrote, and testing the stripped line for a closing fence
+				// would close the block on its own body.
+				continue;
+			}
+			if (depth === blockDepth) {
 				// Check for closing fence: same character, at least as many
 				// repetitions, optionally followed by whitespace, at the start of the
 				// line.
@@ -271,12 +294,14 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			inBlock = false;
 		}
 
-		const indent = leadingSpaces(content);
-		if (!isBlankFrom(content, indent)) {
+		const contentStart = firstNonWhitespace(content);
+		if (contentStart < content.length) {
 			// The marker test comes first, because a list item both opens a
 			// container and sits at the indent of the one around it.
-			const item = LIST_MARKERS.has(content[indent]) ? LIST_ITEM.exec(content) : null;
-			containerIndent = item ? item[0].length : Math.min(containerIndent, indent);
+			const item = LIST_MARKERS.has(content[contentStart]) ? LIST_ITEM.exec(content) : null;
+			containerIndent = item
+				? columnAt(content, item[0].length)
+				: Math.min(containerIndent, columnAt(content, contentStart));
 		}
 
 		const opening = parseOpeningFence(content);

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -42,13 +42,91 @@ export function hasUnquotedBacktick(infoString: string): boolean {
 }
 
 /**
- * An opening code fence, capturing its indent, its run and its info string.
+ * How far a fence may be indented past its container before it is not a fence.
+ *
+ * CommonMark gives four spaces to an indented code block, so a fence at that
+ * indent is literal text. The limit is measured from the content column of the
+ * open container, because a fence inside a list item is indented to that item.
+ */
+const MAX_FENCE_INDENT = 3;
+
+/**
+ * The blockquote markers a line starts with.
+ *
+ * Each marker takes up to three spaces, a `>`, and one optional space. The run
+ * repeats for a nested quote.
+ */
+const BLOCKQUOTE_MARKERS = /^(?: {0,3}>[ \t]?)+/;
+
+/** A list item marker, which opens a container whose content is indented. */
+const LIST_ITEM = /^( *)([-+*]|\d{1,9}[.)])( +)\S/;
+
+/**
+ * An opening code fence, on a line already stripped of blockquote markers.
+ *
+ * The indent is spaces only. A tab counts as four columns, so a tab-indented
+ * fence is inside an indented code block and is not a fence at all.
+ */
+const OPENING_FENCE = /^( *)(`{3,}|~{3,})(.*)$/;
+
+/** A line with its blockquote markers taken off. */
+export interface QuotedLine {
+	/** The line without the markers. */
+	content: string;
+	/** How many markers the line carried, so how deep the quote is. */
+	depth: number;
+}
+
+/**
+ * Take the blockquote markers off a line.
+ *
+ * A fence inside a blockquote is a real code block for Pandoc, and the markers
+ * are structure rather than content, so every fence rule reads the line without
+ * them.
+ */
+export function stripBlockquoteMarkers(line: string): QuotedLine {
+	const found = BLOCKQUOTE_MARKERS.exec(line);
+	if (found === null) {
+		return { content: line, depth: 0 };
+	}
+	return { content: line.slice(found[0].length), depth: found[0].split(">").length - 1 };
+}
+
+/** An opening fence, as read from one line. */
+export interface OpeningFence {
+	/** The indent of the fence, measured after any blockquote markers. */
+	indent: number;
+	/** The run of the fence, which a closing fence must match or exceed. */
+	fence: string;
+	/** The info string that follows the run. */
+	info: string;
+}
+
+/**
+ * Read an opening fence from a line, or report that the line is not one.
  *
  * Exported so that a reader which derives the info string of a block, such as
  * the Typst block scanner, matches the fence exactly as this module does. Two
  * copies of the rule drift apart in silence.
+ *
+ * The indent limit is not applied here, because it depends on the container the
+ * line sits in, which only a reader walking the whole document knows.
+ *
+ * @param content - One line, with its blockquote markers already removed.
  */
-export const OPENING_FENCE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+export function parseOpeningFence(content: string): OpeningFence | undefined {
+	const found = OPENING_FENCE.exec(content);
+	if (found === null) {
+		return undefined;
+	}
+	// The info string of a backtick fence carries no bare backtick, per
+	// CommonMark. A backtick inside a quoted attribute value is a Quarto
+	// extension and is allowed.
+	if (found[2][0] === "`" && hasUnquotedBacktick(found[3])) {
+		return undefined;
+	}
+	return { indent: found[1].length, fence: found[2], info: found[3] };
+}
 
 /**
  * The closing fence that ends a block opened by the given run.
@@ -83,7 +161,16 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 	let offset = 0;
 	let inBlock = false;
 	let blockStart = 0;
+	let blockDepth = 0;
+	let previousLineEnd = 0;
 	let closingFenceRe: RegExp | undefined;
+	// The content column of the innermost open list item. A fence is measured
+	// against this and not against the document, because a fence indented four
+	// spaces inside a list item is live while the same fence at the margin is
+	// literal text. The value is only ever lowered by a line that dedents past
+	// it, so an unclosed item makes the reader accept too much rather than lose
+	// a real block.
+	let containerIndent = 0;
 
 	for (let i = 0; i < lines.length; i++) {
 		const rawLine = lines[i];
@@ -93,31 +180,51 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 		// Advance offset past the newline for the next iteration.
 		offset = lineEnd + (i < lines.length - 1 ? 1 : 0);
 
-		if (inBlock) {
-			// Check for closing fence: same character, at least as many repetitions,
-			// optionally followed by whitespace, at the start of the line.
-			if (closingFenceRe?.test(line)) {
-				ranges.push({ start: blockStart, end: lineEnd });
-				inBlock = false;
-			}
-			continue;
-		}
+		const { content, depth } = stripBlockquoteMarkers(line);
 
-		// Check for opening fence, optionally indented.
-		const openMatch = OPENING_FENCE.exec(line);
-		if (openMatch) {
-			// The info string must not contain bare backticks when using backtick
-			// fences (CommonMark spec).  Backticks inside quoted attribute values
-			// are allowed (Pandoc/Quarto extension).
-			if (openMatch[2][0] === "`" && hasUnquotedBacktick(openMatch[3])) {
+		if (inBlock) {
+			if (depth >= blockDepth) {
+				// Check for closing fence: same character, at least as many
+				// repetitions, optionally followed by whitespace, at the start of the
+				// line.
+				if (closingFenceRe?.test(content)) {
+					ranges.push({ start: blockStart, end: lineEnd });
+					inBlock = false;
+				}
+				previousLineEnd = lineEnd;
 				continue;
 			}
+			// The blockquote ended, and the code block inside it ends with it. Lazy
+			// continuation carries a paragraph across such a line, never the content
+			// of a code block. The line itself is not part of the block, so it falls
+			// through and can open the next one.
+			ranges.push({ start: blockStart, end: Math.max(blockStart, previousLineEnd) });
+			inBlock = false;
+		}
+
+		previousLineEnd = lineEnd;
+
+		if (content.trim() !== "") {
+			const item = LIST_ITEM.exec(content);
+			if (item) {
+				containerIndent = item[1].length + item[2].length + item[3].length;
+			} else {
+				const indent = content.length - content.trimStart().length;
+				if (indent < containerIndent) {
+					containerIndent = indent;
+				}
+			}
+		}
+
+		const opening = parseOpeningFence(content);
+		if (opening && opening.indent <= containerIndent + MAX_FENCE_INDENT) {
 			inBlock = true;
+			blockDepth = depth;
 			// Start the range after the opening fence line so that
 			// attributes in the header (e.g. {r}, {python}) stay outside.
 			blockStart = offset;
 			// Compile the closing fence regex once per block.
-			closingFenceRe = closingFenceRegExp(openMatch[2]);
+			closingFenceRe = closingFenceRegExp(opening.fence);
 		}
 	}
 

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -61,10 +61,11 @@ const BLOCKQUOTE_MARKER = /^ {0,3}>[ \t]?/;
 /**
  * A list item marker, which opens a container whose content is indented.
  *
- * The match runs to the first character of the content, so its length is the
- * column that content starts at.
+ * The match runs to the first character of the content, so its length gives the
+ * column that content starts at. An item with nothing on its line is still an
+ * item, and its content column is one past the marker.
  */
-const LIST_ITEM = /^ *([-+*]|\d{1,9}[.)]) +(?=\S)/;
+const LIST_ITEM = /^ *([-+*]|\d{1,9}[.)])(?:[ \t]+(?=\S)|$)/;
 
 /** Space, tab, `>`, and the marker characters a list item can start with. */
 const SPACE = 32;
@@ -111,6 +112,37 @@ function firstNonWhitespace(content: string): number {
 		index++;
 	}
 	return index;
+}
+
+/**
+ * The same line with a number of columns of indent taken off the front.
+ *
+ * Columns and not characters, because the fence indent is measured in columns:
+ * removing that many characters from a line indented with a tab would take the
+ * tab and three spaces where the fence owns only the tab.
+ *
+ * A tab that straddles the boundary is replaced by the spaces it contributes
+ * past it, which is how CommonMark splits one.
+ */
+export function removeIndentColumns(line: string, indent: number): string {
+	let column = 0;
+	let index = 0;
+	while (index < line.length && column < indent) {
+		const code = line.charCodeAt(index);
+		if (code === SPACE) {
+			column++;
+		} else if (code === TAB) {
+			const advance = TAB_WIDTH - (column % TAB_WIDTH);
+			if (column + advance > indent) {
+				return " ".repeat(column + advance - indent) + line.slice(index + 1);
+			}
+			column += advance;
+		} else {
+			break;
+		}
+		index++;
+	}
+	return line.slice(index);
 }
 
 /**
@@ -299,9 +331,14 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			// The marker test comes first, because a list item both opens a
 			// container and sits at the indent of the one around it.
 			const item = LIST_MARKERS.has(content[contentStart]) ? LIST_ITEM.exec(content) : null;
-			containerIndent = item
-				? columnAt(content, item[0].length)
-				: Math.min(containerIndent, columnAt(content, contentStart));
+			if (item === null) {
+				containerIndent = Math.min(containerIndent, columnAt(content, contentStart));
+			} else {
+				// An item with nothing after its marker matched to the end of the
+				// line, and its content starts in the column after it.
+				const empty = item[0].length === content.length;
+				containerIndent = columnAt(content, item[0].length) + (empty ? 1 : 0);
+			}
 		}
 
 		const opening = parseOpeningFence(content);


### PR DESCRIPTION
The opening fence pattern was `^(\s*)(`{3,}|~{3,})(.*)$`. The unbounded leading `\s*` accepted any indent, and nothing handled a blockquote marker. Every reader built on `getCodeBlockRanges` inherited both, which is the inline attribute diagnostics, the shortcode parser, the element attribute parser and the Typst block scanner.

So a fence sitting inside an indented code block, which is how a document shows a fence to the reader, was treated as live and linted as code. A fence inside a blockquote, which Pandoc reads as a real code block, was skipped by every one of them.

The indent limit is three columns, measured from the content column of the innermost open list item rather than from the margin. That distinction is the whole difficulty: a fence indented four spaces under `1. ` is one column into the item and is live, while the same fence at the margin is literal text. Capping at three absolutely, which is what the issue proposed, would have stopped detecting the ordinary shape of a Quarto document and linted R code as prose.

The approximation is deliberate and errs towards accepting a fence rather than losing one, since a false accept only costs a suppressed diagnostic while a false reject compiles prose the author wrote to be read. The container allowance is therefore lowered only by a line that both starts a block and dedents past it, so a lazy continuation, an empty item, and an item written with a tab all keep it open.

Indent is counted in columns, so a tab advances to the next multiple of four. A tab at the margin opens an indented code block, and the same tab inside a list item leaves the fence live. The Typst body is de-indented by column too, because the fence owns columns rather than characters.

Inside a blockquote, only a line at the depth of the block can close it: container parsing stops inside a fenced block, so a more deeply quoted line is content, and testing it for a closing fence closed a block on its own body. A block also ends where its quote ends, because lazy continuation carries a paragraph across such a line but never the content of a code block. A Typst body keeps any marker the quote does not consume, so one quote deep `> > #x` still reaches the compiler as `> #x`.

The fence rule now lives in `parseOpeningFence` and `stripBlockquoteMarkers`, which `getCodeBlockRanges` and `findTypstBlocks` share, so the two cannot drift apart.

One known gap is left open and recorded in the code and in a follow-up issue: a tab stop is counted from the start of the quoted content rather than from the start of the line, so a tab-indented fence inside a blockquote is charged four columns instead of the two it takes and is not read. That shape was never detected before this change either.

The scanner runs on every keystroke through three providers, so it was measured over 1226 lines and 94 fenced blocks: 73.6 us before, 103.8 us after, with byte-identical ranges. Guarding the blockquote strip behind a four-character test, counting the indent in one scan, and testing the list marker before matching it recovered about half of the cost the container tracking added.