### PR TITLE
feat: compile a raw Typst block in context

### DIFF
--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -33,6 +33,13 @@ export function errorText(stderr: string, injectedLines: number): string {
 	// misstates why there is no image.
 	const mapped = diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
 	if (mapped) {
+		if (mapped.aboveBody) {
+			// A raw block compiles under every raw block before it, so the failure
+			// can belong to one of those. There is no line of this block to name,
+			// but saying nothing about where it is would leave the reader looking
+			// at a block that compiles.
+			return `${mapped.severity} above this block: ${mapped.message}`;
+		}
 		if (mapped.line === undefined) {
 			// A package that would not download, or an input Typst could not read.
 			// Naming a position here would point at a character that has nothing to

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -31,6 +31,11 @@ export function errorText(stderr: string, injectedLines: number): string {
 	// A warning can sit above the error that stopped the compile, so the first
 	// diagnostic is not the one to show. Headlining a failure as a warning
 	// misstates why there is no image.
+	//
+	// Among the errors it is the first that is shown, which is the earliest in
+	// the compiled source. A block compiled under a broken one reports errors of
+	// its own, and those are consequences: showing one of them would send the
+	// reader to a line that is only wrong because the source above it is.
 	const mapped = diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
 	if (mapped) {
 		if (mapped.aboveBody) {

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { typstBlockAt, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { buildPlainSource, buildRawSource } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
 import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
@@ -18,30 +19,6 @@ const PAGE_SETUP = "#set page(width: auto, height: auto, margin: 0.5em)";
 
 /** Read the source from stdin, write the image to stdout. */
 const ARGV = ["compile", "--format", "svg", "-", "-"];
-
-/** One compile request. */
-interface AssembledSource {
-	/** The whole source to send to the compiler. */
-	source: string;
-	/**
-	 * How many lines sit above the block body.
-	 *
-	 * A diagnostic reports a position in the assembled source, so it has to lose
-	 * these before it means anything in the document.
-	 */
-	injectedLines: number;
-}
-
-/**
- * The source for one block.
- *
- * The count travels with the source rather than beside it, because it stops
- * being a constant as soon as a raw block prepends the blocks before it, or a
- * cell prepends its resolved options.
- */
-function assembleSource(block: TypstBlock): AssembledSource {
-	return { source: `${PAGE_SETUP}\n${block.body}`, injectedLines: 1 };
-}
 
 /**
  * The one line a failure shows inside the panel.
@@ -80,7 +57,11 @@ export function errorText(stderr: string, injectedLines: number): string {
 
 /** What the panel shows about the block it is displaying. */
 function headerText(document: vscode.TextDocument, block: TypstBlock): string {
-	return `${path.basename(document.fileName)} · line ${block.fenceLine + 1}`;
+	const place = `${path.basename(document.fileName)} · line ${block.fenceLine + 1}`;
+	// A raw block reaches Typst through the document template, which contributes
+	// imports, show rules and set directives the preview cannot apply. Saying so
+	// beside the image is what stops a divergence being read as a defect.
+	return block.kind === "raw" ? `${place} · raw passthrough, document template not applied` : place;
 }
 
 /**
@@ -179,16 +160,20 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		}
 
 		const document = editor.document;
-		const block = typstBlockAt(document.getText(), document.offsetAt(editor.selection.active));
+		// The whole list is kept, because a raw block compiles with the raw blocks
+		// above it and scanning the document a second time to find them would say
+		// the same thing twice.
+		const blocks = findTypstBlocks(document.getText());
+		const block = blockAtOffset(blocks, document.offsetAt(editor.selection.active));
 		if (block === undefined) {
 			explain("Put the cursor inside a Typst block to preview it.");
 			return;
 		}
-		if (block.kind !== "plain") {
-			// A raw block needs the ones before it, and a cell needs its options
-			// resolved. Compiling either one alone would show an image that the
-			// render does not produce.
-			explain(`A \`${block.kind}\` Typst block cannot be previewed yet.`);
+		if (block.kind === "cell") {
+			// A cell needs its options resolved and its extension present.
+			// Compiling it alone would show an image that the render does not
+			// produce.
+			explain("A `{typst}` cell cannot be previewed yet.");
 			return;
 		}
 
@@ -202,7 +187,8 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		const surface = usePanel();
 		surface.reveal();
 
-		const assembled = assembleSource(block);
+		const assembled =
+			block.kind === "raw" ? buildRawSource(blocks, block, PAGE_SETUP) : buildPlainSource(block, PAGE_SETUP);
 		try {
 			const result = await compiler.compile(assembled.source, ARGV, uncancelled.token);
 			if (result.svg === undefined) {

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import {
 	findTypstBlocks,
-	typstBlockAt,
+	blockAtOffset,
 	precedingRawBlocks,
 	hasLateOptionLine,
 	invalidatesPreview,
@@ -293,23 +293,24 @@ suite("Typst Blocks Test Suite", () => {
 		});
 	});
 
-	suite("typstBlockAt", () => {
+	suite("blockAtOffset", () => {
 		const text = "intro\n\n```typst\n#a\n```\n\ntext\n\n```{=typst}\n#b\n```\n";
+		const blocks = findTypstBlocks(text);
 
 		test("Should find the block holding an offset inside a body", () => {
-			assert.strictEqual(typstBlockAt(text, text.indexOf("#a"))?.kind, "plain");
-			assert.strictEqual(typstBlockAt(text, text.indexOf("#b"))?.kind, "raw");
+			assert.strictEqual(blockAtOffset(blocks, text.indexOf("#a"))?.kind, "plain");
+			assert.strictEqual(blockAtOffset(blocks, text.indexOf("#b"))?.kind, "raw");
 		});
 
 		test("Should find the block when the cursor sits on its opening fence", () => {
 			// A reader who puts the cursor on the fence means that block, and the
 			// body range starts after the fence line, so the fence needs its own case.
-			assert.strictEqual(typstBlockAt(text, text.indexOf("```typst"))?.kind, "plain");
+			assert.strictEqual(blockAtOffset(blocks, text.indexOf("```typst"))?.kind, "plain");
 		});
 
 		test("Should find nothing outside every block", () => {
-			assert.strictEqual(typstBlockAt(text, 0), undefined);
-			assert.strictEqual(typstBlockAt(text, text.indexOf("text")), undefined);
+			assert.strictEqual(blockAtOffset(blocks, 0), undefined);
+			assert.strictEqual(blockAtOffset(blocks, text.indexOf("text")), undefined);
 		});
 	});
 

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -400,6 +400,12 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(invalidatesPreview(firstRaw, insertion(text.indexOf("prose"))), false);
 		});
 
+		test("Should invalidate a plain block changed on its closing fence", () => {
+			// The body ends where the closing fence starts, so an edit exactly at
+			// that offset removes or moves the end of the block.
+			assert.strictEqual(invalidatesPreview(plain, insertion(plain.bodyEnd)), true);
+		});
+
 		test("Should invalidate a block a deletion reaches from above", () => {
 			// The change starts outside the block and ends inside it, so testing its
 			// start offset alone would miss it.

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -1,5 +1,11 @@
 import * as assert from "assert";
-import { findTypstBlocks, typstBlockAt, precedingRawBlocks, hasLateOptionLine } from "../../utils/typst/typstBlocks";
+import {
+	findTypstBlocks,
+	typstBlockAt,
+	precedingRawBlocks,
+	hasLateOptionLine,
+	invalidatesPreview,
+} from "../../utils/typst/typstBlocks";
 
 /** A minimal document holding one fence with the given info string. */
 function fence(info: string): string {
@@ -332,6 +338,75 @@ suite("Typst Blocks Test Suite", () => {
 		test("Should return nothing when the target is the first raw block", () => {
 			const blocks = findTypstBlocks("```{=typst}\n#a\n```\n");
 			assert.deepStrictEqual(precedingRawBlocks(blocks, blocks[0]), []);
+		});
+	});
+
+	suite("invalidatesPreview", () => {
+		// A raw block, then prose, then a plain block and a second raw block, so
+		// every case has something above it and something below it.
+		const text = [
+			"```{=typst}",
+			"#let a = 1",
+			"```",
+			"",
+			"prose",
+			"",
+			"```typst",
+			"#circle()",
+			"```",
+			"",
+			"```{=typst}",
+			"#a",
+			"```",
+			"",
+		].join("\n");
+		const [firstRaw, plain, secondRaw] = findTypstBlocks(text);
+
+		/** A one character insertion at an offset. */
+		function insertion(offset: number): { rangeOffset: number; rangeLength: number } {
+			return { rangeOffset: offset, rangeLength: 0 };
+		}
+
+		test("Should invalidate a plain block changed inside its body", () => {
+			assert.strictEqual(invalidatesPreview(plain, insertion(text.indexOf("#circle"))), true);
+		});
+
+		test("Should invalidate a plain block changed on its opening fence", () => {
+			// The info string decides the kind, so editing the fence can stop the
+			// block being a Typst block at all.
+			assert.strictEqual(invalidatesPreview(plain, insertion(plain.fenceStart)), true);
+		});
+
+		test("Should leave a plain block alone when the change is above it", () => {
+			// A plain block is compiled on its own, so nothing outside it changes
+			// what it renders.
+			assert.strictEqual(invalidatesPreview(plain, insertion(text.indexOf("prose"))), false);
+		});
+
+		test("Should invalidate a raw block changed anywhere above it", () => {
+			// A raw block compiles with every raw block before it, so a change above
+			// it can bind, rebind or remove a name it uses.
+			assert.strictEqual(invalidatesPreview(secondRaw, insertion(text.indexOf("#let"))), true);
+		});
+
+		test("Should invalidate a raw block when a change above it is not in a block", () => {
+			// Prose is where a new fence is typed, and that new block would sit
+			// above the target.
+			assert.strictEqual(invalidatesPreview(secondRaw, insertion(text.indexOf("prose"))), true);
+		});
+
+		test("Should leave a raw block alone when the change is below it", () => {
+			assert.strictEqual(invalidatesPreview(firstRaw, insertion(text.indexOf("prose"))), false);
+		});
+
+		test("Should invalidate a block a deletion reaches from above", () => {
+			// The change starts outside the block and ends inside it, so testing its
+			// start offset alone would miss it.
+			const start = text.indexOf("prose");
+			assert.strictEqual(
+				invalidatesPreview(plain, { rangeOffset: start, rangeLength: text.indexOf("#circle") - start }),
+				true,
+			);
 		});
 	});
 });

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -46,14 +46,12 @@ suite("Typst Diagnostics Test Suite", () => {
 		]);
 	});
 
-	test("Should point at the start of the body for an error in the header", () => {
-		// An error inside the injected header maps above the block. A negative
-		// line is not a position any editor can take, and the column that came
-		// with it was measured against a line the author never wrote, so keeping
-		// it would put the mark at an arbitrary character of the first body line.
-		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 10), [
-			{ line: 0, column: 0, message: "expected pattern", severity: "error" },
-		]);
+	test("Should give no position for an error above the block body", () => {
+		// The injected lines are not all written by the preview: a raw block is
+		// compiled under every raw block before it. Pinning such an error to the
+		// first line of the body blamed this block for a failure in another one,
+		// so the position is dropped and only the message survives.
+		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 10), [{ message: "expected pattern", severity: "error" }]);
 	});
 
 	test("Should read a warning as well as an error", () => {

--- a/src/test/suite/typstDiagnostics.test.ts
+++ b/src/test/suite/typstDiagnostics.test.ts
@@ -51,7 +51,17 @@ suite("Typst Diagnostics Test Suite", () => {
 		// compiled under every raw block before it. Pinning such an error to the
 		// first line of the body blamed this block for a failure in another one,
 		// so the position is dropped and only the message survives.
-		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 10), [{ message: "expected pattern", severity: "error" }]);
+		assert.deepStrictEqual(parseTypstStderr(ONE_ERROR, 10), [
+			{ message: "expected pattern", severity: "error", aboveBody: true },
+		]);
+	});
+
+	test("Should not call a failure without any position one above the body", () => {
+		// A package that would not download has no place at all, which is not the
+		// same as a place the reader can go and look at.
+		assert.deepStrictEqual(parseTypstStderr("error: failed to download package\n", 10), [
+			{ message: "failed to download package", severity: "error" },
+		]);
 	});
 
 	test("Should read a warning as well as an error", () => {

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -29,6 +29,14 @@ suite("Typst Preview Messages Test Suite", () => {
 			);
 		});
 
+		test("Should claim no position for a failure in a block above this one", () => {
+			// A raw block compiles under every raw block before it, so the error can
+			// belong to one of those. Reporting line 1 of this block would name the
+			// wrong block and the wrong line.
+			const text = errorText(diagnostic("error", "unknown variable: accent", 2, 4), 5);
+			assert.strictEqual(text, "error: unknown variable: accent");
+		});
+
 		test("Should claim no position when Typst gave none", () => {
 			// A package that would not download is not about a place in the block.
 			// Reporting "line 1, column 1" would assert a position that does not

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -29,12 +29,13 @@ suite("Typst Preview Messages Test Suite", () => {
 			);
 		});
 
-		test("Should claim no position for a failure in a block above this one", () => {
+		test("Should say that a failure sits above the block rather than in it", () => {
 			// A raw block compiles under every raw block before it, so the error can
 			// belong to one of those. Reporting line 1 of this block would name the
-			// wrong block and the wrong line.
+			// wrong block and the wrong line, and saying nothing about where it is
+			// would leave the reader looking at a block that compiles.
 			const text = errorText(diagnostic("error", "unknown variable: accent", 2, 4), 5);
-			assert.strictEqual(text, "error: unknown variable: accent");
+			assert.strictEqual(text, "error above this block: unknown variable: accent");
 		});
 
 		test("Should claim no position when Typst gave none", () => {

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -1,0 +1,102 @@
+import * as assert from "assert";
+import { findTypstBlocks } from "../../utils/typst/typstBlocks";
+import { buildPlainSource, buildRawSource } from "../../utils/typst/typstSource";
+
+/** The page setup a preview injects above every block. */
+const HEADER = "#set page(width: auto, height: auto, margin: 0.5em)";
+
+/**
+ * A raw block binding a name, a cell between the two, and a raw block using
+ * that name.
+ *
+ * The three fences are deliberately of three different kinds, because the
+ * accumulation rule is about kinds and not about position.
+ */
+const CHAIN = [
+	"```{=typst}",
+	"#let accent = red",
+	"```",
+	"",
+	"Some prose.",
+	"",
+	"```{typst}",
+	"//| width: 10cm",
+	"#square()",
+	"```",
+	"",
+	"```{=typst}",
+	"#text(fill: accent)[Hello]",
+	"```",
+	"",
+].join("\n");
+
+suite("Typst Source Test Suite", () => {
+	suite("buildPlainSource", () => {
+		test("Should put the header above the body", () => {
+			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
+			assert.deepStrictEqual(buildPlainSource(blocks[0], HEADER), {
+				source: `${HEADER}\n#circle()\n`,
+				injectedLines: 1,
+			});
+		});
+
+		test("Should inject nothing when the header is empty", () => {
+			// An empty header must not push the body down by a line, or every
+			// diagnostic would point one line too far.
+			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
+			assert.deepStrictEqual(buildPlainSource(blocks[0], ""), { source: "#circle()\n", injectedLines: 0 });
+		});
+	});
+
+	suite("buildRawSource", () => {
+		test("Should put every preceding raw block above the target, in document order", () => {
+			// A raw block is passed through into the document's Typst context, so a
+			// name bound by an earlier one is in scope for a later one. Compiled
+			// alone, the target below fails on an unknown variable.
+			const blocks = findTypstBlocks(CHAIN);
+			assert.strictEqual(
+				buildRawSource(blocks, blocks[2], HEADER).source,
+				`${HEADER}\n#let accent = red\n#text(fill: accent)[Hello]\n`,
+			);
+		});
+
+		test("Should leave a cell sitting between two raw blocks out of the source", () => {
+			// The filter compiles a cell to an image of its own, so nothing it
+			// contains reaches the Typst context of the raw blocks around it.
+			const blocks = findTypstBlocks(CHAIN);
+			assert.ok(!buildRawSource(blocks, blocks[2], HEADER).source.includes("#square()"));
+		});
+
+		test("Should count the header and every prepended body as injected lines", () => {
+			// A diagnostic reports a position in the assembled source, so the count
+			// is what maps it back to a line of the target block.
+			const blocks = findTypstBlocks(CHAIN);
+			assert.strictEqual(buildRawSource(blocks, blocks[2], HEADER).injectedLines, 2);
+		});
+
+		test("Should compile the first raw block of a document on its own", () => {
+			const blocks = findTypstBlocks(CHAIN);
+			assert.deepStrictEqual(buildRawSource(blocks, blocks[0], HEADER), {
+				source: `${HEADER}\n#let accent = red\n`,
+				injectedLines: 1,
+			});
+		});
+
+		test("Should keep a comment-pipe line inside a raw block as code", () => {
+			// Only a cell carries options. In a raw block the same spelling is an
+			// ordinary Typst comment, and dropping it would change the source.
+			const text = "```{=typst}\n//| width: 10cm\n#circle()\n```\n";
+			const blocks = findTypstBlocks(text);
+			assert.strictEqual(buildRawSource(blocks, blocks[0], HEADER).source, `${HEADER}\n//| width: 10cm\n#circle()\n`);
+		});
+
+		test("Should separate two bodies that do not end with a line ending", () => {
+			// The closing fence of an unclosed block never arrives, so the last body
+			// line has no line ending of its own and would otherwise be glued to the
+			// first line of the target.
+			const text = "```{=typst}\n#let a = 1\n```\n\n```{=typst}\n#a";
+			const blocks = findTypstBlocks(text);
+			assert.strictEqual(buildRawSource(blocks, blocks[1], "").source, "#let a = 1\n#a");
+		});
+	});
+});

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -90,6 +90,17 @@ suite("Typst Source Test Suite", () => {
 			assert.strictEqual(buildRawSource(blocks, blocks[0], HEADER).source, `${HEADER}\n//| width: 10cm\n#circle()\n`);
 		});
 
+		test("Should add nothing for an empty raw block above the target", () => {
+			// An empty body has no line to contribute, so counting it would push
+			// every diagnostic of the target down by one.
+			const text = "```{=typst}\n```\n\n```{=typst}\n#circle()\n```\n";
+			const blocks = findTypstBlocks(text);
+			assert.deepStrictEqual(buildRawSource(blocks, blocks[1], HEADER), {
+				source: `${HEADER}\n#circle()\n`,
+				injectedLines: 1,
+			});
+		});
+
 		test("Should separate two bodies that do not end with a line ending", () => {
 			// The closing fence of an unclosed block never arrives, so the last body
 			// line has no line ending of its own and would otherwise be glued to the

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -279,13 +279,22 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 }
 
 /**
- * The Typst block that holds an offset, or undefined when none does.
+ * The block of a list that holds an offset, or undefined when none does.
  *
  * The opening fence line counts as part of its block. A reader who puts the
  * cursor on the fence means that block, and the body range starts after it.
+ *
+ * Takes a list rather than the text, because a caller that also needs the
+ * blocks around the one under the cursor would otherwise scan the document
+ * twice.
  */
+export function blockAtOffset(blocks: TypstBlock[], offset: number): TypstBlock | undefined {
+	return blocks.find((block) => offset >= block.fenceStart && offset <= block.bodyEnd);
+}
+
+/** The Typst block of a document that holds an offset. */
 export function typstBlockAt(text: string, offset: number): TypstBlock | undefined {
-	return findTypstBlocks(text).find((block) => offset >= block.fenceStart && offset <= block.bodyEnd);
+	return blockAtOffset(findTypstBlocks(text), offset);
 }
 
 /**
@@ -298,4 +307,33 @@ export function typstBlockAt(text: string, offset: number): TypstBlock | undefin
  */
 export function precedingRawBlocks(blocks: TypstBlock[], target: TypstBlock): TypstBlock[] {
 	return blocks.filter((block) => block.kind === "raw" && block.bodyStart < target.bodyStart);
+}
+
+/**
+ * One edit of a document, in the shape `TextDocumentContentChangeEvent` uses.
+ *
+ * Structural, so this module keeps importing no `vscode`.
+ */
+export interface DocumentChange {
+	/** Offset of the first character the edit replaced. */
+	rangeOffset: number;
+	/** How many characters the edit replaced. */
+	rangeLength: number;
+}
+
+/**
+ * Whether an edit makes the preview of a block out of date.
+ *
+ * A raw block is the one kind whose source reaches outside itself: it compiles
+ * with every raw block above it, so anything above it counts, including prose,
+ * where a new fence is typed. A plain block and a cell compile alone, so only
+ * an edit that touches the block itself counts.
+ *
+ * The opening fence is inside that region, because the info string decides the
+ * kind, and so is the closing fence, because removing it changes where the body
+ * ends.
+ */
+export function invalidatesPreview(block: TypstBlock, change: DocumentChange): boolean {
+	const from = block.kind === "raw" ? 0 : block.fenceStart;
+	return change.rangeOffset <= block.bodyEnd && change.rangeOffset + change.rangeLength >= from;
 }

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -284,17 +284,12 @@ export function findTypstBlocks(text: string): TypstBlock[] {
  * The opening fence line counts as part of its block. A reader who puts the
  * cursor on the fence means that block, and the body range starts after it.
  *
- * Takes a list rather than the text, because a caller that also needs the
- * blocks around the one under the cursor would otherwise scan the document
- * twice.
+ * Takes a list rather than the document text, because every caller also needs
+ * the blocks around the one under the cursor: a raw block compiles with the raw
+ * blocks above it. Taking the text would scan the document a second time.
  */
 export function blockAtOffset(blocks: TypstBlock[], offset: number): TypstBlock | undefined {
 	return blocks.find((block) => offset >= block.fenceStart && offset <= block.bodyEnd);
-}
-
-/** The Typst block of a document that holds an offset. */
-export function typstBlockAt(text: string, offset: number): TypstBlock | undefined {
-	return blockAtOffset(findTypstBlocks(text), offset);
 }
 
 /**

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -16,6 +16,15 @@ export interface TypstDiagnostic {
 	line?: number;
 	/** Zero-based column. */
 	column?: number;
+	/**
+	 * Whether Typst gave a position and it sits above the block body.
+	 *
+	 * This separates the two reasons a diagnostic carries no position. A failure
+	 * above the body has a place the reader can go and look at, in the preview
+	 * header or in a block compiled above this one, while a package that would
+	 * not download has no place at all.
+	 */
+	aboveBody?: boolean;
 	/** The message, without its severity prefix. */
 	message: string;
 	severity: "error" | "warning";
@@ -111,7 +120,7 @@ export function parseTypstStderr(stderr: string, injectedLines: number): TypstDi
 			// block compiles under every raw block before it, so the failure can
 			// belong to a different block of the document. Naming a line here would
 			// blame this block for it.
-			diagnostics.push({ message: heading[2], severity });
+			diagnostics.push({ message: heading[2], severity, aboveBody: true });
 			continue;
 		}
 

--- a/src/utils/typst/typstDiagnostics.ts
+++ b/src/utils/typst/typstDiagnostics.ts
@@ -7,10 +7,11 @@ export interface TypstDiagnostic {
 	/**
 	 * Zero-based line within the block body.
 	 *
-	 * Absent when Typst reported no position at all, which happens when the
-	 * failure is not about a place in the source: a package that would not
-	 * download, or an input it could not read. The two position fields are
-	 * always both present or both absent.
+	 * Absent when there is no position in this block to report. That is either a
+	 * failure Typst gave no position for, such as a package that would not
+	 * download, or a position above the body, which belongs to the preview header
+	 * or to a block the preview compiled above this one. The two position fields
+	 * are always both present or both absent.
 	 */
 	line?: number;
 	/** Zero-based column. */
@@ -104,16 +105,17 @@ export function parseTypstStderr(stderr: string, injectedLines: number): TypstDi
 		// line. So the line counts from one and the column counts from zero.
 		const line = Number(position[2]) - 1 - injectedLines;
 
-		diagnostics.push({
-			// A position inside the injected header is not a place in the block, so
-			// it points at the start of the body instead. The column goes with it:
-			// a column measured against a header line means nothing on the first
-			// line of the body, and would put the mark at an arbitrary character.
-			line: Math.max(0, line),
-			column: line < 0 ? 0 : Number(position[3]),
-			message: heading[2],
-			severity,
-		});
+		if (line < 0) {
+			// Above the block body, which is a real place but not one in this
+			// block. The injected lines are not all written by the preview: a raw
+			// block compiles under every raw block before it, so the failure can
+			// belong to a different block of the document. Naming a line here would
+			// blame this block for it.
+			diagnostics.push({ message: heading[2], severity });
+			continue;
+		}
+
+		diagnostics.push({ line, column: Number(position[3]), message: heading[2], severity });
 	}
 
 	return diagnostics;

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -1,0 +1,67 @@
+import { precedingRawBlocks, type TypstBlock } from "./typstBlocks";
+
+/** The source of one compile, and how far it pushed the block body down. */
+export interface AssembledSource {
+	/** The whole source to send to the compiler. */
+	source: string;
+	/**
+	 * How many lines sit above the block body.
+	 *
+	 * A diagnostic reports a position in the assembled source, so it has to lose
+	 * these before it means anything in the document.
+	 */
+	injectedLines: number;
+}
+
+/**
+ * One part of the source, ending with a line ending.
+ *
+ * A body that is missing its own line ending is the body of an unclosed block,
+ * whose closing fence never arrived. Concatenating it as it is would glue its
+ * last line to the first line of whatever follows.
+ */
+function terminated(part: string): string {
+	return part.endsWith("\n") ? part : `${part}\n`;
+}
+
+/**
+ * The body of a block, under everything the preview puts above it.
+ *
+ * The line count is derived from the assembled prefix rather than counted by
+ * the caller, so a caller that prepends one more part cannot forget to say so.
+ */
+function assemble(above: string[], body: string): AssembledSource {
+	const prefix = above
+		.filter((part) => part.length > 0)
+		.map(terminated)
+		.join("");
+	return { source: prefix + body, injectedLines: prefix.split("\n").length - 1 };
+}
+
+/**
+ * The source for a plain ```` ```typst ```` block.
+ *
+ * A plain block is never executed by Quarto and reaches no Typst output, so it
+ * carries no context and compiles on its own.
+ */
+export function buildPlainSource(block: TypstBlock, header: string): AssembledSource {
+	return assemble([header], block.body);
+}
+
+/**
+ * The source for a raw ```` ```{=typst} ```` block, with the blocks it needs.
+ *
+ * Pandoc passes every raw block into the Typst output in document order, so a
+ * raw block commonly holds only `#set` or `#show` rules, or uses a `#let` bound
+ * in an earlier one. Compiled alone it fails or renders blank, so every
+ * preceding raw block goes above it.
+ *
+ * This is an approximation of the render and not a reproduction of it. The
+ * Quarto Typst template contributes imports, `#show` rules and `#set`
+ * directives that the preview has no way to apply, so a block relying on
+ * template state diverges.
+ */
+export function buildRawSource(blocks: TypstBlock[], target: TypstBlock, header: string): AssembledSource {
+	const context = precedingRawBlocks(blocks, target).map((block) => block.body);
+	return assemble([header, ...context], target.body);
+}


### PR DESCRIPTION
A `{=typst}` raw block is passed straight into the Typst output of the document, so it commonly holds only `#set` or `#show` rules, or uses a `#let` bound in an earlier raw block.
Compiled on its own it fails or renders blank.
The preview now compiles such a block under every raw block before it, in document order.

A new `src/utils/typst/typstSource.ts` holds `buildPlainSource` and `buildRawSource`.
Both return the source together with the number of lines injected above the block body, which is what maps a diagnostic back to a line the author wrote.
Deriving that count from the assembled prefix means a later caller that prepends one more part cannot forget to report it.

Two things follow from a block no longer compiling alone.

- A diagnostic above the block body no longer claims a position inside it.
  The parser used to clamp a negative line to zero, which reported a failure in a preceding block as line 1 of the target.
  The panel now says that the failure sits above the block, and keeps the plain message for a failure with no place at all, such as a package that would not download.
- `invalidatesPreview` states the rule for a raw block: an edit anywhere above it can bind, rebind or remove a name it uses, so anything above it counts, including prose, where a new fence is typed.
  A plain block and a cell compile alone, so only an edit that touches the block itself counts.

Known approximation, which the panel header states beside the image: Pandoc emits raw blocks in document order, but the Quarto Typst template also contributes imports, show rules and set directives that the preview cannot apply, so a block relying on template state diverges from the render.

`typstBlockAt` is gone.
Every caller needs the block list as well as the block under the cursor, so `blockAtOffset` takes the list and the document is scanned once.