### PR TITLE
feat: inject theme colours into a Typst preview

### DIFF
--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -145,6 +145,51 @@ Report inline attributes not declared by any installed extension schema as `Unkn
 }
 ```
 
+## Typst Preview
+
+### Preview Text Colour
+
+**Setting**: `quartoWizard.typstPreview.foreground`
+
+Text colour for the Typst block preview. `auto` derives a colour from the active colour theme kind, because the editor does not expose the colour values themselves. `none` injects nothing, so Typst uses its own default of black. Any other value is a Typst colour expression used as it is, for example `luma(80%)` or `rgb("#ff9800")`. The colour is injected above the block, so a `#set text(fill: ...)` inside the block wins. Applies to a plain `typst` block and to a `{=typst}` raw block only, because a `{typst}` cell carries its own colour options.
+
+```json
+{
+  "quartoWizard.typstPreview.foreground": "auto"
+}
+```
+
+### Preview Page Colour
+
+**Setting**: `quartoWizard.typstPreview.background`
+
+Page colour for the Typst block preview. `auto` leaves the page transparent, so the editor or panel background shows through and follows a theme change with no recompile. `none` injects nothing, so Typst uses its own default of white. Any other value is a Typst colour expression used as it is, for example `rgb("#1e1e1e")`. Applies to a plain `typst` block and to a `{=typst}` raw block only.
+
+```json
+{
+  "quartoWizard.typstPreview.background": "auto"
+}
+```
+
+### Preview Timeout
+
+**Setting**: `quartoWizard.typstPreview.timeoutMs`
+
+How long one Typst compile may run, in milliseconds. The default of 20000 covers a first-use package download, which is by far the slowest compile a preview makes. Raise it on a slow connection, and lower it to fail faster when no package is ever downloaded.
+
+| Property | Value    |
+| -------- | -------- |
+| Type     | Number   |
+| Default  | `20000`  |
+| Minimum  | `1000`   |
+| Maximum  | `300000` |
+
+```json
+{
+  "quartoWizard.typstPreview.timeoutMs": 20000
+}
+```
+
 ## Workspace vs User Settings
 
 All Quarto Wizard settings are scoped to "resource", meaning they can be configured at:
@@ -167,6 +212,9 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.autoProjectDetection": "subFolders",
   "quartoWizard.cache.ttlMinutes": 30,
   "quartoWizard.registry.url": "https://m.canouil.dev/quarto-extensions/extensions.json",
-  "quartoWizard.lint.unknownAttributes": false
+  "quartoWizard.lint.unknownAttributes": false,
+  "quartoWizard.typstPreview.foreground": "auto",
+  "quartoWizard.typstPreview.background": "auto",
+  "quartoWizard.typstPreview.timeoutMs": 20000
 }
 ```

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -33,15 +33,18 @@ See [Configuration Reference](configuration.qmd) for all available options.
 
 ### Quick Reference
 
-| Setting                               | Default                                    | Description                                           |
-| ------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
-| `quartoWizard.ask.trustAuthors`       | `ask`                                      | Prompt before trusting authors.                       |
-| `quartoWizard.ask.confirmInstall`     | `ask`                                      | Prompt before installing.                             |
-| `quartoWizard.update.crossSource`     | `false`                                    | Allow registry lookup for GitHub-sourced extensions.  |
-| `quartoWizard.autoProjectDetection`   | `subFolders`                               | When to auto-detect Quarto projects.                  |
-| `quartoWizard.cache.ttlMinutes`       | `30`                                       | Cache duration in minutes.                            |
-| `quartoWizard.registry.url`           | [see docs](configuration.qmd#registry-url) | Custom registry URL.                                  |
-| `quartoWizard.lint.unknownAttributes` | `false`                                    | Flag inline attributes absent from extension schemas. |
+| Setting                                | Default                                    | Description                                           |
+| -------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| `quartoWizard.ask.trustAuthors`        | `ask`                                      | Prompt before trusting authors.                       |
+| `quartoWizard.ask.confirmInstall`      | `ask`                                      | Prompt before installing.                             |
+| `quartoWizard.update.crossSource`      | `false`                                    | Allow registry lookup for GitHub-sourced extensions.  |
+| `quartoWizard.autoProjectDetection`    | `subFolders`                               | When to auto-detect Quarto projects.                  |
+| `quartoWizard.cache.ttlMinutes`        | `30`                                       | Cache duration in minutes.                            |
+| `quartoWizard.registry.url`            | [see docs](configuration.qmd#registry-url) | Custom registry URL.                                  |
+| `quartoWizard.lint.unknownAttributes`  | `false`                                    | Flag inline attributes absent from extension schemas. |
+| `quartoWizard.typstPreview.foreground` | `auto`                                     | Text colour injected above a previewed block.         |
+| `quartoWizard.typstPreview.background` | `auto`                                     | Page colour injected above a previewed block.         |
+| `quartoWizard.typstPreview.timeoutMs`  | `20000`                                    | Time limit for one preview compile.                   |
 
 ## Extension Schema
 

--- a/package.json
+++ b/package.json
@@ -739,6 +739,35 @@
 					"markdownDescription": "Report inline attributes not declared by any installed extension schema as `Unknown attribute`. Disabled by default: Quarto Wizard has no built-in schema for Quarto/Pandoc/revealjs internals (for example `width` on `.column`), so this would flag many valid attributes. Enable only when authoring against extensions whose `_schema.yml` declares a complete attribute set.",
 					"title": "Report Unknown Attributes",
 					"description": "Flag inline attributes absent from extension schemas."
+				},
+				"quartoWizard.typstPreview.foreground": {
+					"order": 20,
+					"scope": "resource",
+					"type": "string",
+					"default": "auto",
+					"markdownDescription": "Text colour for the Typst block preview. `auto` derives a colour from the active colour theme kind, because the editor does not expose the colour values themselves. `none` injects nothing, so Typst uses its own default of black. Any other value is a Typst colour expression used as it is, for example `luma(80%)` or `rgb(\"#ff9800\")`. The colour is injected above the block, so a `#set text(fill: ...)` inside the block wins. Applies to a plain `typst` block and to a `{=typst}` raw block only, because a `{typst}` cell carries its own colour options.",
+					"title": "Preview Text Colour",
+					"description": "Text colour injected above a previewed block."
+				},
+				"quartoWizard.typstPreview.background": {
+					"order": 21,
+					"scope": "resource",
+					"type": "string",
+					"default": "auto",
+					"markdownDescription": "Page colour for the Typst block preview. `auto` leaves the page transparent, so the editor or panel background shows through and follows a theme change with no recompile. `none` injects nothing, so Typst uses its own default of white. Any other value is a Typst colour expression used as it is, for example `rgb(\"#1e1e1e\")`. Applies to a plain `typst` block and to a `{=typst}` raw block only.",
+					"title": "Preview Page Colour",
+					"description": "Page colour injected above a previewed block."
+				},
+				"quartoWizard.typstPreview.timeoutMs": {
+					"order": 22,
+					"scope": "resource",
+					"type": "number",
+					"minimum": 1000,
+					"maximum": 300000,
+					"default": 20000,
+					"markdownDescription": "How long one Typst compile may run, in milliseconds. The default of 20000 covers a first-use package download, which is by far the slowest compile a preview makes. Raise it on a slow connection, and lower it to fail faster when no package is ever downloaded.",
+					"title": "Preview Timeout",
+					"description": "Time limit for one preview compile."
 				}
 			}
 		}

--- a/scripts/docs-config.json
+++ b/scripts/docs-config.json
@@ -132,6 +132,11 @@
 			"id": "lint",
 			"title": "Linting",
 			"prefix": "quartoWizard.lint."
+		},
+		{
+			"id": "typst-preview",
+			"title": "Typst Preview",
+			"prefix": "quartoWizard.typstPreview."
 		}
 	],
 	"paths": {

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -177,6 +177,8 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		panel = held;
 		held.onDidDispose(() => {
 			panel = undefined;
+			// There is no image on screen any more, so no colour describes one.
+			shownForeground = undefined;
 		});
 		return held;
 	};

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -43,6 +43,19 @@ const MIN_TIMEOUT_MS = 1000;
 const MAX_TIMEOUT_MS = 300000;
 
 /**
+ * A usable colour setting, whatever the setting holds.
+ *
+ * Exported for its tests. `package.json` declares the type, and a hand-edited
+ * `settings.json` ignores it, so a value that is not a string reaches the
+ * header and is trimmed there.
+ */
+export function previewColour(value: unknown): string {
+	// The header trims the value, so a value that is not a string throws where
+	// nothing catches it, and the panel opens and then stays empty.
+	return typeof value === "string" ? value : "auto";
+}
+
+/**
  * A usable compile timeout, whatever the setting holds.
  *
  * Exported for its tests. The bounds in `package.json` only guide the settings
@@ -65,8 +78,8 @@ export function previewTimeoutMs(value: unknown): number {
 function previewSettings(document: vscode.TextDocument): TypstPreviewSettings {
 	const config = vscode.workspace.getConfiguration("quartoWizard.typstPreview", document.uri);
 	return {
-		foreground: config.get<string>("foreground", "auto"),
-		background: config.get<string>("background", "auto"),
+		foreground: previewColour(config.get("foreground")),
+		background: previewColour(config.get("background")),
 		timeoutMs: previewTimeoutMs(config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS)),
 	};
 }
@@ -285,7 +298,6 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			settings.foreground,
 			settings.background,
 		);
-		shownForeground = foreground;
 		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
 		try {
 			const result = await useCompiler(binary, settings.timeoutMs).compile(assembled.source, ARGV, uncancelled.token);
@@ -297,6 +309,10 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			if (result.stderr.length > 0) {
 				logMessage(`Typst preview: the compiler warned:\n${result.stderr}`, "debug");
 			}
+			// Recorded here and nowhere else. A failed compile leaves the last good
+			// image on screen, so the colour that image was compiled with is still
+			// the colour the reader is looking at.
+			shownForeground = foreground;
 			surface.show(result.svg, headerText(document, block));
 		} catch (error) {
 			if (error instanceof vscode.CancellationError) {

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -143,6 +143,23 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	const usePanel = (): TypstPreviewPanel => panel ?? holdPanel(TypstPreviewPanel.create(context.extensionUri));
 
 	/**
+	 * The compiler for these settings.
+	 *
+	 * The timeout is read once at construction and the setting is resource
+	 * scoped, so the compiler is replaced when the value it was built with no
+	 * longer applies. Nothing is lost by replacing it mid-run, because the next
+	 * compile supersedes whatever is running anyway.
+	 */
+	const useCompiler = (binary: string, timeoutMs: number): TypstCompiler => {
+		if (compiler === undefined || compilerTimeoutMs !== timeoutMs) {
+			compiler?.dispose();
+			compiler = new TypstCompiler(binary, { timeoutMs });
+			compilerTimeoutMs = timeoutMs;
+		}
+		return compiler;
+	};
+
+	/**
 	 * Put a message in front of the reader.
 	 *
 	 * An open panel takes the message itself, which is both quieter and closer to
@@ -232,25 +249,17 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		}
 
 		const settings = previewSettings(document);
-		if (compiler === undefined || compilerTimeoutMs !== settings.timeoutMs) {
-			// Superseding whatever is running is what the next compile would do
-			// anyway, so nothing is lost by replacing the compiler here.
-			compiler?.dispose();
-			compiler = new TypstCompiler(binary, { timeoutMs: settings.timeoutMs });
-			compilerTimeoutMs = settings.timeoutMs;
-		}
-
 		const surface = usePanel();
 		surface.reveal();
 
-		const header = themeHeader(
+		const { header } = themeHeader(
 			themeKindOf(vscode.window.activeColorTheme.kind),
 			settings.foreground,
 			settings.background,
-		).lines.join("\n");
+		);
 		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
 		try {
-			const result = await compiler.compile(assembled.source, ARGV, uncancelled.token);
+			const result = await useCompiler(binary, settings.timeoutMs).compile(assembled.source, ARGV, uncancelled.token);
 			if (result.svg === undefined) {
 				logMessage(`Typst preview: the compiler reported:\n${result.stderr}`, "debug");
 				surface.showError(errorText(result.stderr, assembled.injectedLines));

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -38,6 +38,24 @@ interface TypstPreviewSettings {
 	timeoutMs: number;
 }
 
+/** The bounds `package.json` declares, repeated here because it cannot enforce them. */
+const MIN_TIMEOUT_MS = 1000;
+const MAX_TIMEOUT_MS = 300000;
+
+/**
+ * A usable compile timeout, whatever the setting holds.
+ *
+ * Exported for its tests. The bounds in `package.json` only guide the settings
+ * user interface, so a hand-edited `settings.json` reaches `setTimeout`
+ * unchecked, and `0` there fails every preview before Typst has read anything.
+ */
+export function previewTimeoutMs(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return DEFAULT_TIMEOUT_MS;
+	}
+	return Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, value));
+}
+
 /**
  * The settings in force for one document.
  *
@@ -49,8 +67,15 @@ function previewSettings(document: vscode.TextDocument): TypstPreviewSettings {
 	return {
 		foreground: config.get<string>("foreground", "auto"),
 		background: config.get<string>("background", "auto"),
-		timeoutMs: config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS),
+		timeoutMs: previewTimeoutMs(config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS)),
 	};
+}
+
+/** The text colour the settings and the active theme resolve to. */
+function resolvedForeground(document: vscode.TextDocument): string {
+	const settings = previewSettings(document);
+	return themeHeader(themeKindOf(vscode.window.activeColorTheme.kind), settings.foreground, settings.background)
+		.foreground;
 }
 
 /**
@@ -122,6 +147,9 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	// The compiler reads its timeout once, and the setting is resource scoped, so
 	// the value it was built with is kept to know when it no longer applies.
 	let compilerTimeoutMs: number | undefined;
+	// The colour the image on screen was compiled with, so a theme change can
+	// tell a new colour from a theme that resolves to the same one.
+	let shownForeground: string | undefined;
 	// One message per session, so a machine that cannot run the preview at all
 	// does not report the same thing on every request.
 	let reportedUnavailable = false;
@@ -252,11 +280,12 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		const surface = usePanel();
 		surface.reveal();
 
-		const { header } = themeHeader(
+		const { header, foreground } = themeHeader(
 			themeKindOf(vscode.window.activeColorTheme.kind),
 			settings.foreground,
 			settings.background,
 		);
+		shownForeground = foreground;
 		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
 		try {
 			const result = await useCompiler(binary, settings.timeoutMs).compile(assembled.source, ARGV, uncancelled.token);
@@ -293,6 +322,21 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 				holdPanel(new TypstPreviewPanel(restored, context.extensionUri));
 				await preview(false);
 			},
+		}),
+	);
+
+	// The text colour is derived from the theme kind and baked into the image, so
+	// a theme change leaves the panel showing the wrong one. The panel background
+	// is a CSS variable and needs no help, and two themes of the same kind
+	// resolve to the same colour, so only a colour that actually changed is worth
+	// a compile.
+	context.subscriptions.push(
+		vscode.window.onDidChangeActiveColorTheme(() => {
+			const editor = vscode.window.activeTextEditor;
+			if (panel === undefined || editor === undefined || resolvedForeground(editor.document) === shownForeground) {
+				return;
+			}
+			void preview(false);
 		}),
 	);
 

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -2,23 +2,56 @@ import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
 import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
-import { buildPlainSource, buildRawSource } from "../../utils/typst/typstSource";
+import { buildPlainSource, buildRawSource, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
-import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
+import { DEFAULT_TIMEOUT_MS, TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
 import { TypstPreviewPanel } from "./typstPreviewPanel";
-
-/**
- * The page setup every preview compiles with.
- *
- * A block is a fragment and not a document, so the page has to shrink to it.
- * The margin is not decoration: on a `width: auto` page the glyphs of the
- * outermost characters clip at the edge of the viewBox without it.
- */
-const PAGE_SETUP = "#set page(width: auto, height: auto, margin: 0.5em)";
 
 /** Read the source from stdin, write the image to stdout. */
 const ARGV = ["compile", "--format", "svg", "-", "-"];
+
+/**
+ * The active colour theme as the pure modules name it.
+ *
+ * Exported for its tests. `HighContrast` is the dark one and `HighContrastLight`
+ * the light one, which is the pairing a mapping written from the names alone
+ * gets wrong.
+ */
+export function themeKindOf(kind: vscode.ColorThemeKind): TypstThemeKind {
+	switch (kind) {
+		case vscode.ColorThemeKind.Light:
+			return "light";
+		case vscode.ColorThemeKind.HighContrast:
+			return "high-contrast";
+		case vscode.ColorThemeKind.HighContrastLight:
+			return "high-contrast-light";
+		default:
+			return "dark";
+	}
+}
+
+/** What the settings say about previewing one document. */
+interface TypstPreviewSettings {
+	foreground: string;
+	background: string;
+	timeoutMs: number;
+}
+
+/**
+ * The settings in force for one document.
+ *
+ * They are resource scoped, so a multi-root workspace can hold a different
+ * answer per folder, and the document is what says which folder that is.
+ */
+function previewSettings(document: vscode.TextDocument): TypstPreviewSettings {
+	const config = vscode.workspace.getConfiguration("quartoWizard.typstPreview", document.uri);
+	return {
+		foreground: config.get<string>("foreground", "auto"),
+		background: config.get<string>("background", "auto"),
+		timeoutMs: config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS),
+	};
+}
 
 /**
  * The one line a failure shows inside the panel.
@@ -86,6 +119,9 @@ function headerText(document: vscode.TextDocument, block: TypstBlock): string {
 export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	let panel: TypstPreviewPanel | undefined;
 	let compiler: TypstCompiler | undefined;
+	// The compiler reads its timeout once, and the setting is resource scoped, so
+	// the value it was built with is kept to know when it no longer applies.
+	let compilerTimeoutMs: number | undefined;
 	// One message per session, so a machine that cannot run the preview at all
 	// does not report the same thing on every request.
 	let reportedUnavailable = false;
@@ -194,13 +230,25 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			reportUnavailable("The Typst preview needs the Typst binary that ships inside Quarto, and it was not found.");
 			return;
 		}
-		compiler ??= new TypstCompiler(binary);
+
+		const settings = previewSettings(document);
+		if (compiler === undefined || compilerTimeoutMs !== settings.timeoutMs) {
+			// Superseding whatever is running is what the next compile would do
+			// anyway, so nothing is lost by replacing the compiler here.
+			compiler?.dispose();
+			compiler = new TypstCompiler(binary, { timeoutMs: settings.timeoutMs });
+			compilerTimeoutMs = settings.timeoutMs;
+		}
 
 		const surface = usePanel();
 		surface.reveal();
 
-		const assembled =
-			block.kind === "raw" ? buildRawSource(blocks, block, PAGE_SETUP) : buildPlainSource(block, PAGE_SETUP);
+		const header = themeHeader(
+			themeKindOf(vscode.window.activeColorTheme.kind),
+			settings.foreground,
+			settings.background,
+		).lines.join("\n");
+		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
 		try {
 			const result = await compiler.compile(assembled.source, ARGV, uncancelled.token);
 			if (result.svg === undefined) {
@@ -246,6 +294,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			invalidateTypstBinary();
 			compiler?.dispose();
 			compiler = undefined;
+			compilerTimeoutMs = undefined;
 			reportedUnavailable = false;
 		}),
 	);

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -100,8 +100,13 @@ export function invalidateTypstBinary(): void {
 /** How long a killed child gets to exit before it is killed again, harder. */
 const KILL_GRACE_MS = 2000;
 
-/** How long one compile gets, which also covers a first-use package download. */
-const TIMEOUT_MS = 20000;
+/**
+ * How long one compile gets, which also covers a first-use package download.
+ *
+ * Exported so that the setting which overrides it reads its own default from
+ * here, rather than repeating the number a third time.
+ */
+export const DEFAULT_TIMEOUT_MS = 20000;
 
 /**
  * How much output one compile may produce before it is treated as a failure.
@@ -187,7 +192,7 @@ export class TypstCompiler {
 		}
 		this.stopCurrent();
 
-		const timeoutMs = this.options.timeoutMs ?? TIMEOUT_MS;
+		const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 		const maxOutputBytes = this.options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
 
 		return new Promise<TypstCompileResult>((resolve, reject) => {

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { errorText, previewTimeoutMs, themeKindOf } from "../../providers/typstPreview";
+import { errorText, previewColour, previewTimeoutMs, themeKindOf } from "../../providers/typstPreview";
 import { DEFAULT_TIMEOUT_MS } from "../../providers/typstPreview/typstCompiler";
 
 /** One diagnostic as Typst writes it, on the two lines it uses. */
@@ -77,6 +77,24 @@ suite("Typst Preview Messages Test Suite", () => {
 				// A hand-edited `settings.json` reaches the compiler unchecked, and
 				// `setTimeout` accepts every one of these without complaining.
 				assert.strictEqual(previewTimeoutMs(value), expected);
+			});
+		}
+	});
+
+	suite("previewColour", () => {
+		const cases: [string, unknown, string][] = [
+			["a colour expression", 'rgb("#ff9800")', 'rgb("#ff9800")'],
+			["one of the two words", "none", "none"],
+			["a number, which has no trim", 5, "auto"],
+			["a null, which a cleared key can leave", null, "auto"],
+			["an object", { r: 1 }, "auto"],
+		];
+
+		for (const [description, value, expected] of cases) {
+			test(`Should handle ${description}`, () => {
+				// The header trims the value, so a value that is not a string throws
+				// where nothing catches it, and the panel opens and then stays empty.
+				assert.strictEqual(previewColour(value), expected);
 			});
 		}
 	});

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
-import { errorText } from "../../providers/typstPreview";
+import * as vscode from "vscode";
+import { errorText, themeKindOf } from "../../providers/typstPreview";
 
 /** One diagnostic as Typst writes it, on the two lines it uses. */
 function diagnostic(severity: string, message: string, line: number, column: number, file = "<stdin>"): string {
@@ -57,5 +58,22 @@ suite("Typst Preview Messages Test Suite", () => {
 		test("Should say so when the compiler reported nothing at all", () => {
 			assert.strictEqual(errorText("", 1), "Typst produced no image and reported nothing.");
 		});
+	});
+
+	suite("themeKindOf", () => {
+		const kinds: [vscode.ColorThemeKind, string][] = [
+			[vscode.ColorThemeKind.Light, "light"],
+			[vscode.ColorThemeKind.Dark, "dark"],
+			[vscode.ColorThemeKind.HighContrast, "high-contrast"],
+			[vscode.ColorThemeKind.HighContrastLight, "high-contrast-light"],
+		];
+
+		for (const [kind, expected] of kinds) {
+			test(`Should map ${expected} onto the pure kind`, () => {
+				// `HighContrast` is the dark one and `HighContrastLight` the light one,
+				// which is the pairing a mapping written from the names gets wrong.
+				assert.strictEqual(themeKindOf(kind), expected);
+			});
+		}
 	});
 });

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { errorText, themeKindOf } from "../../providers/typstPreview";
+import { errorText, previewTimeoutMs, themeKindOf } from "../../providers/typstPreview";
+import { DEFAULT_TIMEOUT_MS } from "../../providers/typstPreview/typstCompiler";
 
 /** One diagnostic as Typst writes it, on the two lines it uses. */
 function diagnostic(severity: string, message: string, line: number, column: number, file = "<stdin>"): string {
@@ -58,6 +59,26 @@ suite("Typst Preview Messages Test Suite", () => {
 		test("Should say so when the compiler reported nothing at all", () => {
 			assert.strictEqual(errorText("", 1), "Typst produced no image and reported nothing.");
 		});
+	});
+
+	suite("previewTimeoutMs", () => {
+		const cases: [string, unknown, number][] = [
+			["a value inside the bounds", 5000, 5000],
+			["zero, which would fail every compile at once", 0, 1000],
+			["a negative value", -1, 1000],
+			["a value above the upper bound", 999999, 300000],
+			["a value that is not a number at all", "soon", DEFAULT_TIMEOUT_MS],
+			["a value that is not finite", Number.NaN, DEFAULT_TIMEOUT_MS],
+		];
+
+		for (const [description, value, expected] of cases) {
+			test(`Should handle ${description}`, () => {
+				// The bounds in `package.json` only guide the settings user interface.
+				// A hand-edited `settings.json` reaches the compiler unchecked, and
+				// `setTimeout` accepts every one of these without complaining.
+				assert.strictEqual(previewTimeoutMs(value), expected);
+			});
+		}
 	});
 
 	suite("themeKindOf", () => {

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -173,6 +173,14 @@ suite("Typst Source Test Suite", () => {
 			);
 		});
 
+		test("Should read a blank colour as auto rather than as an expression", () => {
+			// A user who clears the field in the settings user interface leaves an
+			// empty string, which is neither `auto` nor `none`. Written through as an
+			// expression it gives `fill: )`, and every compile then fails on the
+			// header rather than on the block.
+			assert.deepStrictEqual(themeHeader("dark", "  ", ""), themeHeader("dark", "auto", "auto"));
+		});
+
 		test("Should count both header lines as injected lines", () => {
 			// A diagnostic reports a position in the assembled source, so a header
 			// that grows by a line and does not say so moves every reported line.

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -1,9 +1,14 @@
 import * as assert from "assert";
 import { findTypstBlocks } from "../../utils/typst/typstBlocks";
-import { buildPlainSource, buildRawSource } from "../../utils/typst/typstSource";
+import { buildPlainSource, buildRawSource, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 
 /** The page setup a preview injects above every block. */
 const HEADER = "#set page(width: auto, height: auto, margin: 0.5em)";
+
+/** The whole header as one string, which is what the builders take. */
+function header(kind: TypstThemeKind, foreground: string, background: string): string {
+	return themeHeader(kind, foreground, background).lines.join("\n");
+}
 
 /**
  * A raw block binding a name, a cell between the two, and a raw block using
@@ -108,6 +113,76 @@ suite("Typst Source Test Suite", () => {
 			const text = "```{=typst}\n#let a = 1\n```\n\n```{=typst}\n#a";
 			const blocks = findTypstBlocks(text);
 			assert.strictEqual(buildRawSource(blocks, blocks[1], "").source, "#let a = 1\n#a");
+		});
+	});
+
+	suite("themeHeader", () => {
+		test("Should size the page to the block and keep a margin", () => {
+			// A block is a fragment and not a document, so the page shrinks to it.
+			// The margin is not decoration: on a `width: auto` page the glyphs of the
+			// outermost characters clip at the edge of the viewBox without it.
+			const { lines } = themeHeader("dark", "none", "none");
+			assert.deepStrictEqual(lines, ["#set page(width: auto, height: auto, margin: 0.5em)"]);
+		});
+
+		const kinds: [TypstThemeKind, string][] = [
+			["light", "#3b3b3b"],
+			["dark", "#cccccc"],
+			["high-contrast", "#ffffff"],
+			["high-contrast-light", "#292929"],
+		];
+
+		for (const [kind, colour] of kinds) {
+			test(`Should give a ${kind} theme its own text colour`, () => {
+				// The extension host cannot read a theme colour value, so the kind is
+				// all there is to derive one from.
+				const { lines, foreground } = themeHeader(kind, "auto", "none");
+				assert.strictEqual(foreground, `rgb("${colour}")`);
+				assert.strictEqual(lines[1], `#set text(fill: rgb("${colour}"))`);
+			});
+		}
+
+		test("Should write no text line when the foreground is none", () => {
+			// This is what lets an author who sets the colour inside the block keep
+			// the preview out of it entirely.
+			const { lines, foreground } = themeHeader("dark", "none", "auto");
+			assert.strictEqual(lines.length, 1);
+			assert.strictEqual(foreground, "");
+		});
+
+		test("Should pass a Typst colour expression through unchanged", () => {
+			// The value is Typst source and not a colour this module understands, so
+			// anything that is neither `auto` nor `none` is written as it is.
+			const { lines, foreground } = themeHeader("dark", "luma(80%)", "rgb(30, 30, 30)");
+			assert.strictEqual(foreground, "luma(80%)");
+			assert.deepStrictEqual(lines, [
+				"#set page(width: auto, height: auto, margin: 0.5em, fill: rgb(30, 30, 30))",
+				"#set text(fill: luma(80%))",
+			]);
+		});
+
+		test("Should leave the page transparent when the background is auto", () => {
+			// The surface behind the image already carries the editor background and
+			// follows a theme change with no recompile, so the page stays out of it.
+			const { lines } = themeHeader("dark", "none", "auto");
+			assert.deepStrictEqual(lines, ["#set page(width: auto, height: auto, margin: 0.5em, fill: none)"]);
+		});
+
+		test("Should report the same foreground for two kinds that share a colour", () => {
+			// A theme change recompiles only when this value changes, so a setting
+			// that does not depend on the kind must report the same value for every
+			// kind.
+			assert.strictEqual(
+				themeHeader("light", "black", "auto").foreground,
+				themeHeader("dark", "black", "auto").foreground,
+			);
+		});
+
+		test("Should count both header lines as injected lines", () => {
+			// A diagnostic reports a position in the assembled source, so a header
+			// that grows by a line and does not say so moves every reported line.
+			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
+			assert.strictEqual(buildPlainSource(blocks[0], header("dark", "auto", "auto")).injectedLines, 2);
 		});
 	});
 });

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -5,11 +5,6 @@ import { buildPlainSource, buildRawSource, themeHeader, type TypstThemeKind } fr
 /** The page setup a preview injects above every block. */
 const HEADER = "#set page(width: auto, height: auto, margin: 0.5em)";
 
-/** The whole header as one string, which is what the builders take. */
-function header(kind: TypstThemeKind, foreground: string, background: string): string {
-	return themeHeader(kind, foreground, background).lines.join("\n");
-}
-
 /**
  * A raw block binding a name, a cell between the two, and a raw block using
  * that name.
@@ -121,8 +116,8 @@ suite("Typst Source Test Suite", () => {
 			// A block is a fragment and not a document, so the page shrinks to it.
 			// The margin is not decoration: on a `width: auto` page the glyphs of the
 			// outermost characters clip at the edge of the viewBox without it.
-			const { lines } = themeHeader("dark", "none", "none");
-			assert.deepStrictEqual(lines, ["#set page(width: auto, height: auto, margin: 0.5em)"]);
+			const { header } = themeHeader("dark", "none", "none");
+			assert.strictEqual(header, "#set page(width: auto, height: auto, margin: 0.5em)");
 		});
 
 		const kinds: [TypstThemeKind, string][] = [
@@ -136,36 +131,36 @@ suite("Typst Source Test Suite", () => {
 			test(`Should give a ${kind} theme its own text colour`, () => {
 				// The extension host cannot read a theme colour value, so the kind is
 				// all there is to derive one from.
-				const { lines, foreground } = themeHeader(kind, "auto", "none");
+				const { header, foreground } = themeHeader(kind, "auto", "none");
 				assert.strictEqual(foreground, `rgb("${colour}")`);
-				assert.strictEqual(lines[1], `#set text(fill: rgb("${colour}"))`);
+				assert.ok(header.endsWith(`\n#set text(fill: rgb("${colour}"))`));
 			});
 		}
 
 		test("Should write no text line when the foreground is none", () => {
 			// This is what lets an author who sets the colour inside the block keep
 			// the preview out of it entirely.
-			const { lines, foreground } = themeHeader("dark", "none", "auto");
-			assert.strictEqual(lines.length, 1);
+			const { header, foreground } = themeHeader("dark", "none", "auto");
+			assert.ok(!header.includes("#set text"));
 			assert.strictEqual(foreground, "");
 		});
 
 		test("Should pass a Typst colour expression through unchanged", () => {
 			// The value is Typst source and not a colour this module understands, so
 			// anything that is neither `auto` nor `none` is written as it is.
-			const { lines, foreground } = themeHeader("dark", "luma(80%)", "rgb(30, 30, 30)");
+			const { header, foreground } = themeHeader("dark", "luma(80%)", "rgb(30, 30, 30)");
 			assert.strictEqual(foreground, "luma(80%)");
-			assert.deepStrictEqual(lines, [
-				"#set page(width: auto, height: auto, margin: 0.5em, fill: rgb(30, 30, 30))",
-				"#set text(fill: luma(80%))",
-			]);
+			assert.strictEqual(
+				header,
+				"#set page(width: auto, height: auto, margin: 0.5em, fill: rgb(30, 30, 30))\n#set text(fill: luma(80%))",
+			);
 		});
 
 		test("Should leave the page transparent when the background is auto", () => {
 			// The surface behind the image already carries the editor background and
 			// follows a theme change with no recompile, so the page stays out of it.
-			const { lines } = themeHeader("dark", "none", "auto");
-			assert.deepStrictEqual(lines, ["#set page(width: auto, height: auto, margin: 0.5em, fill: none)"]);
+			const { header } = themeHeader("dark", "none", "auto");
+			assert.strictEqual(header, "#set page(width: auto, height: auto, margin: 0.5em, fill: none)");
 		});
 
 		test("Should report the same foreground for two kinds that share a colour", () => {
@@ -182,7 +177,8 @@ suite("Typst Source Test Suite", () => {
 			// A diagnostic reports a position in the assembled source, so a header
 			// that grows by a line and does not say so moves every reported line.
 			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
-			assert.strictEqual(buildPlainSource(blocks[0], header("dark", "auto", "auto")).injectedLines, 2);
+			const { header } = themeHeader("dark", "auto", "auto");
+			assert.strictEqual(buildPlainSource(blocks[0], header).injectedLines, 2);
 		});
 	});
 });

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -113,6 +113,18 @@ function typstColour(hex: string): string {
 }
 
 /**
+ * One colour setting, with a blank value read as `auto`.
+ *
+ * Clearing the field in the settings user interface leaves an empty string,
+ * which is neither of the two words and is not an expression either. Written
+ * through it gives `fill: )`, and every compile then fails on the injected
+ * header rather than on the block the reader is looking at.
+ */
+function setting(value: string): string {
+	return value.trim() === "" ? AUTO : value.trim();
+}
+
+/**
  * The header a plain or a raw block compiles under.
  *
  * The page setup is always written: a block is a fragment and not a document,
@@ -130,14 +142,16 @@ function typstColour(hex: string): string {
  *   its own, or any Typst colour expression, used as it is.
  */
 export function themeHeader(kind: TypstThemeKind, foreground: string, background: string): TypstThemeHeader {
+	const text = setting(foreground);
 	// An `auto` page is transparent, so the surface behind the image supplies the
 	// background and follows a theme change with no recompile.
-	const fill = background === NONE ? "" : `, fill: ${background === AUTO ? NONE : background}`;
-	const page = `#set page(width: auto, height: auto, margin: 0.5em${fill})`;
+	const page = setting(background);
+	const fill = page === NONE ? "" : `, fill: ${page === AUTO ? NONE : page}`;
+	const geometry = `#set page(width: auto, height: auto, margin: 0.5em${fill})`;
 
-	if (foreground === NONE) {
-		return { header: page, foreground: "" };
+	if (text === NONE) {
+		return { header: geometry, foreground: "" };
 	}
-	const colour = foreground === AUTO ? typstColour(THEME_TEXT[kind]) : foreground;
-	return { header: `${page}\n#set text(fill: ${colour})`, foreground: colour };
+	const colour = text === AUTO ? typstColour(THEME_TEXT[kind]) : text;
+	return { header: `${geometry}\n#set text(fill: ${colour})`, foreground: colour };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -65,3 +65,78 @@ export function buildRawSource(blocks: TypstBlock[], target: TypstBlock, header:
 	const context = precedingRawBlocks(blocks, target).map((block) => block.body);
 	return assemble([header, ...context], target.body);
 }
+
+/**
+ * The colour themes the preview tells apart.
+ *
+ * This mirrors `vscode.ColorThemeKind`, which cannot be named here because this
+ * module imports no `vscode`. The provider maps one onto the other.
+ */
+export type TypstThemeKind = "light" | "dark" | "high-contrast" | "high-contrast-light";
+
+/** The lines the preview puts above a block body, and the colour they carry. */
+export interface TypstThemeHeader {
+	/** The `#set` lines, in the order they are written. */
+	lines: string[];
+	/**
+	 * The text colour as it is written into the source, empty when none is.
+	 *
+	 * A theme change recompiles only when this value changes. It is the whole
+	 * theme dependence of the header, because the page never derives anything
+	 * from the theme kind.
+	 */
+	foreground: string;
+}
+
+/** The two values a colour setting can take that are not a colour. */
+const AUTO = "auto";
+const NONE = "none";
+
+/**
+ * The text colour each theme kind gets.
+ *
+ * The host cannot read a theme colour value, so these are the `editor.foreground`
+ * of the four default themes: Light Modern, Dark Modern, High Contrast and High
+ * Contrast Light. A theme of a given kind sits close enough to its default for
+ * the text to stay legible, and an author who disagrees sets the colour.
+ */
+const THEME_TEXT: Record<TypstThemeKind, string> = {
+	light: "#3b3b3b",
+	dark: "#cccccc",
+	"high-contrast": "#ffffff",
+	"high-contrast-light": "#292929",
+};
+
+/** A hex colour as Typst source, which has no bare hex literal. */
+function typstColour(hex: string): string {
+	return `rgb("${hex}")`;
+}
+
+/**
+ * The header a plain or a raw block compiles under.
+ *
+ * The page setup is always written: a block is a fragment and not a document,
+ * so the page has to shrink to it, and on a `width: auto` page the glyphs of the
+ * outermost characters clip at the edge of the viewBox without the margin.
+ *
+ * The colours are a floor and not a ceiling. They are written above the body, so
+ * a later `#set` in the author's own code wins.
+ *
+ * @param kind - The active colour theme kind, which is all the host exposes.
+ * @param foreground - `auto` to derive from the kind, `none` to write no text
+ *   line at all, or any Typst colour expression, used as it is.
+ * @param background - `auto` for a transparent page, so the surface behind the
+ *   image supplies the background, `none` to write no page fill and leave Typst
+ *   its own, or any Typst colour expression, used as it is.
+ */
+export function themeHeader(kind: TypstThemeKind, foreground: string, background: string): TypstThemeHeader {
+	const fill = background === NONE ? "" : `, fill: ${background === AUTO ? NONE : background}`;
+	const lines = [`#set page(width: auto, height: auto, margin: 0.5em${fill})`];
+
+	if (foreground === NONE) {
+		return { lines, foreground: "" };
+	}
+	const colour = foreground === AUTO ? typstColour(THEME_TEXT[kind]) : foreground;
+	lines.push(`#set text(fill: ${colour})`);
+	return { lines, foreground: colour };
+}

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -74,10 +74,10 @@ export function buildRawSource(blocks: TypstBlock[], target: TypstBlock, header:
  */
 export type TypstThemeKind = "light" | "dark" | "high-contrast" | "high-contrast-light";
 
-/** The lines the preview puts above a block body, and the colour they carry. */
+/** What the preview puts above a block body, and the colour it carries. */
 export interface TypstThemeHeader {
-	/** The `#set` lines, in the order they are written. */
-	lines: string[];
+	/** The `#set` lines, which is what the builders take. */
+	header: string;
 	/**
 	 * The text colour as it is written into the source, empty when none is.
 	 *
@@ -130,13 +130,14 @@ function typstColour(hex: string): string {
  *   its own, or any Typst colour expression, used as it is.
  */
 export function themeHeader(kind: TypstThemeKind, foreground: string, background: string): TypstThemeHeader {
+	// An `auto` page is transparent, so the surface behind the image supplies the
+	// background and follows a theme change with no recompile.
 	const fill = background === NONE ? "" : `, fill: ${background === AUTO ? NONE : background}`;
-	const lines = [`#set page(width: auto, height: auto, margin: 0.5em${fill})`];
+	const page = `#set page(width: auto, height: auto, margin: 0.5em${fill})`;
 
 	if (foreground === NONE) {
-		return { lines, foreground: "" };
+		return { header: page, foreground: "" };
 	}
 	const colour = foreground === AUTO ? typstColour(THEME_TEXT[kind]) : foreground;
-	lines.push(`#set text(fill: ${colour})`);
-	return { lines, foreground: colour };
+	return { header: `${page}\n#set text(fill: ${colour})`, foreground: colour };
 }


### PR DESCRIPTION
A plain `typst` block and a `{=typst}` raw block carry no colour options, so the compiled image was black text on a transparent page, unreadable in a dark theme. The preview now writes a page setup and a text colour above the block body.

The extension host cannot read a theme colour value. `vscode.window.activeColorTheme` exposes only `.kind`, so the four kinds map onto the `editor.foreground` of the four default themes. Two themes of the same kind resolve to the same colour, which is what makes the recompile on a theme change cheap: it runs only when the resolved colour actually changed. The panel background stays a CSS variable and follows a theme with no compile at all.

The injected lines are a floor and not a ceiling. They sit above the body, so a `#set` in the author's own code wins. None of this applies to a `{typst}` cell, which carries the filter's own colour contract.

Three settings arrive with it, all resource scoped.

- `quartoWizard.typstPreview.foreground` and `.background` each take `auto`, `none`, or a Typst colour expression used as it is. The two words differ: `auto` derives a colour for the text and leaves the page transparent, while `none` writes nothing and leaves Typst its own default.
- `quartoWizard.typstPreview.timeoutMs` bounds one compile, which also covers a first-use package download.

The bounds and types in `package.json` guide the settings user interface and nothing else, so each value is checked again before it is used: a timeout that is not a finite number falls back to the default and is otherwise clamped, a colour that is not a string reads as `auto`, and a blank colour reads as `auto` rather than reaching Typst as an empty expression.

`docs/reference/configuration.qmd` and the quick reference table in `docs/reference/index.qmd` are regenerated from the contributions.