### PR TITLE
feat: preview a Typst cell with the filter options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The Typst preview fixtures are recorded input and recorded output, and one of
+# them is written with CRLF on purpose. Normalising line endings on checkout or
+# on commit would leave that fixture passing while covering nothing.
+src/test/fixtures/typstPreview/** -text

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,7 @@ export function activate(context: vscode.ExtensionContext) {
 	registerSnippetCompletionProvider(context, snippetCache);
 
 	// Register the Typst block preview for Quarto documents
-	registerTypstPreview(context, schemaCache);
+	registerTypstPreview(context);
 
 	// Register URI handler for browser-based extension installation (e.g., vscode://mcanouil.quarto-wizard/install?repo=owner/repo)
 	context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,7 @@ export function activate(context: vscode.ExtensionContext) {
 	registerSnippetCompletionProvider(context, snippetCache);
 
 	// Register the Typst block preview for Quarto documents
-	registerTypstPreview(context);
+	registerTypstPreview(context, schemaCache);
 
 	// Register URI handler for browser-based extension installation (e.g., vscode://mcanouil.quarto-wizard/install?repo=owner/repo)
 	context.subscriptions.push(

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
-import type { SchemaCache } from "@quarto-wizard/schema";
 import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
@@ -11,6 +10,16 @@ import { TypstPreviewPanel } from "./typstPreviewPanel";
 
 /** Read the source from stdin, write the image to stdout. */
 const ARGV = ["compile", "--format", "svg", "-", "-"];
+
+/** Where the lines of a compile live, so a diagnostic can be placed. */
+export interface ErrorPlace {
+	/** How many lines sit above the compiled code in the assembled source. */
+	injectedLines: number;
+	/** How many lines of the block body sit above the first compiled line. */
+	bodyLineOffset?: number;
+	/** The file whose contents were compiled instead of the block body. */
+	externalFile?: string;
+}
 
 /**
  * The active colour theme as the pure modules name it.
@@ -98,8 +107,8 @@ function resolvedForeground(document: vscode.TextDocument): string {
  * Exported for its tests. The choice of which diagnostic to show carries most
  * of the behaviour, and it is not reachable through the command.
  */
-export function errorText(stderr: string, injectedLines: number): string {
-	const diagnostics = parseTypstStderr(stderr, injectedLines);
+export function errorText(stderr: string, place: ErrorPlace): string {
+	const diagnostics = parseTypstStderr(stderr, place.injectedLines);
 	// A warning can sit above the error that stopped the compile, so the first
 	// diagnostic is not the one to show. Headlining a failure as a warning
 	// misstates why there is no image.
@@ -123,10 +132,19 @@ export function errorText(stderr: string, injectedLines: number): string {
 			// do with the failure.
 			return `${mapped.severity}: ${mapped.message}`;
 		}
-		// The line is counted inside the block, while the panel header counts
-		// document lines, so it says which of the two it means.
 		const column = (mapped.column ?? 0) + 1;
-		return `${mapped.severity} at line ${mapped.line + 1}, column ${column} of the block: ${mapped.message}`;
+		if (place.externalFile !== undefined) {
+			// The body was replaced by that file, so no line of the block corresponds
+			// to the failure at all. Naming the block would send the reader to a line
+			// that has nothing to do with it.
+			return `${mapped.severity} at line ${mapped.line + 1}, column ${column} of ${place.externalFile}: ${mapped.message}`;
+		}
+		// The line is counted inside the block, while the panel header counts
+		// document lines, so it says which of the two it means. A cell compiles its
+		// code and not its body, so the leading option run is added back: without it
+		// every position in a cell with options is short by the length of that run.
+		const line = mapped.line + (place.bodyLineOffset ?? 0) + 1;
+		return `${mapped.severity} at line ${line}, column ${column} of the block: ${mapped.message}`;
 	}
 
 	// Nothing mapped, which means every diagnostic pointed at another file, such
@@ -160,7 +178,7 @@ function headerText(document: vscode.TextDocument, request: CompileRequest): str
  * binary. Neither condition is worth a prompt: the extension does many other
  * things, and a user who never writes a Typst block should never hear about it.
  */
-export function registerTypstPreview(context: vscode.ExtensionContext, schemaCache: SchemaCache): void {
+export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	let panel: TypstPreviewPanel | undefined;
 	let compiler: TypstCompiler | undefined;
 	// The compiler reads its timeout once, and the setting is resource scoped, so
@@ -282,7 +300,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext, schemaCac
 			settings.foreground,
 			settings.background,
 		);
-		const request = await buildCompileRequest(document, editor.selection.active, header, schemaCache);
+		const request = await buildCompileRequest(document, editor.selection.active, header);
 		if (isUnavailable(request)) {
 			explain(request.unavailable);
 			return;
@@ -301,7 +319,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext, schemaCac
 			const result = await useCompiler(binary, settings.timeoutMs).compile(request.source, ARGV, uncancelled.token);
 			if (result.svg === undefined) {
 				logMessage(`Typst preview: the compiler reported:\n${result.stderr}`, "debug");
-				surface.showError(errorText(result.stderr, request.injectedLines));
+				surface.showError(errorText(result.stderr, request));
 				return;
 			}
 			if (result.stderr.length > 0) {

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,10 +1,11 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
-import { buildPlainSource, buildRawSource, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
+import type { SchemaCache } from "@quarto-wizard/schema";
+import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
+import { buildCompileRequest, type CompileRequest } from "./typstContext";
 import { DEFAULT_TIMEOUT_MS, TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
 import { TypstPreviewPanel } from "./typstPreviewPanel";
 
@@ -139,12 +140,17 @@ export function errorText(stderr: string, injectedLines: number): string {
 }
 
 /** What the panel shows about the block it is displaying. */
-function headerText(document: vscode.TextDocument, block: TypstBlock): string {
-	const place = `${path.basename(document.fileName)} · line ${block.fenceLine + 1}`;
-	// A raw block reaches Typst through the document template, which contributes
-	// imports, show rules and set directives the preview cannot apply. Saying so
-	// beside the image is what stops a divergence being read as a defect.
-	return block.kind === "raw" ? `${place} · raw passthrough, document template not applied` : place;
+function headerText(document: vscode.TextDocument, request: CompileRequest): string {
+	const parts = [`${path.basename(document.fileName)} · line ${request.block.fenceLine + 1}`];
+	if (request.brandMode !== undefined) {
+		// A cell resolves its `auto` colours against one side of the brand, and
+		// which side it took is not visible in the image when the two are close.
+		parts.push(`${request.brandMode} brand`);
+	}
+	// Everything the preview does not reproduce about this block. Saying so beside
+	// the image is what stops a divergence being read as a defect.
+	parts.push(...request.notes);
+	return parts.join(" · ");
 }
 
 /**
@@ -154,7 +160,7 @@ function headerText(document: vscode.TextDocument, block: TypstBlock): string {
  * binary. Neither condition is worth a prompt: the extension does many other
  * things, and a user who never writes a Typst block should never hear about it.
  */
-export function registerTypstPreview(context: vscode.ExtensionContext): void {
+export function registerTypstPreview(context: vscode.ExtensionContext, schemaCache: SchemaCache): void {
 	let panel: TypstPreviewPanel | undefined;
 	let compiler: TypstCompiler | undefined;
 	// The compiler reads its timeout once, and the setting is resource scoped, so
@@ -268,20 +274,17 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		}
 
 		const document = editor.document;
-		// The whole list is kept, because a raw block compiles with the raw blocks
-		// above it and scanning the document a second time to find them would say
-		// the same thing twice.
-		const blocks = findTypstBlocks(document.getText());
-		const block = blockAtOffset(blocks, document.offsetAt(editor.selection.active));
-		if (block === undefined) {
-			explain("Put the cursor inside a Typst block to preview it.");
-			return;
-		}
-		if (block.kind === "cell") {
-			// A cell needs its options resolved and its extension present.
-			// Compiling it alone would show an image that the render does not
-			// produce.
-			explain("A `{typst}` cell cannot be previewed yet.");
+		const settings = previewSettings(document);
+		// The header applies to a plain block and a raw block. A cell keeps the
+		// colour contract of the filter instead, and drops it.
+		const { header, foreground } = themeHeader(
+			themeKindOf(vscode.window.activeColorTheme.kind),
+			settings.foreground,
+			settings.background,
+		);
+		const request = await buildCompileRequest(document, editor.selection.active, header, schemaCache);
+		if (isUnavailable(request)) {
+			explain(request.unavailable);
 			return;
 		}
 
@@ -291,21 +294,14 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			return;
 		}
 
-		const settings = previewSettings(document);
 		const surface = usePanel();
 		surface.reveal();
 
-		const { header, foreground } = themeHeader(
-			themeKindOf(vscode.window.activeColorTheme.kind),
-			settings.foreground,
-			settings.background,
-		);
-		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
 		try {
-			const result = await useCompiler(binary, settings.timeoutMs).compile(assembled.source, ARGV, uncancelled.token);
+			const result = await useCompiler(binary, settings.timeoutMs).compile(request.source, ARGV, uncancelled.token);
 			if (result.svg === undefined) {
 				logMessage(`Typst preview: the compiler reported:\n${result.stderr}`, "debug");
-				surface.showError(errorText(result.stderr, assembled.injectedLines));
+				surface.showError(errorText(result.stderr, request.injectedLines));
 				return;
 			}
 			if (result.stderr.length > 0) {
@@ -315,7 +311,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			// image on screen, so the colour that image was compiled with is still
 			// the colour the reader is looking at.
 			shownForeground = foreground;
-			surface.show(result.svg, headerText(document, block));
+			surface.show(result.svg, headerText(document, request));
 		} catch (error) {
 			if (error instanceof vscode.CancellationError) {
 				return;

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,0 +1,251 @@
+import * as path from "node:path";
+import { readFileSync } from "node:fs";
+import * as vscode from "vscode";
+import type { SchemaCache } from "@quarto-wizard/schema";
+import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { buildPlainSource, buildRawSource, buildCell, isUnavailable } from "../../utils/typst/typstSource";
+import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
+import { getWorkspaceSchemaIndex } from "../../utils/workspaceSchemaIndex";
+import { logMessage } from "../../utils/log";
+import { readBrand, readMetadataChain } from "./typstMetadata";
+
+/**
+ * One document and one position turned into a compile.
+ *
+ * This is where the three block kinds stop being interchangeable. A plain block
+ * and a raw block are assembled by the preview, under the preview's own theme
+ * header. A ```` ```{typst} ```` cell belongs to the `typst-render` extension,
+ * and it is assembled under the extension's options and colours instead, so the
+ * image matches the render rather than the editor.
+ */
+
+/**
+ * The version of `typst-render` the golden fixtures were recorded from.
+ *
+ * `src/test/fixtures/typstPreview/README.md` states the refresh procedure. A
+ * newer installed version is not an error: it is a hint that the fixtures are
+ * due a refresh, and a log line is what turns silent drift into something a bug
+ * report can name.
+ */
+export const PINNED_TYPST_RENDER_VERSION = "0.21.0";
+
+/** The full identifier the schema index registers beside the short name. */
+const TYPST_RENDER_ID = `mcanouil/${TYPST_RENDER}`;
+
+/** Everything the compiler and the panel need for one block. */
+export interface CompileRequest {
+	/** The block under the cursor. */
+	block: TypstBlock;
+	/** The whole source to send to the compiler. */
+	source: string;
+	/** How many lines sit above the block body, for mapping a diagnostic back. */
+	injectedLines: number;
+	/** The brand mode a cell resolved with, absent for the other two kinds. */
+	brandMode?: TypstBrandMode;
+	/** What the panel should say about the block beside the image. */
+	notes: string[];
+}
+
+/** A block that cannot be previewed, and the one line that says why. */
+export interface UnavailableRequest {
+	unavailable: string;
+}
+
+/** Whether building a request reported why it could not be done. */
+export function isUnavailableRequest(result: CompileRequest | UnavailableRequest): result is UnavailableRequest {
+	return "unavailable" in result;
+}
+
+/** The brand mode the editor theme asks for, when the document names none. */
+function themeBrandMode(): TypstBrandMode {
+	const kind = vscode.window.activeColorTheme.kind;
+	return kind === vscode.ColorThemeKind.Light || kind === vscode.ColorThemeKind.HighContrastLight ? "light" : "dark";
+}
+
+/**
+ * The installed `typst-render`, when the owning project has one.
+ *
+ * The owning project root is what is asked, not the workspace folder. A project
+ * in a subfolder keeps its own `_extensions/`, and asking the folder would miss
+ * it and report a cell as unpreviewable in a project that installed the
+ * extension.
+ */
+async function installedTypstRender(
+	projectRoot: string | undefined,
+	schemaCache: SchemaCache,
+): Promise<{ installed: false } | { installed: true; version?: string }> {
+	if (projectRoot === undefined) {
+		return { installed: false };
+	}
+	const index = await getWorkspaceSchemaIndex(projectRoot, schemaCache);
+	// The index registers the full identifier and the short name, and a project
+	// can have installed the extension under either.
+	if (index.schemaMap.get(TYPST_RENDER_ID) === undefined && index.schemaMap.get(TYPST_RENDER) === undefined) {
+		return { installed: false };
+	}
+	return {
+		installed: true,
+		version: (index.extMap.get(TYPST_RENDER_ID) ?? index.extMap.get(TYPST_RENDER))?.manifest.version,
+	};
+}
+
+/** Whether an installed version is above the version the fixtures were recorded from. */
+export function isNewerThanPinned(installed: string, pinned: string = PINNED_TYPST_RENDER_VERSION): boolean {
+	const parts = (value: string): number[] => value.split(/[.+-]/).map((part) => Number.parseInt(part, 10));
+	const left = parts(installed);
+	const right = parts(pinned);
+	for (let index = 0; index < Math.max(left.length, right.length); index++) {
+		const a = left[index];
+		const b = right[index];
+		// A part that is not a number ends the comparison rather than deciding it.
+		// A pre-release suffix is not worth a warning of its own.
+		if (Number.isNaN(a) || Number.isNaN(b) || a === undefined || b === undefined) {
+			return false;
+		}
+		if (a !== b) {
+			return a > b;
+		}
+	}
+	return false;
+}
+
+/** Said once per session, because the version does not change while it runs. */
+let reportedDrift = false;
+
+/**
+ * What the first version of the preview does not reproduce about a cell.
+ *
+ * Each of these compiles to something, so refusing them would be worse than
+ * showing the image and saying what is missing from it.
+ *
+ * Exported for its tests: the panel is what shows these, and reaching them
+ * through a compile would need the extension installed and Typst running.
+ */
+export function limitations(block: TypstBlock): string[] {
+	const notes: string[] = [];
+	const format = block.options.format;
+	if (format === "pdf" || format === "html") {
+		// The preview always compiles to SVG, because that is what a webview, a
+		// hover and a decoration can all show.
+		notes.push(`the preview compiles to SVG, not to ${format}`);
+	}
+	if (block.options.output === "asis") {
+		// An `asis` cell is emitted into the document Typst is already laying out,
+		// so it inherits a page the preview has no way to reproduce.
+		notes.push("an `output: asis` cell inherits the document page, which the preview cannot apply");
+	}
+	if (typeof block.options.pages === "string" && block.options.pages !== "all") {
+		notes.push("the preview shows the first page only");
+	}
+	return notes;
+}
+
+/**
+ * The compile one block asks for.
+ *
+ * `header` is the preview's own theme header, and it applies to a plain block
+ * and a raw block alone. A cell keeps the colour contract of `typst-render`:
+ * the filter writes the page fill and the text fill itself, from the options in
+ * force, and a second set of directives above them would show an image the
+ * render does not produce.
+ */
+export async function buildCompileRequest(
+	document: vscode.TextDocument,
+	position: vscode.Position,
+	header: string,
+	schemaCache: SchemaCache,
+): Promise<CompileRequest | UnavailableRequest> {
+	// The whole list is kept, because a raw block compiles with the raw blocks
+	// above it and scanning the document a second time would say the same thing
+	// twice.
+	const blocks = findTypstBlocks(document.getText());
+	const block = blockAtOffset(blocks, document.offsetAt(position));
+	if (block === undefined) {
+		return { unavailable: "Put the cursor inside a Typst block to preview it." };
+	}
+
+	if (block.kind !== "cell") {
+		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
+		return { block, ...assembled, notes: [] };
+	}
+
+	const chain = await readMetadataChain(document);
+	const installed = await installedTypstRender(chain.projectRoot, schemaCache);
+	if (!installed.installed) {
+		// Never previewed with guessed options. A cell compiled without the
+		// extension's own defaults would show an image the render does not
+		// produce, which is worse than showing none.
+		return {
+			unavailable: "A `{typst}` cell needs the typst-render extension, and this project does not have it installed.",
+		};
+	}
+	if (installed.version !== undefined && !reportedDrift && isNewerThanPinned(installed.version)) {
+		reportedDrift = true;
+		logMessage(
+			`Typst preview: typst-render ${installed.version} is installed and the golden fixtures were recorded from ` +
+				`${PINNED_TYPST_RENDER_VERSION}. Refresh them, following src/test/fixtures/typstPreview/README.md.`,
+			"warn",
+		);
+	}
+
+	const documentDirectory = document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
+	const brand = await readBrand(chain, documentDirectory);
+	// The one deliberate deviation from the filter. It always defaults to light,
+	// and the preview follows the editor theme instead, so a dark editor shows a
+	// dark image. An explicit `brand-mode:` still wins.
+	const brandMode = documentBrandMode(chain.metadata) ?? themeBrandMode();
+
+	const built = buildCell(block, {
+		levels: chain.levels,
+		brand,
+		mode: brandMode,
+		readFile: (documentPath) => readTypstFile(documentPath, documentDirectory, chain.projectRoot),
+	});
+	if (isUnavailable(built)) {
+		return { unavailable: built.unavailable };
+	}
+
+	return { block, ...built, brandMode, notes: limitations(block) };
+}
+
+/**
+ * A `preamble:` or `file:` path read as text, `_modules/paths.lua:34-48`.
+ *
+ * A leading `/` means the project root, and every other path is relative to the
+ * document directory. This is not the rule `root`, `font-path` and
+ * `package-path` follow, and conflating the two would read a preamble from the
+ * wrong directory in every project whose documents are not at its root.
+ *
+ * Synchronous, because the pure assembler takes the read as a plain callback and
+ * an asynchronous one would push the whole pipeline into a second pass.
+ *
+ * The path is not confined to the project, because the filter does not confine
+ * it either and a preview that refused a path a render accepts would be wrong
+ * about the document. The whole feature is gated on a trusted workspace, which
+ * is the same boundary a render itself sits behind.
+ */
+function readTypstFile(
+	documentPath: string,
+	documentDirectory: string | undefined,
+	projectRoot: string | undefined,
+): string | undefined {
+	const fromProjectRoot = documentPath.startsWith("/");
+	const base = fromProjectRoot ? projectRoot : documentDirectory;
+	if (base === undefined) {
+		return undefined;
+	}
+	const resolved = path.join(base, fromProjectRoot ? documentPath.slice(1) : documentPath);
+
+	// The open document wins, so a `.typ` being edited beside the block previews
+	// before it is saved.
+	for (const open of vscode.workspace.textDocuments) {
+		if (open.uri.scheme === "file" && path.normalize(open.uri.fsPath) === path.normalize(resolved)) {
+			return open.getText();
+		}
+	}
+	try {
+		return readFileSync(resolved, "utf8");
+	} catch {
+		return undefined;
+	}
+}

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -91,7 +91,10 @@ async function installedTypstRender(projectRoot: string | undefined): Promise<{ 
 	const installed = extensions.find(
 		(extension) =>
 			extension.id.name === TYPST_RENDER &&
-			(extension.id.owner === undefined || extension.id.owner === TYPST_RENDER_OWNER),
+			// Discovery reports `null` and not `undefined` for an ownerless install,
+			// so the loose comparison is deliberate: a copy placed by hand straight
+			// into `_extensions/typst-render/` has no owner directory to read.
+			(extension.id.owner == null || extension.id.owner === TYPST_RENDER_OWNER),
 	);
 	return installed === undefined ? undefined : { version: installed.manifest.version };
 }

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,13 +1,19 @@
-import * as path from "node:path";
-import { readFileSync } from "node:fs";
 import * as vscode from "vscode";
+import * as semver from "semver";
 import type { SchemaCache } from "@quarto-wizard/schema";
 import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
-import { buildPlainSource, buildRawSource, buildCell, isUnavailable } from "../../utils/typst/typstSource";
+import {
+	buildPlainSource,
+	buildRawSource,
+	buildCell,
+	isUnavailable,
+	type Unavailable,
+} from "../../utils/typst/typstSource";
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
 import { getWorkspaceSchemaIndex } from "../../utils/workspaceSchemaIndex";
+import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
 import { logMessage } from "../../utils/log";
-import { readBrand, readMetadataChain } from "./typstMetadata";
+import { readBrand, readMetadataChain, readSourceText, resolveQuartoPath, type MetadataChain } from "./typstMetadata";
 
 /**
  * One document and one position turned into a compile.
@@ -46,16 +52,6 @@ export interface CompileRequest {
 	notes: string[];
 }
 
-/** A block that cannot be previewed, and the one line that says why. */
-export interface UnavailableRequest {
-	unavailable: string;
-}
-
-/** Whether building a request reported why it could not be done. */
-export function isUnavailableRequest(result: CompileRequest | UnavailableRequest): result is UnavailableRequest {
-	return "unavailable" in result;
-}
-
 /** The brand mode the editor theme asks for, when the document names none. */
 function themeBrandMode(): TypstBrandMode {
 	const kind = vscode.window.activeColorTheme.kind;
@@ -63,7 +59,7 @@ function themeBrandMode(): TypstBrandMode {
 }
 
 /**
- * The installed `typst-render`, when the owning project has one.
+ * The installed `typst-render`, or undefined when the project has none.
  *
  * The owning project root is what is asked, not the workspace folder. A project
  * in a subfolder keeps its own `_extensions/`, and asking the folder would miss
@@ -73,71 +69,45 @@ function themeBrandMode(): TypstBrandMode {
 async function installedTypstRender(
 	projectRoot: string | undefined,
 	schemaCache: SchemaCache,
-): Promise<{ installed: false } | { installed: true; version?: string }> {
+): Promise<{ version?: string } | undefined> {
 	if (projectRoot === undefined) {
-		return { installed: false };
+		return undefined;
 	}
 	const index = await getWorkspaceSchemaIndex(projectRoot, schemaCache);
 	// The index registers the full identifier and the short name, and a project
 	// can have installed the extension under either.
 	if (index.schemaMap.get(TYPST_RENDER_ID) === undefined && index.schemaMap.get(TYPST_RENDER) === undefined) {
-		return { installed: false };
+		return undefined;
 	}
-	return {
-		installed: true,
-		version: (index.extMap.get(TYPST_RENDER_ID) ?? index.extMap.get(TYPST_RENDER))?.manifest.version,
-	};
+	return { version: (index.extMap.get(TYPST_RENDER_ID) ?? index.extMap.get(TYPST_RENDER))?.manifest.version };
 }
 
-/** Whether an installed version is above the version the fixtures were recorded from. */
+/**
+ * Whether an installed version is above the one the fixtures were recorded from.
+ *
+ * A version this cannot read is not a warning. `semver.valid` rejects a version
+ * the extension is free to write, and reporting one as drift would send a reader
+ * to a refresh procedure that has nothing to do with what they are seeing.
+ */
 export function isNewerThanPinned(installed: string, pinned: string = PINNED_TYPST_RENDER_VERSION): boolean {
-	const parts = (value: string): number[] => value.split(/[.+-]/).map((part) => Number.parseInt(part, 10));
-	const left = parts(installed);
-	const right = parts(pinned);
-	for (let index = 0; index < Math.max(left.length, right.length); index++) {
-		const a = left[index];
-		const b = right[index];
-		// A part that is not a number ends the comparison rather than deciding it.
-		// A pre-release suffix is not worth a warning of its own.
-		if (Number.isNaN(a) || Number.isNaN(b) || a === undefined || b === undefined) {
-			return false;
-		}
-		if (a !== b) {
-			return a > b;
-		}
-	}
-	return false;
+	const left = semver.coerce(installed);
+	return left !== null && semver.gt(left, pinned);
 }
 
 /** Said once per session, because the version does not change while it runs. */
 let reportedDrift = false;
 
-/**
- * What the first version of the preview does not reproduce about a cell.
- *
- * Each of these compiles to something, so refusing them would be worse than
- * showing the image and saying what is missing from it.
- *
- * Exported for its tests: the panel is what shows these, and reaching them
- * through a compile would need the extension installed and Typst running.
- */
-export function limitations(block: TypstBlock): string[] {
-	const notes: string[] = [];
-	const format = block.options.format;
-	if (format === "pdf" || format === "html") {
-		// The preview always compiles to SVG, because that is what a webview, a
-		// hover and a decoration can all show.
-		notes.push(`the preview compiles to SVG, not to ${format}`);
+/** Report once that the fixtures may no longer describe the installed filter. */
+function reportDrift(version: string | undefined): void {
+	if (version === undefined || reportedDrift || !isNewerThanPinned(version)) {
+		return;
 	}
-	if (block.options.output === "asis") {
-		// An `asis` cell is emitted into the document Typst is already laying out,
-		// so it inherits a page the preview has no way to reproduce.
-		notes.push("an `output: asis` cell inherits the document page, which the preview cannot apply");
-	}
-	if (typeof block.options.pages === "string" && block.options.pages !== "all") {
-		notes.push("the preview shows the first page only");
-	}
-	return notes;
+	reportedDrift = true;
+	logMessage(
+		`Typst preview: typst-render ${version} is installed and the golden fixtures were recorded from ` +
+			`${PINNED_TYPST_RENDER_VERSION}. Refresh them, following src/test/fixtures/typstPreview/README.md.`,
+		"warn",
+	);
 }
 
 /**
@@ -154,11 +124,12 @@ export async function buildCompileRequest(
 	position: vscode.Position,
 	header: string,
 	schemaCache: SchemaCache,
-): Promise<CompileRequest | UnavailableRequest> {
+): Promise<CompileRequest | Unavailable> {
+	const text = document.getText();
 	// The whole list is kept, because a raw block compiles with the raw blocks
 	// above it and scanning the document a second time would say the same thing
 	// twice.
-	const blocks = findTypstBlocks(document.getText());
+	const blocks = findTypstBlocks(text);
 	const block = blockAtOffset(blocks, document.offsetAt(position));
 	if (block === undefined) {
 		return { unavailable: "Put the cursor inside a Typst block to preview it." };
@@ -166,12 +137,19 @@ export async function buildCompileRequest(
 
 	if (block.kind !== "cell") {
 		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
-		return { block, ...assembled, notes: [] };
+		// A raw block reaches Typst through the document template, which contributes
+		// imports, show rules and set directives the preview cannot apply. Saying so
+		// beside the image is what stops a divergence being read as a defect.
+		const notes = block.kind === "raw" ? ["the document template is not applied to a raw passthrough"] : [];
+		return { block, ...assembled, notes };
 	}
 
-	const chain = await readMetadataChain(document);
-	const installed = await installedTypstRender(chain.projectRoot, schemaCache);
-	if (!installed.installed) {
+	// The gate comes before the metadata chain, because it needs only the project
+	// root and it rejects every cell in a project that never installed the
+	// extension. Reading the chain first would spend the whole walk to say no.
+	const projectRoot = await findOwningProjectRoot(document.uri);
+	const installed = await installedTypstRender(projectRoot, schemaCache);
+	if (installed === undefined) {
 		// Never previewed with guessed options. A cell compiled without the
 		// extension's own defaults would show an image the render does not
 		// produce, which is worse than showing none.
@@ -179,33 +157,26 @@ export async function buildCompileRequest(
 			unavailable: "A `{typst}` cell needs the typst-render extension, and this project does not have it installed.",
 		};
 	}
-	if (installed.version !== undefined && !reportedDrift && isNewerThanPinned(installed.version)) {
-		reportedDrift = true;
-		logMessage(
-			`Typst preview: typst-render ${installed.version} is installed and the golden fixtures were recorded from ` +
-				`${PINNED_TYPST_RENDER_VERSION}. Refresh them, following src/test/fixtures/typstPreview/README.md.`,
-			"warn",
-		);
-	}
+	reportDrift(installed.version);
 
-	const documentDirectory = document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
-	const brand = await readBrand(chain, documentDirectory);
+	const chain = await readMetadataChain(document, text, projectRoot);
+	const brand = await readBrand(chain);
 	// The one deliberate deviation from the filter. It always defaults to light,
 	// and the preview follows the editor theme instead, so a dark editor shows a
 	// dark image. An explicit `brand-mode:` still wins.
 	const brandMode = documentBrandMode(chain.metadata) ?? themeBrandMode();
 
-	const built = buildCell(block, {
+	const built = await buildCell(block, {
 		levels: chain.levels,
 		brand,
 		mode: brandMode,
-		readFile: (documentPath) => readTypstFile(documentPath, documentDirectory, chain.projectRoot),
+		readFile: (documentPath) => readTypstFile(documentPath, chain),
 	});
 	if (isUnavailable(built)) {
-		return { unavailable: built.unavailable };
+		return built;
 	}
 
-	return { block, ...built, brandMode, notes: limitations(block) };
+	return { block, ...built, brandMode };
 }
 
 /**
@@ -216,36 +187,12 @@ export async function buildCompileRequest(
  * `package-path` follow, and conflating the two would read a preamble from the
  * wrong directory in every project whose documents are not at its root.
  *
- * Synchronous, because the pure assembler takes the read as a plain callback and
- * an asynchronous one would push the whole pipeline into a second pass.
- *
  * The path is not confined to the project, because the filter does not confine
  * it either and a preview that refused a path a render accepts would be wrong
  * about the document. The whole feature is gated on a trusted workspace, which
  * is the same boundary a render itself sits behind.
  */
-function readTypstFile(
-	documentPath: string,
-	documentDirectory: string | undefined,
-	projectRoot: string | undefined,
-): string | undefined {
-	const fromProjectRoot = documentPath.startsWith("/");
-	const base = fromProjectRoot ? projectRoot : documentDirectory;
-	if (base === undefined) {
-		return undefined;
-	}
-	const resolved = path.join(base, fromProjectRoot ? documentPath.slice(1) : documentPath);
-
-	// The open document wins, so a `.typ` being edited beside the block previews
-	// before it is saved.
-	for (const open of vscode.workspace.textDocuments) {
-		if (open.uri.scheme === "file" && path.normalize(open.uri.fsPath) === path.normalize(resolved)) {
-			return open.getText();
-		}
-	}
-	try {
-		return readFileSync(resolved, "utf8");
-	} catch {
-		return undefined;
-	}
+async function readTypstFile(documentPath: string, chain: MetadataChain): Promise<string | undefined> {
+	const resolved = resolveQuartoPath(documentPath, chain.documentDirectory, chain.projectRoot);
+	return resolved === undefined ? undefined : readSourceText(resolved);
 }

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import * as semver from "semver";
-import type { SchemaCache } from "@quarto-wizard/schema";
 import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
 import {
 	buildPlainSource,
@@ -10,7 +9,7 @@ import {
 	type Unavailable,
 } from "../../utils/typst/typstSource";
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
-import { getWorkspaceSchemaIndex } from "../../utils/workspaceSchemaIndex";
+import { getInstalledExtensionsCached } from "../../utils/installedExtensionsCache";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
 import { logMessage } from "../../utils/log";
 import { readBrand, readMetadataChain, readSourceText, resolveQuartoPath, type MetadataChain } from "./typstMetadata";
@@ -35,8 +34,8 @@ import { readBrand, readMetadataChain, readSourceText, resolveQuartoPath, type M
  */
 export const PINNED_TYPST_RENDER_VERSION = "0.21.0";
 
-/** The full identifier the schema index registers beside the short name. */
-const TYPST_RENDER_ID = `mcanouil/${TYPST_RENDER}`;
+/** The owner the extension is published under, beside its bare name. */
+const TYPST_RENDER_OWNER = "mcanouil";
 
 /** Everything the compiler and the panel need for one block. */
 export interface CompileRequest {
@@ -48,6 +47,15 @@ export interface CompileRequest {
 	injectedLines: number;
 	/** The brand mode a cell resolved with, absent for the other two kinds. */
 	brandMode?: TypstBrandMode;
+	/**
+	 * How many lines of the block body sit above the first compiled line.
+	 *
+	 * Zero for a plain block and a raw block, whose whole body is compiled. A
+	 * cell compiles its code and not its body, so its leading `//|` run counts.
+	 */
+	bodyLineOffset: number;
+	/** The `file:` whose contents replaced a cell body, when one did. */
+	externalFile?: string;
 	/** What the panel should say about the block beside the image. */
 	notes: string[];
 }
@@ -65,21 +73,27 @@ function themeBrandMode(): TypstBrandMode {
  * in a subfolder keeps its own `_extensions/`, and asking the folder would miss
  * it and report a cell as unpreviewable in a project that installed the
  * extension.
+ *
+ * The question is whether the extension is installed, so the installed
+ * extensions are what is read. The workspace schema index answers a narrower
+ * question: it holds only extensions whose `_schema.yml` parsed, so an install
+ * with a missing or broken schema file would read as absent and the preview
+ * would tell a user to install something they already have.
+ *
+ * The owner is matched when the manifest carries one, because an extension
+ * installed from a repository records it and one copied by hand may not.
  */
-async function installedTypstRender(
-	projectRoot: string | undefined,
-	schemaCache: SchemaCache,
-): Promise<{ version?: string } | undefined> {
+async function installedTypstRender(projectRoot: string | undefined): Promise<{ version?: string } | undefined> {
 	if (projectRoot === undefined) {
 		return undefined;
 	}
-	const index = await getWorkspaceSchemaIndex(projectRoot, schemaCache);
-	// The index registers the full identifier and the short name, and a project
-	// can have installed the extension under either.
-	if (index.schemaMap.get(TYPST_RENDER_ID) === undefined && index.schemaMap.get(TYPST_RENDER) === undefined) {
-		return undefined;
-	}
-	return { version: (index.extMap.get(TYPST_RENDER_ID) ?? index.extMap.get(TYPST_RENDER))?.manifest.version };
+	const extensions = await getInstalledExtensionsCached(projectRoot);
+	const installed = extensions.find(
+		(extension) =>
+			extension.id.name === TYPST_RENDER &&
+			(extension.id.owner === undefined || extension.id.owner === TYPST_RENDER_OWNER),
+	);
+	return installed === undefined ? undefined : { version: installed.manifest.version };
 }
 
 /**
@@ -123,7 +137,6 @@ export async function buildCompileRequest(
 	document: vscode.TextDocument,
 	position: vscode.Position,
 	header: string,
-	schemaCache: SchemaCache,
 ): Promise<CompileRequest | Unavailable> {
 	const text = document.getText();
 	// The whole list is kept, because a raw block compiles with the raw blocks
@@ -141,14 +154,14 @@ export async function buildCompileRequest(
 		// imports, show rules and set directives the preview cannot apply. Saying so
 		// beside the image is what stops a divergence being read as a defect.
 		const notes = block.kind === "raw" ? ["the document template is not applied to a raw passthrough"] : [];
-		return { block, ...assembled, notes };
+		return { block, ...assembled, notes, bodyLineOffset: 0 };
 	}
 
 	// The gate comes before the metadata chain, because it needs only the project
 	// root and it rejects every cell in a project that never installed the
 	// extension. Reading the chain first would spend the whole walk to say no.
 	const projectRoot = await findOwningProjectRoot(document.uri);
-	const installed = await installedTypstRender(projectRoot, schemaCache);
+	const installed = await installedTypstRender(projectRoot);
 	if (installed === undefined) {
 		// Never previewed with guessed options. A cell compiled without the
 		// extension's own defaults would show an image the render does not

--- a/src/providers/typstPreview/typstMetadata.ts
+++ b/src/providers/typstPreview/typstMetadata.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import * as yaml from "js-yaml";
 import { getMetadataFiles } from "../../utils/metadataFilesRegistry";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
+import { parseFrontMatter } from "../../utils/yamlPosition";
 import {
 	BRAND_CANDIDATES,
 	EMPTY_BRAND,
@@ -11,7 +12,7 @@ import {
 	splitBrand,
 	type Brand,
 } from "../../utils/typst/typstBrand";
-import { extensionLevel, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
+import { extensionLevel, mapping, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
 
 /**
  * The Quarto metadata chain of one document, read from disk.
@@ -29,27 +30,47 @@ export interface MetadataChain {
 	metadata: Record<string, unknown>;
 	/** The project root that owns the document, when one does. */
 	projectRoot?: string;
+	/** The directory holding the document, when it is a file on disk. */
+	documentDirectory?: string;
+	/**
+	 * The directory a relative `brand:` path resolves from.
+	 *
+	 * Quarto splits the two cases at `src/project/project-shared.ts:597` and
+	 * `:665`: a `brand:` in the project configuration resolves from the project
+	 * root, and one reaching the file metadata resolves from the directory of the
+	 * document. So this is the project root when `_quarto.yml` is the only level
+	 * that names the key, and the document directory when any higher level does.
+	 */
+	brandBase?: string;
 }
 
-/** A YAML document read from disk, or undefined when it is absent or invalid. */
-async function readYaml(fsPath: string): Promise<unknown> {
-	// The open document wins, so an unsaved edit to `_quarto.yml` drives the
-	// preview the way an unsaved edit to the document itself already does.
+/**
+ * A file read as text, preferring a copy open in the editor.
+ *
+ * An unsaved edit to `_quarto.yml` or to a `.typ` beside the block drives the
+ * preview the way an unsaved edit to the document itself already does.
+ */
+export async function readSourceText(fsPath: string): Promise<string | undefined> {
+	const target = path.normalize(fsPath);
 	for (const open of vscode.workspace.textDocuments) {
-		if (open.uri.scheme === "file" && path.normalize(open.uri.fsPath) === path.normalize(fsPath)) {
-			return parse(open.getText());
+		if (open.uri.scheme === "file" && path.normalize(open.uri.fsPath) === target) {
+			return open.getText();
 		}
 	}
 	try {
 		const buffer = await vscode.workspace.fs.readFile(vscode.Uri.file(fsPath));
-		return parse(Buffer.from(buffer).toString("utf8"));
+		return Buffer.from(buffer).toString("utf8");
 	} catch {
 		return undefined;
 	}
 }
 
-/** A YAML string parsed, or undefined when it does not parse. */
-function parse(text: string): unknown {
+/** A YAML document read from disk, or undefined when it is absent or invalid. */
+async function readYaml(fsPath: string): Promise<unknown> {
+	const text = await readSourceText(fsPath);
+	if (text === undefined) {
+		return undefined;
+	}
 	try {
 		return yaml.load(text);
 	} catch {
@@ -57,31 +78,34 @@ function parse(text: string): unknown {
 	}
 }
 
-/** The first of a set of candidate file names that reads, in the given order. */
+/**
+ * The first of a set of candidate file names that reads.
+ *
+ * The candidates are read together and the first defined one wins, because a
+ * directory carrying neither is the common case in the `_metadata.yml` walk and
+ * reading them one after another would pay two misses per directory.
+ */
 async function readFirst(directory: string, names: readonly string[]): Promise<unknown> {
-	for (const name of names) {
-		const document = await readYaml(path.join(directory, name));
-		if (document !== undefined) {
-			return document;
-		}
-	}
-	return undefined;
+	const documents = await Promise.all(names.map((name) => readYaml(path.join(directory, name))));
+	return documents.find((document) => document !== undefined);
 }
 
 /**
- * The front matter of a Quarto document.
+ * A path Quarto resolves against a document or a project,
+ * `_modules/paths.lua:34-48` and `src/project/project-shared.ts:574-584`.
  *
- * Deliberately its own reader rather than `getYamlFrontMatterRange`, which
- * answers a range in a document that may be open and edited. Here the text is
- * already in hand and only the parsed mapping is wanted.
+ * A leading `/` means the project root, and every other path is relative to the
+ * directory passed in. Undefined when there is no directory to resolve against,
+ * which is a document that lives outside every project root.
  */
-export function readFrontMatter(text: string): unknown {
-	const normalised = text.replace(/\r\n/g, "\n");
-	if (!normalised.startsWith("---\n")) {
-		return undefined;
-	}
-	const end = normalised.indexOf("\n---", 3);
-	return end === -1 ? undefined : parse(normalised.slice(4, end + 1));
+export function resolveQuartoPath(
+	quartoPath: string,
+	from: string | undefined,
+	projectRoot: string | undefined,
+): string | undefined {
+	const fromProjectRoot = quartoPath.startsWith("/");
+	const base = fromProjectRoot ? projectRoot : from;
+	return base === undefined ? undefined : path.join(base, fromProjectRoot ? quartoPath.slice(1) : quartoPath);
 }
 
 /**
@@ -104,6 +128,12 @@ function directoriesDownTo(projectRoot: string, documentDirectory: string): stri
 	return directories;
 }
 
+/** One level of the chain, and where a `brand:` path it names would resolve from. */
+interface Level {
+	source: unknown;
+	brandBase?: string;
+}
+
 /**
  * The metadata chain of a document, lowest level first.
  *
@@ -111,59 +141,73 @@ function directoriesDownTo(projectRoot: string, documentDirectory: string): stri
  * through `metadata-files:`, the `_metadata.yml` walk from the project root down
  * to the document directory, and the document front matter last.
  *
+ * Every level is read at once. None of them depends on another's value, and a
+ * document three directories deep otherwise pays a dozen serial reads on every
+ * request. `Promise.all` keeps the index order, which is the precedence order.
+ *
  * `getMetadataFiles` is not itself the chain. It returns only the files reached
  * through `metadata-files:`, and it returns them as a set, so they are read in
  * path order rather than in declaration order. Two of them setting the same key
  * is the only case where that differs, and Quarto is the authority on it, not
  * this preview.
+ *
+ * @param text - The document text, when the caller already has it.
+ * @param projectRoot - The owning root, when the caller has already found it.
  */
-export async function readMetadataChain(document: vscode.TextDocument): Promise<MetadataChain> {
-	const documents: unknown[] = [];
-	const projectRoot = await findOwningProjectRoot(document.uri);
+export async function readMetadataChain(
+	document: vscode.TextDocument,
+	text = document.getText(),
+	projectRoot?: string,
+): Promise<MetadataChain> {
+	const owningRoot = projectRoot ?? (await findOwningProjectRoot(document.uri));
 	const documentDirectory = document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
 
-	if (projectRoot !== undefined) {
-		documents.push(await readFirst(projectRoot, ["_quarto.yml", "_quarto.yaml"]));
+	// The project configuration is its own case for `brand:`, so each level says
+	// which directory a relative path it names would resolve from. Every level
+	// above `_quarto.yml` reaches Quarto through the file metadata, which resolves
+	// from the directory of the document rather than from the level's own.
+	const pending: Promise<Level>[] = [];
+	const level = async (source: Promise<unknown>, brandBase?: string): Promise<Level> => ({
+		source: await source,
+		brandBase,
+	});
 
-		for (const file of [...(await getMetadataFiles(projectRoot))].sort()) {
-			documents.push(await readYaml(file));
+	if (owningRoot !== undefined) {
+		pending.push(level(readFirst(owningRoot, ["_quarto.yml", "_quarto.yaml"]), owningRoot));
+
+		for (const file of [...(await getMetadataFiles(owningRoot))].sort()) {
+			pending.push(level(readYaml(file), documentDirectory));
 		}
 
 		if (documentDirectory !== undefined) {
-			for (const directory of directoriesDownTo(projectRoot, documentDirectory)) {
-				documents.push(await readFirst(directory, ["_metadata.yml", "_metadata.yaml"]));
+			for (const directory of directoriesDownTo(owningRoot, documentDirectory)) {
+				pending.push(level(readFirst(directory, ["_metadata.yml", "_metadata.yaml"]), documentDirectory));
 			}
 		}
 	}
 
-	documents.push(readFrontMatter(document.getText()));
-
 	const levels: TypstGlobalLevel[] = [];
 	const metadata: Record<string, unknown> = {};
-	for (const source of documents) {
-		if (source === null || typeof source !== "object" || Array.isArray(source)) {
+	let brandBase: string | undefined;
+	for (const { source, brandBase: base } of [
+		...(await Promise.all(pending)),
+		{ source: parseFrontMatter(text), brandBase: documentDirectory },
+	]) {
+		const map = mapping(source);
+		if (map === undefined) {
 			continue;
 		}
-		Object.assign(metadata, source as Record<string, unknown>);
-		const level = extensionLevel(source);
-		if (level !== undefined) {
-			levels.push(level);
+		Object.assign(metadata, map);
+		if (map.brand !== undefined) {
+			brandBase = base;
+		}
+		const extension = extensionLevel(map);
+		if (extension !== undefined) {
+			levels.push(extension);
 		}
 	}
 
-	return { levels, metadata, projectRoot };
-}
-
-/**
- * A `brand:` path resolved the way Quarto resolves one,
- * `src/project/project-shared.ts:574-584`.
- *
- * A leading `/` means the project root. Every other path is relative to the
- * directory of the level that wrote the key, which is the document directory for
- * a document-level `brand:` and the project root for a project-level one.
- */
-function resolveBrandPath(brandPath: string, from: string, projectRoot: string): string {
-	return brandPath.startsWith("/") ? path.join(projectRoot, brandPath.slice(1)) : path.join(from, brandPath);
+	return { levels, metadata, projectRoot: owningRoot, documentDirectory, brandBase };
 }
 
 /**
@@ -176,36 +220,36 @@ function resolveBrandPath(brandPath: string, from: string, projectRoot: string):
  * A document outside every project root has no brand, because a brand is a
  * property of a project and there is no root to resolve a path against.
  */
-export async function readBrand(chain: MetadataChain, documentDirectory: string | undefined): Promise<Brand> {
+export async function readBrand(chain: MetadataChain): Promise<Brand> {
 	const projectRoot = chain.projectRoot;
 	if (projectRoot === undefined) {
 		return EMPTY_BRAND;
 	}
 
 	const override = readBrandOverride(chain.metadata.brand);
-	// The key is read from the merged chain, so the level that wrote it is the
-	// highest one that names it. The document directory is where a document-level
-	// path resolves from, and the project root is the fallback.
-	const from = documentDirectory ?? projectRoot;
+	// The chain recorded which level wrote the key, because the project
+	// configuration resolves a relative path from the project root and every level
+	// above it resolves from the directory of the document.
+	const from = chain.brandBase ?? projectRoot;
+	const read = async (brandPath: string | undefined): Promise<unknown> => {
+		const resolved = brandPath === undefined ? undefined : resolveQuartoPath(brandPath, from, projectRoot);
+		return resolved === undefined ? undefined : readYaml(resolved);
+	};
 
 	if (override.kind === "disabled") {
 		return EMPTY_BRAND;
 	}
 	if (override.kind === "unified") {
-		return splitBrand(await readYaml(resolveBrandPath(override.path, from, projectRoot)));
+		return splitBrand(await read(override.path));
 	}
 	if (override.kind === "split") {
-		const read = async (brandPath: string | undefined): Promise<unknown> =>
-			brandPath === undefined ? undefined : readYaml(resolveBrandPath(brandPath, from, projectRoot));
-		return joinBrands(await read(override.light), await read(override.dark));
+		const [light, dark] = await Promise.all([read(override.light), read(override.dark)]);
+		return joinBrands(light, dark);
 	}
 
-	let brand = EMPTY_BRAND;
-	for (const candidate of BRAND_CANDIDATES) {
-		const document = await readYaml(path.join(projectRoot, candidate));
-		if (document !== undefined) {
-			brand = splitBrand(document);
-		}
-	}
-	return brand;
+	// All four are read together, because the last one that exists wins and every
+	// one of them has to be looked at to know which that is.
+	const documents = await Promise.all(BRAND_CANDIDATES.map((candidate) => readYaml(path.join(projectRoot, candidate))));
+	const last = documents.filter((document) => document !== undefined).pop();
+	return last === undefined ? EMPTY_BRAND : splitBrand(last);
 }

--- a/src/providers/typstPreview/typstMetadata.ts
+++ b/src/providers/typstPreview/typstMetadata.ts
@@ -1,0 +1,211 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import * as yaml from "js-yaml";
+import { getMetadataFiles } from "../../utils/metadataFilesRegistry";
+import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
+import {
+	BRAND_CANDIDATES,
+	EMPTY_BRAND,
+	joinBrands,
+	readBrandOverride,
+	splitBrand,
+	type Brand,
+} from "../../utils/typst/typstBrand";
+import { extensionLevel, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
+
+/**
+ * The Quarto metadata chain of one document, read from disk.
+ *
+ * This is the impure half of the cell pipeline. Everything it produces is plain
+ * data, so the assembly under `src/utils/typst/` stays pure and testable without
+ * a workspace.
+ */
+
+/** The metadata one document compiles under. */
+export interface MetadataChain {
+	/** The `typst-render` mapping of each level, lowest first. */
+	levels: TypstGlobalLevel[];
+	/** Every level's own metadata, merged shallowly, lowest first. */
+	metadata: Record<string, unknown>;
+	/** The project root that owns the document, when one does. */
+	projectRoot?: string;
+}
+
+/** A YAML document read from disk, or undefined when it is absent or invalid. */
+async function readYaml(fsPath: string): Promise<unknown> {
+	// The open document wins, so an unsaved edit to `_quarto.yml` drives the
+	// preview the way an unsaved edit to the document itself already does.
+	for (const open of vscode.workspace.textDocuments) {
+		if (open.uri.scheme === "file" && path.normalize(open.uri.fsPath) === path.normalize(fsPath)) {
+			return parse(open.getText());
+		}
+	}
+	try {
+		const buffer = await vscode.workspace.fs.readFile(vscode.Uri.file(fsPath));
+		return parse(Buffer.from(buffer).toString("utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+/** A YAML string parsed, or undefined when it does not parse. */
+function parse(text: string): unknown {
+	try {
+		return yaml.load(text);
+	} catch {
+		return undefined;
+	}
+}
+
+/** The first of a set of candidate file names that reads, in the given order. */
+async function readFirst(directory: string, names: readonly string[]): Promise<unknown> {
+	for (const name of names) {
+		const document = await readYaml(path.join(directory, name));
+		if (document !== undefined) {
+			return document;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * The front matter of a Quarto document.
+ *
+ * Deliberately its own reader rather than `getYamlFrontMatterRange`, which
+ * answers a range in a document that may be open and edited. Here the text is
+ * already in hand and only the parsed mapping is wanted.
+ */
+export function readFrontMatter(text: string): unknown {
+	const normalised = text.replace(/\r\n/g, "\n");
+	if (!normalised.startsWith("---\n")) {
+		return undefined;
+	}
+	const end = normalised.indexOf("\n---", 3);
+	return end === -1 ? undefined : parse(normalised.slice(4, end + 1));
+}
+
+/**
+ * Every directory from a project root down to a document, root first.
+ *
+ * This is what the `_metadata.yml` walk visits, and the order is the precedence
+ * order: a file deeper in the tree is nearer the document and wins.
+ */
+function directoriesDownTo(projectRoot: string, documentDirectory: string): string[] {
+	const relative = path.relative(projectRoot, documentDirectory);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		return [];
+	}
+	const directories = [projectRoot];
+	let current = projectRoot;
+	for (const segment of relative.split(path.sep).filter((part) => part.length > 0)) {
+		current = path.join(current, segment);
+		directories.push(current);
+	}
+	return directories;
+}
+
+/**
+ * The metadata chain of a document, lowest level first.
+ *
+ * The order is Quarto's own: the project `_quarto.yml`, the files it reaches
+ * through `metadata-files:`, the `_metadata.yml` walk from the project root down
+ * to the document directory, and the document front matter last.
+ *
+ * `getMetadataFiles` is not itself the chain. It returns only the files reached
+ * through `metadata-files:`, and it returns them as a set, so they are read in
+ * path order rather than in declaration order. Two of them setting the same key
+ * is the only case where that differs, and Quarto is the authority on it, not
+ * this preview.
+ */
+export async function readMetadataChain(document: vscode.TextDocument): Promise<MetadataChain> {
+	const documents: unknown[] = [];
+	const projectRoot = await findOwningProjectRoot(document.uri);
+	const documentDirectory = document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
+
+	if (projectRoot !== undefined) {
+		documents.push(await readFirst(projectRoot, ["_quarto.yml", "_quarto.yaml"]));
+
+		for (const file of [...(await getMetadataFiles(projectRoot))].sort()) {
+			documents.push(await readYaml(file));
+		}
+
+		if (documentDirectory !== undefined) {
+			for (const directory of directoriesDownTo(projectRoot, documentDirectory)) {
+				documents.push(await readFirst(directory, ["_metadata.yml", "_metadata.yaml"]));
+			}
+		}
+	}
+
+	documents.push(readFrontMatter(document.getText()));
+
+	const levels: TypstGlobalLevel[] = [];
+	const metadata: Record<string, unknown> = {};
+	for (const source of documents) {
+		if (source === null || typeof source !== "object" || Array.isArray(source)) {
+			continue;
+		}
+		Object.assign(metadata, source as Record<string, unknown>);
+		const level = extensionLevel(source);
+		if (level !== undefined) {
+			levels.push(level);
+		}
+	}
+
+	return { levels, metadata, projectRoot };
+}
+
+/**
+ * A `brand:` path resolved the way Quarto resolves one,
+ * `src/project/project-shared.ts:574-584`.
+ *
+ * A leading `/` means the project root. Every other path is relative to the
+ * directory of the level that wrote the key, which is the document directory for
+ * a document-level `brand:` and the project root for a project-level one.
+ */
+function resolveBrandPath(brandPath: string, from: string, projectRoot: string): string {
+	return brandPath.startsWith("/") ? path.join(projectRoot, brandPath.slice(1)) : path.join(from, brandPath);
+}
+
+/**
+ * The brand a document resolves against.
+ *
+ * The four candidate paths and their order are Quarto's, and so is the rule that
+ * the last one that exists wins rather than the first: the loop upstream does
+ * not stop at its first hit.
+ *
+ * A document outside every project root has no brand, because a brand is a
+ * property of a project and there is no root to resolve a path against.
+ */
+export async function readBrand(chain: MetadataChain, documentDirectory: string | undefined): Promise<Brand> {
+	const projectRoot = chain.projectRoot;
+	if (projectRoot === undefined) {
+		return EMPTY_BRAND;
+	}
+
+	const override = readBrandOverride(chain.metadata.brand);
+	// The key is read from the merged chain, so the level that wrote it is the
+	// highest one that names it. The document directory is where a document-level
+	// path resolves from, and the project root is the fallback.
+	const from = documentDirectory ?? projectRoot;
+
+	if (override.kind === "disabled") {
+		return EMPTY_BRAND;
+	}
+	if (override.kind === "unified") {
+		return splitBrand(await readYaml(resolveBrandPath(override.path, from, projectRoot)));
+	}
+	if (override.kind === "split") {
+		const read = async (brandPath: string | undefined): Promise<unknown> =>
+			brandPath === undefined ? undefined : readYaml(resolveBrandPath(brandPath, from, projectRoot));
+		return joinBrands(await read(override.light), await read(override.dark));
+	}
+
+	let brand = EMPTY_BRAND;
+	for (const candidate of BRAND_CANDIDATES) {
+		const document = await readYaml(path.join(projectRoot, candidate));
+		if (document !== undefined) {
+			brand = splitBrand(document);
+		}
+	}
+	return brand;
+}

--- a/src/providers/typstPreview/typstMetadata.ts
+++ b/src/providers/typstPreview/typstMetadata.ts
@@ -1,7 +1,6 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 import * as yaml from "js-yaml";
-import { getMetadataFiles } from "../../utils/metadataFilesRegistry";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
 import { parseFrontMatter } from "../../utils/yamlPosition";
 import {
@@ -131,25 +130,58 @@ function directoriesDownTo(projectRoot: string, documentDirectory: string): stri
 /** One level of the chain, and where a `brand:` path it names would resolve from. */
 interface Level {
 	source: unknown;
+	/** The directory the level's own relative paths resolve against. */
+	directory: string;
+	/** The directory a `brand:` it names resolves against, which is not the same. */
 	brandBase?: string;
+}
+
+/**
+ * The files one level pulls in through `metadata-file:` and `metadata-files:`,
+ * `src/config/metadata.ts:51-66`.
+ *
+ * The singular key comes first, then the list in declaration order, and every
+ * path resolves against the directory of the file that named it.
+ */
+function includedPaths(level: Level): string[] {
+	const map = mapping(level.source);
+	if (map === undefined) {
+		return [];
+	}
+	const named: string[] = [];
+	if (typeof map["metadata-file"] === "string") {
+		named.push(map["metadata-file"]);
+	}
+	if (Array.isArray(map["metadata-files"])) {
+		named.push(...map["metadata-files"].filter((entry): entry is string => typeof entry === "string"));
+	}
+	return named.map((name) => path.resolve(level.directory, name));
 }
 
 /**
  * The metadata chain of a document, lowest level first.
  *
- * The order is Quarto's own: the project `_quarto.yml`, the files it reaches
- * through `metadata-files:`, the `_metadata.yml` walk from the project root down
- * to the document directory, and the document front matter last.
+ * The order is Quarto's own: the project `_quarto.yml`, the `_metadata.yml` walk
+ * from the project root down to the document directory, and the document front
+ * matter last. Each of those can pull in more files, and those sit immediately
+ * above the level that named them, because `mergeProjectMetadata` at
+ * `src/project/project-context.ts:613` merges the included metadata over the
+ * file that included it.
  *
- * Every level is read at once. None of them depends on another's value, and a
- * document three directories deep otherwise pays a dozen serial reads on every
- * request. `Promise.all` keeps the index order, which is the precedence order.
+ * The targets are read per level rather than through `getMetadataFiles`, which
+ * is not the chain and cannot be made into one. It aggregates every target
+ * declared anywhere under the project root into one unordered set, so previewing
+ * one document would merge a file named only in another document's front matter,
+ * and no target would carry the directory that decides where a `brand:` it names
+ * resolves from.
  *
- * `getMetadataFiles` is not itself the chain. It returns only the files reached
- * through `metadata-files:`, and it returns them as a set, so they are read in
- * path order rather than in declaration order. Two of them setting the same key
- * is the only case where that differs, and Quarto is the authority on it, not
- * this preview.
+ * The levels are read together, then their targets are read together. None of
+ * them depends on another's value, and a document three directories deep
+ * otherwise pays a dozen serial reads on every request. `Promise.all` keeps the
+ * index order, which is the precedence order.
+ *
+ * Inclusion is not recursive: a target's own `metadata-files:` is not followed,
+ * which is what Quarto does as well.
  *
  * @param text - The document text, when the caller already has it.
  * @param projectRoot - The owning root, when the caller has already found it.
@@ -165,34 +197,44 @@ export async function readMetadataChain(
 	// The project configuration is its own case for `brand:`, so each level says
 	// which directory a relative path it names would resolve from. Every level
 	// above `_quarto.yml` reaches Quarto through the file metadata, which resolves
-	// from the directory of the document rather than from the level's own.
+	// a `brand:` from the directory of the document rather than from the level's
+	// own, while `metadata-files:` always resolves from the level's own.
 	const pending: Promise<Level>[] = [];
-	const level = async (source: Promise<unknown>, brandBase?: string): Promise<Level> => ({
+	const read = async (source: Promise<unknown>, directory: string, brandBase?: string): Promise<Level> => ({
 		source: await source,
+		directory,
 		brandBase,
 	});
 
 	if (owningRoot !== undefined) {
-		pending.push(level(readFirst(owningRoot, ["_quarto.yml", "_quarto.yaml"]), owningRoot));
-
-		for (const file of [...(await getMetadataFiles(owningRoot))].sort()) {
-			pending.push(level(readYaml(file), documentDirectory));
-		}
+		pending.push(read(readFirst(owningRoot, ["_quarto.yml", "_quarto.yaml"]), owningRoot, owningRoot));
 
 		if (documentDirectory !== undefined) {
 			for (const directory of directoriesDownTo(owningRoot, documentDirectory)) {
-				pending.push(level(readFirst(directory, ["_metadata.yml", "_metadata.yaml"]), documentDirectory));
+				pending.push(read(readFirst(directory, ["_metadata.yml", "_metadata.yaml"]), directory, documentDirectory));
 			}
 		}
 	}
 
+	const declared = [
+		...(await Promise.all(pending)),
+		{ source: parseFrontMatter(text), directory: documentDirectory ?? "", brandBase: documentDirectory },
+	];
+
+	// Every target of every level, read together, then spliced in above the level
+	// that named it.
+	const included = await Promise.all(
+		declared.map((level) => Promise.all(includedPaths(level).map((file) => readYaml(file)))),
+	);
+	const ordered = declared.flatMap((level, index) => [
+		level,
+		...included[index].map((source) => ({ ...level, source })),
+	]);
+
 	const levels: TypstGlobalLevel[] = [];
 	const metadata: Record<string, unknown> = {};
 	let brandBase: string | undefined;
-	for (const { source, brandBase: base } of [
-		...(await Promise.all(pending)),
-		{ source: parseFrontMatter(text), brandBase: documentDirectory },
-	]) {
+	for (const { source, brandBase: base } of ordered) {
 		const map = mapping(source);
 		if (map === undefined) {
 			continue;

--- a/src/test/fixtures/typstPreview/README.md
+++ b/src/test/fixtures/typstPreview/README.md
@@ -13,8 +13,9 @@ An expectation written by hand would only ever agree with the port.
 The fixtures were recorded from `mcanouil/quarto-typst-render` version `0.21.0`.
 Every `meta.json` repeats that version beside the brand mode of its recording.
 
-`src/providers/typstPreview/typstContext.ts` reads the installed version from the workspace schema index and logs a warning when it is above the pinned one.
+`src/providers/typstPreview/typstContext.ts` reads the installed version from the extension's own `_extension.yml` manifest and logs a warning when it is above the pinned one.
 That turns silent drift into a log line between refreshes.
+The fixture suite checks the same constant against every `meta.json`, so a fixture recorded from another version fails the build rather than making that warning lie.
 
 ## What each fixture covers
 

--- a/src/test/fixtures/typstPreview/README.md
+++ b/src/test/fixtures/typstPreview/README.md
@@ -1,0 +1,48 @@
+# Typst preview golden fixtures
+
+These fixtures are recorded output of the `typst-render` filter, not expectations written by hand.
+Each `expected.typ` is a file the filter itself wrote through its own `output-source: true` option.
+`src/test/suite/typstFixtures.test.ts` compiles the same block through the TypeScript port and compares the two byte for byte, after normalising line endings.
+
+That is what makes them a drift guard.
+When the filter changes what it compiles, a refreshed fixture disagrees with the port, and the test names the block that moved.
+An expectation written by hand would only ever agree with the port.
+
+## Pinned version
+
+The fixtures were recorded from `mcanouil/quarto-typst-render` version `0.21.0`.
+Every `meta.json` repeats that version beside the brand mode of its recording.
+
+`src/providers/typstPreview/typstContext.ts` reads the installed version from the workspace schema index and logs a warning when it is above the pinned one.
+That turns silent drift into a log line between refreshes.
+
+## What each fixture covers
+
+| Fixture | Dimension |
+| --- | --- |
+| `bare` | A block with no option at all. |
+| `geometry` | `width`, `height` and `margin` on the page directive. |
+| `background` | A hex background, which locks the `rgb("...")` wrapping. |
+| `foreground` | A foreground, which locks the `#set text(fill: ...)` line and its position. |
+| `inherit-none` | A block writing `background: none` over a global colour, which the filter leaves as the bare word. |
+| `preamble-string` | An inline preamble. |
+| `preamble-list` | A list mixing an inline entry and a `.typ` path, which contributes the blank line the file's own ending carries. |
+| `file` | A `file:` option, whose contents replace the block body and keep their trailing line ending. |
+| `brand-auto` | `auto` colours against a `_brand.yml` with a palette alias. |
+| `brand-dual-light` | The light side of a brand whose two modes differ. |
+| `brand-dual-dark` | The dark side of the same brand. |
+| `crlf` | The same block written with CRLF line endings. |
+
+## Refresh procedure
+
+Run this whenever the pinned version moves.
+
+1. Make a working directory outside this repository, and copy `_extensions/typst-render` of `mcanouil/quarto-typst-render` into it.
+2. Copy the fixture directory into it as well, so its `block.qmd`, its side files and its `_brand.yml` are all in place.
+3. Render it: `quarto render block.qmd --to html`.
+   The front matter already sets `engine: markdown`, `output-source: true` and an `output-directory` of `./recorded`.
+4. Copy the emitted `recorded/block/typst-block-1.typ` over `expected.typ`.
+   A document whose colours differ between the two modes emits `typst-block-1-light.typ` and `typst-block-1-dark.typ` instead, one per fixture.
+5. Update `extensionVersion` in every `meta.json`.
+6. Run `npm run test` and read every difference before accepting it.
+   A difference is a change in what the filter compiles, and the port has to follow it.

--- a/src/test/fixtures/typstPreview/background/block.qmd
+++ b/src/test/fixtures/typstPreview/background/block.qmd
@@ -1,0 +1,15 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+//| background: "#faf6ee"
+#circle(radius: 10pt)
+```

--- a/src/test/fixtures/typstPreview/background/expected.typ
+++ b/src/test/fixtures/typstPreview/background/expected.typ
@@ -1,0 +1,5 @@
+#let _typst_render_background = rgb("#faf6ee")
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: rgb("#faf6ee"))
+#circle(radius: 10pt)

--- a/src/test/fixtures/typstPreview/background/meta.json
+++ b/src/test/fixtures/typstPreview/background/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/bare/block.qmd
+++ b/src/test/fixtures/typstPreview/bare/block.qmd
@@ -1,0 +1,14 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+#circle(radius: 10pt)
+```

--- a/src/test/fixtures/typstPreview/bare/expected.typ
+++ b/src/test/fixtures/typstPreview/bare/expected.typ
@@ -1,0 +1,5 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: none)
+#circle(radius: 10pt)

--- a/src/test/fixtures/typstPreview/bare/meta.json
+++ b/src/test/fixtures/typstPreview/bare/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/brand-auto/_brand.yml
+++ b/src/test/fixtures/typstPreview/brand-auto/_brand.yml
@@ -1,0 +1,10 @@
+color:
+  palette:
+    ink: "#1b1b1b"
+    paper: "#fdf6e3"
+  foreground: ink
+  background: paper
+  primary: "#268bd2"
+typography:
+  base:
+    family: Inter

--- a/src/test/fixtures/typstPreview/brand-auto/_quarto.yml
+++ b/src/test/fixtures/typstPreview/brand-auto/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/src/test/fixtures/typstPreview/brand-auto/block.qmd
+++ b/src/test/fixtures/typstPreview/brand-auto/block.qmd
@@ -1,0 +1,16 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+    background: auto
+    foreground: auto
+---
+
+```{typst}
+#text[Branded]
+```

--- a/src/test/fixtures/typstPreview/brand-auto/expected.typ
+++ b/src/test/fixtures/typstPreview/brand-auto/expected.typ
@@ -1,0 +1,6 @@
+#let _typst_render_background = rgb("#fdf6e3")
+#let _typst_render_foreground = rgb("#1b1b1b")
+#let _typst_render_brand = ("color": ("background": "#fdf6e3", "foreground": "#1b1b1b", "primary": "#268bd2"), "typography": ("base": ("family": "Inter")))
+#set page(width: auto, height: auto, margin: 0.5em, fill: rgb("#fdf6e3"))
+#set text(fill: rgb("#1b1b1b"))
+#text[Branded]

--- a/src/test/fixtures/typstPreview/brand-auto/meta.json
+++ b/src/test/fixtures/typstPreview/brand-auto/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/brand-dual-dark/_brand.yml
+++ b/src/test/fixtures/typstPreview/brand-dual-dark/_brand.yml
@@ -1,0 +1,14 @@
+color:
+  palette:
+    ink: "#1b1b1b"
+    paper: "#fdf6e3"
+  foreground:
+    light: ink
+    dark: "#e8e8e8"
+  background:
+    light: paper
+    dark: "#101418"
+  primary: "#268bd2"
+typography:
+  base:
+    family: Inter

--- a/src/test/fixtures/typstPreview/brand-dual-dark/_quarto.yml
+++ b/src/test/fixtures/typstPreview/brand-dual-dark/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/src/test/fixtures/typstPreview/brand-dual-dark/block.qmd
+++ b/src/test/fixtures/typstPreview/brand-dual-dark/block.qmd
@@ -1,0 +1,17 @@
+---
+engine: markdown
+format: html
+brand-mode: dark
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+    background: auto
+    foreground: auto
+---
+
+```{typst}
+#text[Branded]
+```

--- a/src/test/fixtures/typstPreview/brand-dual-dark/expected.typ
+++ b/src/test/fixtures/typstPreview/brand-dual-dark/expected.typ
@@ -1,0 +1,6 @@
+#let _typst_render_background = rgb("#101418")
+#let _typst_render_foreground = rgb("#e8e8e8")
+#let _typst_render_brand = ("color": ("background": "#101418", "foreground": "#e8e8e8", "primary": "#268bd2"), "typography": ("base": ("family": "Inter")))
+#set page(width: auto, height: auto, margin: 0.5em, fill: rgb("#101418"))
+#set text(fill: rgb("#e8e8e8"))
+#text[Branded]

--- a/src/test/fixtures/typstPreview/brand-dual-dark/meta.json
+++ b/src/test/fixtures/typstPreview/brand-dual-dark/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "dark",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/brand-dual-light/_brand.yml
+++ b/src/test/fixtures/typstPreview/brand-dual-light/_brand.yml
@@ -1,0 +1,14 @@
+color:
+  palette:
+    ink: "#1b1b1b"
+    paper: "#fdf6e3"
+  foreground:
+    light: ink
+    dark: "#e8e8e8"
+  background:
+    light: paper
+    dark: "#101418"
+  primary: "#268bd2"
+typography:
+  base:
+    family: Inter

--- a/src/test/fixtures/typstPreview/brand-dual-light/_quarto.yml
+++ b/src/test/fixtures/typstPreview/brand-dual-light/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  type: default

--- a/src/test/fixtures/typstPreview/brand-dual-light/block.qmd
+++ b/src/test/fixtures/typstPreview/brand-dual-light/block.qmd
@@ -1,0 +1,17 @@
+---
+engine: markdown
+format: html
+brand-mode: dark
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+    background: auto
+    foreground: auto
+---
+
+```{typst}
+#text[Branded]
+```

--- a/src/test/fixtures/typstPreview/brand-dual-light/expected.typ
+++ b/src/test/fixtures/typstPreview/brand-dual-light/expected.typ
@@ -1,0 +1,6 @@
+#let _typst_render_background = rgb("#fdf6e3")
+#let _typst_render_foreground = rgb("#1b1b1b")
+#let _typst_render_brand = ("color": ("background": "#fdf6e3", "foreground": "#1b1b1b", "primary": "#268bd2"), "typography": ("base": ("family": "Inter")))
+#set page(width: auto, height: auto, margin: 0.5em, fill: rgb("#fdf6e3"))
+#set text(fill: rgb("#1b1b1b"))
+#text[Branded]

--- a/src/test/fixtures/typstPreview/brand-dual-light/meta.json
+++ b/src/test/fixtures/typstPreview/brand-dual-light/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/crlf/block.qmd
+++ b/src/test/fixtures/typstPreview/crlf/block.qmd
@@ -1,0 +1,16 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+//| margin: 2mm
+//| width: 5cm
+#circle(radius: 8pt)
+```

--- a/src/test/fixtures/typstPreview/crlf/expected.typ
+++ b/src/test/fixtures/typstPreview/crlf/expected.typ
@@ -1,0 +1,5 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: 5cm, height: auto, margin: 2mm, fill: none)
+#circle(radius: 8pt)

--- a/src/test/fixtures/typstPreview/crlf/meta.json
+++ b/src/test/fixtures/typstPreview/crlf/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/file/block.qmd
+++ b/src/test/fixtures/typstPreview/file/block.qmd
@@ -1,0 +1,15 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+//| file: diagram.typ
+#circle(radius: 99pt)
+```

--- a/src/test/fixtures/typstPreview/file/diagram.typ
+++ b/src/test/fixtures/typstPreview/file/diagram.typ
@@ -1,0 +1,1 @@
+#rect(width: 3cm, height: 1cm)

--- a/src/test/fixtures/typstPreview/file/expected.typ
+++ b/src/test/fixtures/typstPreview/file/expected.typ
@@ -1,0 +1,5 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: none)
+#rect(width: 3cm, height: 1cm)

--- a/src/test/fixtures/typstPreview/file/meta.json
+++ b/src/test/fixtures/typstPreview/file/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/foreground/block.qmd
+++ b/src/test/fixtures/typstPreview/foreground/block.qmd
@@ -1,0 +1,16 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+//| foreground: "#1a1a1a"
+//| background: navy
+#text[Hello]
+```

--- a/src/test/fixtures/typstPreview/foreground/expected.typ
+++ b/src/test/fixtures/typstPreview/foreground/expected.typ
@@ -1,0 +1,6 @@
+#let _typst_render_background = navy
+#let _typst_render_foreground = rgb("#1a1a1a")
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: navy)
+#set text(fill: rgb("#1a1a1a"))
+#text[Hello]

--- a/src/test/fixtures/typstPreview/foreground/meta.json
+++ b/src/test/fixtures/typstPreview/foreground/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/geometry/block.qmd
+++ b/src/test/fixtures/typstPreview/geometry/block.qmd
@@ -1,0 +1,17 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+//| width: 6cm
+//| height: 4cm
+//| margin: 1cm
+#rect(width: 100%)
+```

--- a/src/test/fixtures/typstPreview/geometry/expected.typ
+++ b/src/test/fixtures/typstPreview/geometry/expected.typ
@@ -1,0 +1,5 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: 6cm, height: 4cm, margin: 1cm, fill: none)
+#rect(width: 100%)

--- a/src/test/fixtures/typstPreview/geometry/meta.json
+++ b/src/test/fixtures/typstPreview/geometry/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/inherit-none/block.qmd
+++ b/src/test/fixtures/typstPreview/inherit-none/block.qmd
@@ -1,0 +1,16 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+    background: "#123456"
+---
+
+```{typst}
+//| background: none
+#circle(radius: 10pt)
+```

--- a/src/test/fixtures/typstPreview/inherit-none/expected.typ
+++ b/src/test/fixtures/typstPreview/inherit-none/expected.typ
@@ -1,0 +1,5 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: none)
+#circle(radius: 10pt)

--- a/src/test/fixtures/typstPreview/inherit-none/meta.json
+++ b/src/test/fixtures/typstPreview/inherit-none/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/preamble-list/block.qmd
+++ b/src/test/fixtures/typstPreview/preamble-list/block.qmd
@@ -1,0 +1,17 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+    preamble:
+      - "#let accent = orange"
+      - shared.typ
+---
+
+```{typst}
+#text(fill: accent)[#greeting]
+```

--- a/src/test/fixtures/typstPreview/preamble-list/expected.typ
+++ b/src/test/fixtures/typstPreview/preamble-list/expected.typ
@@ -1,0 +1,8 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: none)
+#let accent = orange
+#let greeting = [Bonjour]
+
+#text(fill: accent)[#greeting]

--- a/src/test/fixtures/typstPreview/preamble-list/meta.json
+++ b/src/test/fixtures/typstPreview/preamble-list/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/fixtures/typstPreview/preamble-list/shared.typ
+++ b/src/test/fixtures/typstPreview/preamble-list/shared.typ
@@ -1,0 +1,1 @@
+#let greeting = [Bonjour]

--- a/src/test/fixtures/typstPreview/preamble-string/block.qmd
+++ b/src/test/fixtures/typstPreview/preamble-string/block.qmd
@@ -1,0 +1,15 @@
+---
+engine: markdown
+format: html
+filters:
+  - typst-render
+extensions:
+  typst-render:
+    output-directory: ./recorded
+    output-source: true
+---
+
+```{typst}
+//| preamble: "#let accent = red"
+#text(fill: accent)[Hi]
+```

--- a/src/test/fixtures/typstPreview/preamble-string/expected.typ
+++ b/src/test/fixtures/typstPreview/preamble-string/expected.typ
@@ -1,0 +1,6 @@
+#let _typst_render_background = none
+#let _typst_render_foreground = none
+#let _typst_render_brand = ("color": (:), "typography": (:))
+#set page(width: auto, height: auto, margin: 0.5em, fill: none)
+#let accent = red
+#text(fill: accent)[Hi]

--- a/src/test/fixtures/typstPreview/preamble-string/meta.json
+++ b/src/test/fixtures/typstPreview/preamble-string/meta.json
@@ -1,0 +1,4 @@
+{
+	"brandMode": "light",
+	"extensionVersion": "0.21.0"
+}

--- a/src/test/suite/typstBrand.test.ts
+++ b/src/test/suite/typstBrand.test.ts
@@ -1,0 +1,194 @@
+import * as assert from "assert";
+import {
+	BRAND_CANDIDATES,
+	EMPTY_BRAND,
+	brandColourReader,
+	brandDictionary,
+	joinBrands,
+	readBrandOverride,
+	splitBrand,
+} from "../../utils/typst/typstBrand";
+
+/** A brand whose palette aliases the two colours a preview reads. */
+const ALIASED = {
+	color: {
+		palette: { ink: "#1b1b1b", paper: "#fdf6e3" },
+		foreground: "ink",
+		background: "paper",
+		primary: "#268bd2",
+	},
+	typography: { base: { family: "Inter" } },
+};
+
+/** A brand whose two modes disagree, written the way `_brand.yml` writes it. */
+const DUAL = {
+	color: {
+		palette: { ink: "#1b1b1b", paper: "#fdf6e3" },
+		foreground: { light: "ink", dark: "#e8e8e8" },
+		background: { light: "paper", dark: "#101418" },
+	},
+};
+
+suite("Typst Brand Test Suite", () => {
+	suite("BRAND_CANDIDATES", () => {
+		test("Should be the four paths Quarto looks at, in Quarto's order", () => {
+			assert.deepStrictEqual(BRAND_CANDIDATES, [
+				"_brand.yml",
+				"_brand.yaml",
+				"_brand/_brand.yml",
+				"_brand/_brand.yaml",
+			]);
+		});
+	});
+
+	suite("brandColourReader", () => {
+		test("Should follow a palette alias to its value", () => {
+			const read = brandColourReader(splitBrand(ALIASED));
+			assert.strictEqual(read("light", "background"), "#fdf6e3");
+			assert.strictEqual(read("light", "foreground"), "#1b1b1b");
+		});
+
+		test("Should read a colour value that needs no alias", () => {
+			assert.strictEqual(brandColourReader(splitBrand(ALIASED))("light", "primary"), "#268bd2");
+		});
+
+		test("Should read the palette entry itself by name", () => {
+			assert.strictEqual(brandColourReader(splitBrand(ALIASED))("light", "ink"), "#1b1b1b");
+		});
+
+		test("Should answer nothing for a name the brand never mentions", () => {
+			// The name itself would otherwise reach the source as `rgb("danger")`,
+			// which does not compile, and `background: auto` must fall back instead.
+			assert.strictEqual(brandColourReader(splitBrand(ALIASED))("light", "danger"), undefined);
+		});
+
+		test("Should read each mode of a brand whose modes disagree", () => {
+			const read = brandColourReader(splitBrand(DUAL));
+			assert.strictEqual(read("light", "background"), "#fdf6e3");
+			assert.strictEqual(read("dark", "background"), "#101418");
+			assert.strictEqual(read("dark", "foreground"), "#e8e8e8");
+		});
+
+		test("Should share the palette between the two modes", () => {
+			// The split copies the palette to both sides, which is what lets an alias
+			// resolve the same way while the name it points at differs by mode.
+			assert.strictEqual(brandColourReader(splitBrand(DUAL))("dark", "ink"), "#1b1b1b");
+		});
+
+		test("Should leave a name out of the mode that does not define it", () => {
+			const brand = splitBrand({ color: { foreground: { dark: "#eee" } } });
+			assert.strictEqual(brandColourReader(brand)("dark", "foreground"), "#eee");
+			assert.strictEqual(brandColourReader(brand)("light", "foreground"), undefined);
+		});
+
+		test("Should answer nothing rather than loop on a cycle", () => {
+			// Quarto throws here. A preview that threw would take out the compile
+			// over a brand file the render also rejects.
+			const brand = splitBrand({ color: { palette: { a: "b", b: "a" }, foreground: "a" } });
+			assert.strictEqual(brandColourReader(brand)("light", "foreground"), undefined);
+		});
+
+		test("Should answer nothing for a brand with no colour at all", () => {
+			assert.strictEqual(brandColourReader(EMPTY_BRAND)("light", "background"), undefined);
+			assert.strictEqual(brandColourReader(splitBrand(undefined))("light", "background"), undefined);
+		});
+	});
+
+	suite("brandDictionary", () => {
+		test("Should carry the resolved hex of every role the brand defines", () => {
+			assert.strictEqual(
+				brandDictionary(splitBrand(ALIASED), "light"),
+				'("color": ("background": "#fdf6e3", "foreground": "#1b1b1b", "primary": "#268bd2"), ' +
+					'"typography": ("base": ("family": "Inter")))',
+			);
+		});
+
+		test("Should hold both keys and an empty dictionary when the brand says nothing", () => {
+			// Consuming Typst code has one shape to read, so the two keys are always
+			// present. `(:)` is the empty dictionary; `()` is the empty array.
+			assert.strictEqual(brandDictionary(EMPTY_BRAND, "light"), '("color": (:), "typography": (:))');
+		});
+
+		test("Should read the dark side of a brand whose modes disagree", () => {
+			assert.strictEqual(
+				brandDictionary(splitBrand(DUAL), "dark"),
+				'("color": ("background": "#101418", "foreground": "#e8e8e8"), "typography": (:))',
+			);
+		});
+
+		test("Should fall back to the other mode for a role written on one side only", () => {
+			// Quarto marks a brand as carrying a dark mode as soon as one role
+			// declares a dark value, so a light-only role would otherwise vanish.
+			const brand = splitBrand({ color: { foreground: { dark: "#eee" }, primary: "#268bd2" } });
+			assert.ok(brandDictionary(brand, "dark").includes('"primary": "#268bd2"'));
+		});
+
+		test("Should leave out a role written in a notation that is not hex", () => {
+			// The dictionary carries brand values, and a consumer would read any
+			// other notation as the name of a palette entry.
+			const brand = splitBrand({ color: { primary: "rebeccapurple", secondary: "#268bd2" } });
+			assert.strictEqual(brandDictionary(brand, "light"), '("color": ("secondary": "#268bd2"), "typography": (:))');
+		});
+
+		test("Should leave out a hex of a length CSS does not allow", () => {
+			const brand = splitBrand({ color: { primary: "#12345" } });
+			assert.strictEqual(brandDictionary(brand, "light"), '("color": (:), "typography": (:))');
+		});
+
+		test("Should carry neither light, dark nor link, which are not roles", () => {
+			const brand = splitBrand({ color: { light: "#ffffff", dark: "#000000", link: "#268bd2" } });
+			assert.strictEqual(brandDictionary(brand, "light"), '("color": (:), "typography": (:))');
+		});
+
+		test("Should read a typography entry written as a bare family name", () => {
+			const brand = splitBrand({ typography: { base: "Inter", headings: { family: "Fira Sans" } } });
+			assert.strictEqual(
+				brandDictionary(brand, "light"),
+				'("color": (:), "typography": ("base": ("family": "Inter"), "headings": ("family": "Fira Sans")))',
+			);
+		});
+
+		test("Should escape a family name that carries a quote", () => {
+			const brand = splitBrand({ typography: { base: { family: 'A "B"' } } });
+			assert.ok(brandDictionary(brand, "light").includes('"base": ("family": "A \\"B\\"")'));
+		});
+	});
+
+	suite("readBrandOverride", () => {
+		test("Should read an absent or true key as the project default", () => {
+			assert.deepStrictEqual(readBrandOverride(undefined), { kind: "default" });
+			assert.deepStrictEqual(readBrandOverride(true), { kind: "default" });
+		});
+
+		test("Should read false as no brand at all", () => {
+			assert.deepStrictEqual(readBrandOverride(false), { kind: "disabled" });
+		});
+
+		test("Should read a string as one unified file", () => {
+			assert.deepStrictEqual(readBrandOverride("theme/_brand.yml"), { kind: "unified", path: "theme/_brand.yml" });
+		});
+
+		test("Should read a map as one file per mode", () => {
+			assert.deepStrictEqual(readBrandOverride({ light: "a.yml", dark: "b.yml" }), {
+				kind: "split",
+				light: "a.yml",
+				dark: "b.yml",
+			});
+		});
+
+		test("Should read a shape Quarto would reject as the project default", () => {
+			// Quarto validates the key and reports it, and saying the same thing
+			// twice about a document Quarto is already refusing helps nobody.
+			assert.deepStrictEqual(readBrandOverride(["a.yml"]), { kind: "default" });
+		});
+	});
+
+	suite("joinBrands", () => {
+		test("Should take each mode from its own file", () => {
+			const brand = joinBrands({ color: { background: "#fdf6e3" } }, { color: { background: "#101418" } });
+			const read = brandColourReader(brand);
+			assert.strictEqual(read("light", "background"), "#fdf6e3");
+			assert.strictEqual(read("dark", "background"), "#101418");
+		});
+	});
+});

--- a/src/test/suite/typstFixtures.test.ts
+++ b/src/test/suite/typstFixtures.test.ts
@@ -1,0 +1,127 @@
+import * as assert from "assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { splitBrand, EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
+import { extensionLevel, type TypstBrandMode, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
+import { buildCell, isUnavailable } from "../../utils/typst/typstSource";
+
+/**
+ * The recorded fixtures of the `typst-render` cell pipeline.
+ *
+ * Each `expected.typ` is output of the filter itself, written by its own
+ * `output-source: true`, and not an expectation written by hand. That is what
+ * makes the comparison a drift guard: when the filter changes what it compiles,
+ * a refreshed fixture disagrees with this port and says so.
+ *
+ * `src/test/fixtures/typstPreview/README.md` holds the refresh procedure and the
+ * pinned extension version.
+ */
+
+const FIXTURES = path.join(__dirname, "..", "..", "..", "src", "test", "fixtures", "typstPreview");
+
+/** What `meta.json` pins about the render that produced a fixture. */
+interface FixtureMeta {
+	brandMode: TypstBrandMode;
+	extensionVersion: string;
+}
+
+/** The front matter of a `.qmd`, parsed, or undefined when it has none. */
+function frontMatter(text: string): unknown {
+	const normalised = text.replace(/\r\n/g, "\n");
+	if (!normalised.startsWith("---\n")) {
+		return undefined;
+	}
+	const end = normalised.indexOf("\n---", 3);
+	return end === -1 ? undefined : yaml.load(normalised.slice(4, end + 1));
+}
+
+/** One YAML file of a fixture directory, or undefined when it is absent. */
+function readYaml(directory: string, name: string): unknown {
+	const file = path.join(directory, name);
+	return fs.existsSync(file) ? yaml.load(fs.readFileSync(file, "utf8")) : undefined;
+}
+
+/**
+ * The metadata levels of a fixture, lowest first.
+ *
+ * A fixture is one directory, so the chain is the project `_quarto.yml` and then
+ * the document front matter. The `_metadata.yml` walk and the `metadata-files:`
+ * targets sit between the two, and the provider is what assembles them from
+ * disk; no fixture needs a level the provider alone can find.
+ */
+function levelsOf(directory: string, metadata: unknown): TypstGlobalLevel[] {
+	const levels: TypstGlobalLevel[] = [];
+	for (const source of [readYaml(directory, "_quarto.yml"), metadata]) {
+		const level = extensionLevel(source);
+		if (level !== undefined) {
+			levels.push(level);
+		}
+	}
+	return levels;
+}
+
+/** The brand of a fixture, from the first candidate path that exists. */
+function brandOf(directory: string): Brand {
+	for (const candidate of ["_brand.yml", "_brand.yaml"]) {
+		const document = readYaml(directory, candidate);
+		if (document !== undefined) {
+			return splitBrand(document);
+		}
+	}
+	return EMPTY_BRAND;
+}
+
+/** The one cell of a fixture document. */
+function cellOf(text: string): TypstBlock {
+	const blocks = findTypstBlocks(text);
+	const block = blockAtOffset(blocks, blocks[0].bodyStart);
+	assert.ok(block !== undefined && block.kind === "cell", "the fixture must hold one executable cell");
+	return block;
+}
+
+suite("Typst Fixtures Test Suite", () => {
+	const names = fs
+		.readdirSync(FIXTURES, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+
+	test("Should find the recorded fixtures", () => {
+		// A path that stopped resolving would otherwise turn every comparison below
+		// into a suite that silently asserts nothing.
+		assert.ok(names.length > 0, `no fixture directory under ${FIXTURES}`);
+	});
+
+	for (const name of names) {
+		const directory = path.join(FIXTURES, name);
+
+		test(`Should compile the ${name} fixture byte for byte`, () => {
+			const meta = JSON.parse(fs.readFileSync(path.join(directory, "meta.json"), "utf8")) as FixtureMeta;
+			const text = fs.readFileSync(path.join(directory, "block.qmd"), "utf8");
+			const metadata = frontMatter(text);
+
+			const built = buildCell(cellOf(text), {
+				levels: levelsOf(directory, metadata),
+				brand: brandOf(directory),
+				// `meta.json` pins the side of the recording, which is what the fixture
+				// compares against. It is not always the mode the document asks for: a
+				// document whose colours differ between the two is rendered twice, and
+				// each side is one fixture.
+				mode: meta.brandMode,
+				readFile: (documentPath) => {
+					const file = path.join(directory, documentPath);
+					return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : undefined;
+				},
+			});
+
+			assert.ok(!isUnavailable(built), `the fixture did not assemble: ${JSON.stringify(built)}`);
+			// Line endings are normalised on both sides. The filter writes the source
+			// it compiled, which Typst reads with either ending, and a fixture
+			// recorded on one platform must not fail on another.
+			const expected = fs.readFileSync(path.join(directory, "expected.typ"), "utf8");
+			assert.strictEqual(built.source.replace(/\r\n/g, "\n"), expected.replace(/\r\n/g, "\n"));
+		});
+	}
+});

--- a/src/test/suite/typstFixtures.test.ts
+++ b/src/test/suite/typstFixtures.test.ts
@@ -80,6 +80,14 @@ suite("Typst Fixtures Test Suite", () => {
 		.map((entry) => entry.name)
 		.sort();
 
+	test("Should keep the CRLF fixture written with CRLF", () => {
+		// Both sides are normalised before the comparison, so a checkout that turned
+		// this file into LF would leave its test passing while covering nothing. The
+		// root `.gitattributes` is what stops that, and this is what notices.
+		const text = fs.readFileSync(path.join(FIXTURES, "crlf", "block.qmd"), "utf8");
+		assert.ok(text.includes("\r\n"), "the crlf fixture must be written with CRLF line endings");
+	});
+
 	test("Should find the recorded fixtures", () => {
 		// A path that stopped resolving would otherwise turn every comparison below
 		// into a suite that silently asserts nothing.

--- a/src/test/suite/typstFixtures.test.ts
+++ b/src/test/suite/typstFixtures.test.ts
@@ -3,9 +3,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as yaml from "js-yaml";
 import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
-import { splitBrand, EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
+import { BRAND_CANDIDATES, splitBrand, EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
 import { extensionLevel, type TypstBrandMode, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
+import { parseFrontMatter } from "../../utils/yamlPosition";
 import { buildCell, isUnavailable } from "../../utils/typst/typstSource";
+import { PINNED_TYPST_RENDER_VERSION } from "../../providers/typstPreview/typstContext";
 
 /**
  * The recorded fixtures of the `typst-render` cell pipeline.
@@ -25,16 +27,6 @@ const FIXTURES = path.join(__dirname, "..", "..", "..", "src", "test", "fixtures
 interface FixtureMeta {
 	brandMode: TypstBrandMode;
 	extensionVersion: string;
-}
-
-/** The front matter of a `.qmd`, parsed, or undefined when it has none. */
-function frontMatter(text: string): unknown {
-	const normalised = text.replace(/\r\n/g, "\n");
-	if (!normalised.startsWith("---\n")) {
-		return undefined;
-	}
-	const end = normalised.indexOf("\n---", 3);
-	return end === -1 ? undefined : yaml.load(normalised.slice(4, end + 1));
 }
 
 /** One YAML file of a fixture directory, or undefined when it is absent. */
@@ -64,7 +56,7 @@ function levelsOf(directory: string, metadata: unknown): TypstGlobalLevel[] {
 
 /** The brand of a fixture, from the first candidate path that exists. */
 function brandOf(directory: string): Brand {
-	for (const candidate of ["_brand.yml", "_brand.yaml"]) {
+	for (const candidate of BRAND_CANDIDATES) {
 		const document = readYaml(directory, candidate);
 		if (document !== undefined) {
 			return splitBrand(document);
@@ -97,12 +89,15 @@ suite("Typst Fixtures Test Suite", () => {
 	for (const name of names) {
 		const directory = path.join(FIXTURES, name);
 
-		test(`Should compile the ${name} fixture byte for byte`, () => {
+		test(`Should compile the ${name} fixture byte for byte`, async () => {
 			const meta = JSON.parse(fs.readFileSync(path.join(directory, "meta.json"), "utf8")) as FixtureMeta;
+			// The constant is what the runtime drift warning compares against, so a
+			// fixture recorded from another version would make that warning lie.
+			assert.strictEqual(meta.extensionVersion, PINNED_TYPST_RENDER_VERSION);
 			const text = fs.readFileSync(path.join(directory, "block.qmd"), "utf8");
-			const metadata = frontMatter(text);
+			const metadata = parseFrontMatter(text);
 
-			const built = buildCell(cellOf(text), {
+			const built = await buildCell(cellOf(text), {
 				levels: levelsOf(directory, metadata),
 				brand: brandOf(directory),
 				// `meta.json` pins the side of the recording, which is what the fixture
@@ -110,7 +105,7 @@ suite("Typst Fixtures Test Suite", () => {
 				// document whose colours differ between the two is rendered twice, and
 				// each side is one fixture.
 				mode: meta.brandMode,
-				readFile: (documentPath) => {
+				readFile: async (documentPath) => {
 					const file = path.join(directory, documentPath);
 					return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : undefined;
 				},

--- a/src/test/suite/typstOptions.test.ts
+++ b/src/test/suite/typstOptions.test.ts
@@ -1,0 +1,308 @@
+import * as assert from "assert";
+import { findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { EMPTY_BRAND, brandColourReader } from "../../utils/typst/typstBrand";
+import {
+	TYPST_DEFAULTS,
+	cssColourToTypst,
+	documentBrandMode,
+	extensionLevel,
+	mergeGlobalConfigs,
+	resolveColourConfig,
+	resolveColourValue,
+	resolveGlobalConfig,
+	resolveTypstOptions,
+	type BrandColourReader,
+	type TypstGlobalLevel,
+} from "../../utils/typst/typstOptions";
+
+/** The one cell of a document written as an option run over one line of code. */
+function cell(options: string[]): TypstBlock {
+	const body = [...options.map((option) => `//| ${option}`), "#circle()"].join("\n");
+	return findTypstBlocks(`\`\`\`{typst}\n${body}\n\`\`\`\n`)[0];
+}
+
+/** A document with no brand at all, which is what every candidate path missing means. */
+const NO_BRAND_READER = brandColourReader(EMPTY_BRAND);
+
+/** A brand answering one colour per mode, for the `auto` cases. */
+function brandOf(light: Record<string, string>, dark: Record<string, string> = light): BrandColourReader {
+	return (mode, name) => (mode === "light" ? light : dark)[name];
+}
+
+suite("Typst Options Test Suite", () => {
+	suite("TYPST_DEFAULTS", () => {
+		// Cross-checked against `typst-render.lua:35-64` rather than read at run
+		// time, because the schema's own `default:` values are documentation and
+		// disagree with the filter in places.
+		test("Should carry the filter's own default for every key it defaults", () => {
+			assert.deepStrictEqual(TYPST_DEFAULTS, {
+				dpi: 144,
+				width: "auto",
+				height: "auto",
+				margin: "0.5em",
+				background: "none",
+				preamble: "",
+				cache: true,
+				"cache-refresh": false,
+				"output-directory": "./assets/typst-render",
+				"output-source": false,
+				echo: false,
+				"code-fold": false,
+				"code-line-numbers": false,
+				eval: true,
+				include: true,
+				output: true,
+				pages: "all",
+			});
+		});
+
+		test("Should hold no key at all for a key the filter defaults to nil", () => {
+			// `merge_options` copies with `pairs`, which skips a nil value, so these
+			// four are absent from a merged table rather than undefined in it.
+			for (const key of ["format", "foreground", "file", "input"]) {
+				assert.ok(!Object.hasOwn(TYPST_DEFAULTS, key), `${key} should be absent`);
+			}
+		});
+	});
+
+	suite("cssColourToTypst", () => {
+		const cases: [string, string][] = [
+			["#fdfdfd", 'rgb("#fdfdfd")'],
+			["#fff", 'rgb("#fff")'],
+			["rgb(255, 0, 0)", 'rgb("rgb(255, 0, 0)")'],
+			["hsl(120, 50%, 50%)", 'rgb("hsl(120, 50%, 50%)")'],
+			// Already Typst form. Wrapping it again would nest a quote inside a
+			// quoted string, which does not compile.
+			['rgb("#fff")', 'rgb("#fff")'],
+			['hsl("120deg, 50%, 50%")', 'hsl("120deg, 50%, 50%")'],
+			// Typst-native spellings, which pass through untouched.
+			["blue", "blue"],
+			["luma(240)", "luma(240)"],
+			["oklch(70% 0.1 200deg)", "oklch(70% 0.1 200deg)"],
+			["none", "none"],
+		];
+
+		for (const [input, expected] of cases) {
+			test(`Should read \`${input}\` as \`${expected}\``, () => {
+				assert.strictEqual(cssColourToTypst(input), expected);
+			});
+		}
+	});
+
+	suite("resolveColourValue", () => {
+		test("Should read one mode of a pair", () => {
+			assert.strictEqual(resolveColourValue({ light: "white", dark: "black" }, "dark"), "black");
+		});
+
+		test("Should fall back to the other mode when the wanted one is absent", () => {
+			// A brand commonly writes one side only, and a block that then rendered
+			// with no colour at all would look like the option was ignored.
+			assert.strictEqual(resolveColourValue({ light: "white" }, "dark"), "white");
+		});
+
+		test("Should read a plain string as itself in either mode", () => {
+			assert.strictEqual(resolveColourValue("navy", "dark"), "navy");
+		});
+
+		test("Should answer nothing for an absent colour", () => {
+			assert.strictEqual(resolveColourValue(undefined, "light"), undefined);
+		});
+	});
+
+	suite("resolveColourConfig", () => {
+		test("Should keep both sides of a light and dark map", () => {
+			const resolved = resolveColourConfig({ light: "#fff", dark: "#000" }, "background", NO_BRAND_READER);
+			assert.deepStrictEqual(resolved, { light: 'rgb("#fff")', dark: 'rgb("#000")' });
+		});
+
+		test("Should collapse a map that names one side to that side", () => {
+			assert.strictEqual(resolveColourConfig({ dark: "#000" }, "background", NO_BRAND_READER), 'rgb("#000")');
+		});
+
+		test("Should read auto from the brand, as a pair when the modes differ", () => {
+			const brand = brandOf({ background: "#fdf6e3" }, { background: "#101418" });
+			assert.deepStrictEqual(resolveColourConfig("auto", "background", brand), {
+				light: 'rgb("#fdf6e3")',
+				dark: 'rgb("#101418")',
+			});
+		});
+
+		test("Should collapse auto to one colour when the brand names the same one twice", () => {
+			// A pair would send the filter down its dual-rendering path for no
+			// difference in output.
+			const brand = brandOf({ background: "#fdf6e3" });
+			assert.strictEqual(resolveColourConfig("auto", "background", brand), 'rgb("#fdf6e3")');
+		});
+
+		test("Should fall back when auto finds no brand colour", () => {
+			assert.strictEqual(resolveColourConfig("auto", "background", NO_BRAND_READER), undefined);
+		});
+
+		test("Should answer nothing for an empty colour", () => {
+			assert.strictEqual(resolveColourConfig("", "foreground", NO_BRAND_READER), undefined);
+		});
+	});
+
+	suite("extensionLevel", () => {
+		test("Should read the extensions mapping", () => {
+			const level = extensionLevel({ extensions: { "typst-render": { dpi: 300 } } });
+			assert.deepStrictEqual(level, { dpi: 300 });
+		});
+
+		test("Should fall back to the bare top-level key", () => {
+			// A legacy spelling the filter still reads, so a document written the old
+			// way previews the way it renders.
+			assert.deepStrictEqual(extensionLevel({ "typst-render": { dpi: 300 } }), { dpi: 300 });
+		});
+
+		test("Should prefer the extensions mapping over the bare key", () => {
+			const level = extensionLevel({
+				extensions: { "typst-render": { dpi: 300 } },
+				"typst-render": { dpi: 96 },
+			});
+			assert.deepStrictEqual(level, { dpi: 300 });
+		});
+
+		test("Should answer nothing for a document that names neither", () => {
+			assert.strictEqual(extensionLevel({ title: "A document" }), undefined);
+		});
+	});
+
+	suite("documentBrandMode", () => {
+		test("Should read an explicit mode", () => {
+			assert.strictEqual(documentBrandMode({ "brand-mode": "dark" }), "dark");
+			assert.strictEqual(documentBrandMode({ "brand-mode": "light" }), "light");
+		});
+
+		test("Should answer nothing when the document sets none", () => {
+			// The filter defaults to light here. The preview follows the editor theme
+			// instead, and undefined is what says the document has no opinion.
+			assert.strictEqual(documentBrandMode({ title: "A document" }), undefined);
+		});
+	});
+
+	suite("resolveGlobalConfig", () => {
+		test("Should coerce a numeric key and drop one that is not a number", () => {
+			assert.strictEqual(resolveGlobalConfig({ dpi: "300" }, NO_BRAND_READER).dpi, 300);
+			assert.ok(!Object.hasOwn(resolveGlobalConfig({ dpi: "wide" }, NO_BRAND_READER), "dpi"));
+		});
+
+		test("Should keep the three-way values of echo, code-fold and output", () => {
+			assert.strictEqual(resolveGlobalConfig({ echo: "fenced" }, NO_BRAND_READER).echo, "fenced");
+			assert.strictEqual(resolveGlobalConfig({ "code-fold": "show" }, NO_BRAND_READER)["code-fold"], "show");
+			assert.strictEqual(resolveGlobalConfig({ output: "asis" }, NO_BRAND_READER).output, "asis");
+		});
+
+		test("Should read an invalid code-fold as false, which is what the warning does", () => {
+			assert.strictEqual(resolveGlobalConfig({ "code-fold": "maybe" }, NO_BRAND_READER)["code-fold"], false);
+		});
+
+		test("Should keep a code-line-numbers range verbatim", () => {
+			assert.strictEqual(
+				resolveGlobalConfig({ "code-line-numbers": "1|3-4" }, NO_BRAND_READER)["code-line-numbers"],
+				"1|3-4",
+			);
+		});
+
+		test("Should store preamble and font-path as lists whichever way they are written", () => {
+			assert.deepStrictEqual(resolveGlobalConfig({ preamble: "#let a = 1" }, NO_BRAND_READER).preamble, ["#let a = 1"]);
+			assert.deepStrictEqual(resolveGlobalConfig({ preamble: ["a", "b.typ"] }, NO_BRAND_READER).preamble, [
+				"a",
+				"b.typ",
+			]);
+			assert.deepStrictEqual(resolveGlobalConfig({ "font-path": "fonts" }, NO_BRAND_READER)["font-path"], ["fonts"]);
+		});
+
+		test("Should read an empty preamble as an empty list, which clears an outer one", () => {
+			assert.deepStrictEqual(resolveGlobalConfig({ preamble: "" }, NO_BRAND_READER).preamble, []);
+		});
+
+		test("Should ignore an input that is not a map", () => {
+			// A string is a warning upstream and is dropped, which leaves whatever an
+			// outer level set.
+			assert.ok(!Object.hasOwn(resolveGlobalConfig({ input: "a=1" }, NO_BRAND_READER), "input"));
+			assert.deepStrictEqual(resolveGlobalConfig({ input: { a: 1 } }, NO_BRAND_READER).input, { a: "1" });
+		});
+	});
+
+	suite("mergeGlobalConfigs", () => {
+		test("Should let a later level win, key by key", () => {
+			const levels: TypstGlobalLevel[] = [{ dpi: 96, margin: "1cm" }, { dpi: 300 }];
+			const merged = mergeGlobalConfigs(levels, NO_BRAND_READER);
+			assert.strictEqual(merged.dpi, 300);
+			assert.strictEqual(merged.margin, "1cm");
+		});
+
+		test("Should resolve each level on its own", () => {
+			// Resolving the merged mapping instead would read two half-written pairs
+			// as though one level had written both halves.
+			const levels: TypstGlobalLevel[] = [{ background: { light: "#fff", dark: "#000" } }, { background: "navy" }];
+			assert.strictEqual(mergeGlobalConfigs(levels, NO_BRAND_READER).background, "navy");
+		});
+	});
+
+	suite("resolveTypstOptions", () => {
+		test("Should let a block option win over a global one", () => {
+			const options = resolveTypstOptions(cell(["margin: 2mm"]), { margin: "1cm" }, NO_BRAND_READER);
+			assert.strictEqual(options.margin, "2mm");
+		});
+
+		test("Should leave the default in place when nothing overrides it", () => {
+			assert.strictEqual(resolveTypstOptions(cell([]), {}, NO_BRAND_READER).width, "auto");
+		});
+
+		test("Should wrap a block colour as a Typst expression", () => {
+			const options = resolveTypstOptions(cell(['background: "#faf6ee"']), {}, NO_BRAND_READER);
+			assert.strictEqual(options.background, 'rgb("#faf6ee")');
+		});
+
+		test("Should not wrap a colour inherited from a global level a second time", () => {
+			// A global value is already an expression, and `rgb("rgb("#fff")")` does
+			// not compile.
+			const options = resolveTypstOptions(cell([]), { background: 'rgb("#faf6ee")' }, NO_BRAND_READER);
+			assert.strictEqual(options.background, 'rgb("#faf6ee")');
+		});
+
+		test("Should leave a block background of none as the bare word", () => {
+			// The guard upstream is against the default and not against the inherited
+			// value, so `none` is left alone rather than rewritten.
+			const options = resolveTypstOptions(
+				cell(["background: none"]),
+				{ background: 'rgb("#123456")' },
+				NO_BRAND_READER,
+			);
+			assert.strictEqual(options.background, "none");
+		});
+
+		test("Should resolve a block auto colour through the brand", () => {
+			const brand = brandOf({ background: "#fdf6e3" });
+			const options = resolveTypstOptions(cell(["background: auto"]), {}, brand);
+			assert.strictEqual(options.background, 'rgb("#fdf6e3")');
+		});
+
+		test("Should leave no foreground key when auto finds no brand", () => {
+			// The filter assigns `DEFAULTS.foreground`, which is nil, and assigning
+			// nil in Lua removes the key.
+			const options = resolveTypstOptions(cell(["foreground: auto"]), {}, NO_BRAND_READER);
+			assert.ok(!Object.hasOwn(options, "foreground"));
+		});
+
+		test("Should drop a per-block cache-refresh, which is a global option", () => {
+			const options = resolveTypstOptions(cell(["cache-refresh: true"]), {}, NO_BRAND_READER);
+			assert.strictEqual(options["cache-refresh"], false);
+		});
+
+		test("Should keep a block input string apart from the global input map", () => {
+			// The merge would otherwise replace the map with the string.
+			const options = resolveTypstOptions(cell(["input: theme=dark"]), { input: { lang: "en" } }, NO_BRAND_READER);
+			assert.deepStrictEqual(options.input, { lang: "en" });
+			assert.strictEqual(options._block_input, "theme=dark");
+		});
+
+		test("Should keep a block dpi as the string the comment-pipe parsed", () => {
+			// The coercion is at the compile and not at the merge, so the merged
+			// table carries the string.
+			assert.strictEqual(resolveTypstOptions(cell(["dpi: 300"]), {}, NO_BRAND_READER).dpi, "300");
+		});
+	});
+});

--- a/src/test/suite/typstOptions.test.ts
+++ b/src/test/suite/typstOptions.test.ts
@@ -280,6 +280,13 @@ suite("Typst Options Test Suite", () => {
 			assert.strictEqual(options.background, 'rgb("#fdf6e3")');
 		});
 
+		test("Should fall back to the default fill when an auto background finds no brand", () => {
+			// The fallback is `DEFAULTS[key]`, and the two colours differ there: the
+			// background has one and the foreground does not.
+			const options = resolveTypstOptions(cell(["background: auto"]), {}, NO_BRAND_READER);
+			assert.strictEqual(options.background, "none");
+		});
+
 		test("Should leave no foreground key when auto finds no brand", () => {
 			// The filter assigns `DEFAULTS.foreground`, which is nil, and assigning
 			// nil in Lua removes the key.
@@ -292,11 +299,12 @@ suite("Typst Options Test Suite", () => {
 			assert.strictEqual(options["cache-refresh"], false);
 		});
 
-		test("Should keep a block input string apart from the global input map", () => {
-			// The merge would otherwise replace the map with the string.
+		test("Should keep the global input map when a block writes an input string", () => {
+			// `input` is a map globally and a comma-separated string per block, so a
+			// plain merge would replace the map with the string and every later reader
+			// of the map would find one.
 			const options = resolveTypstOptions(cell(["input: theme=dark"]), { input: { lang: "en" } }, NO_BRAND_READER);
 			assert.deepStrictEqual(options.input, { lang: "en" });
-			assert.strictEqual(options._block_input, "theme=dark");
 		});
 
 		test("Should keep a block dpi as the string the comment-pipe parsed", () => {

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -5,17 +5,17 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 import { findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
 import { EMPTY_BRAND, brandColourReader, splitBrand } from "../../utils/typst/typstBrand";
-import { buildCell, isUnavailable, resolvePreamble } from "../../utils/typst/typstSource";
+import { mergeGlobalConfigs, resolveTypstOptions, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
+import { buildCell, cellNotes, isUnavailable, resolvePreamble } from "../../utils/typst/typstSource";
 import type { SchemaCache } from "@quarto-wizard/schema";
 import {
 	buildCompileRequest,
 	isNewerThanPinned,
-	isUnavailableRequest,
-	limitations,
 	PINNED_TYPST_RENDER_VERSION,
 } from "../../providers/typstPreview/typstContext";
-import { readBrand, readFrontMatter, readMetadataChain } from "../../providers/typstPreview/typstMetadata";
+import { readBrand, readMetadataChain, resolveQuartoPath } from "../../providers/typstPreview/typstMetadata";
 import { invalidateProjectRoots, setProjectRoots } from "../../utils/projectRootsRegistry";
+import { parseFrontMatter } from "../../utils/yamlPosition";
 import { makeFolder, makeRoot } from "./projectFixtures";
 
 /** The one cell of a document written as an option run over one line of code. */
@@ -25,35 +25,35 @@ function cell(options: string[], code = "#circle()"): TypstBlock {
 }
 
 /** A read that answers from a table rather than from disk. */
-function reader(files: Record<string, string>): (documentPath: string) => string | undefined {
-	return (documentPath) => files[documentPath];
+function reader(files: Record<string, string>): (documentPath: string) => Promise<string | undefined> {
+	return (documentPath) => Promise.resolve(files[documentPath]);
 }
 
 suite("Typst Preview Context Test Suite", () => {
 	suite("resolvePreamble", () => {
-		test("Should keep an entry that is not a path as inline code", () => {
-			assert.strictEqual(resolvePreamble("#let a = 1", reader({})), "#let a = 1");
+		test("Should keep an entry that is not a path as inline code", async () => {
+			assert.strictEqual(await resolvePreamble("#let a = 1", reader({})), "#let a = 1");
 		});
 
-		test("Should read an entry ending in .typ from disk", () => {
-			assert.strictEqual(resolvePreamble("shared.typ", reader({ "shared.typ": "#let a = 1\n" })), "#let a = 1\n");
+		test("Should read an entry ending in .typ from disk", async () => {
+			assert.strictEqual(await resolvePreamble("shared.typ", reader({ "shared.typ": "#let a = 1\n" })), "#let a = 1\n");
 		});
 
-		test("Should join a list with newlines, in order", () => {
-			const resolved = resolvePreamble(["#let a = 1", "shared.typ"], reader({ "shared.typ": "#let b = 2" }));
+		test("Should join a list with newlines, in order", async () => {
+			const resolved = await resolvePreamble(["#let a = 1", "shared.typ"], reader({ "shared.typ": "#let b = 2" }));
 			assert.strictEqual(resolved, "#let a = 1\n#let b = 2");
 		});
 
-		test("Should drop an entry that cannot be read rather than failing", () => {
+		test("Should drop an entry that cannot be read rather than failing", async () => {
 			// The filter logs and carries on. A preview that refused the whole block
 			// would say nothing about the one entry that is wrong.
-			assert.strictEqual(resolvePreamble(["#let a = 1", "missing.typ"], reader({})), "#let a = 1");
+			assert.strictEqual(await resolvePreamble(["#let a = 1", "missing.typ"], reader({})), "#let a = 1");
 		});
 
-		test("Should answer nothing for an absent or empty preamble", () => {
-			assert.strictEqual(resolvePreamble(undefined, reader({})), "");
-			assert.strictEqual(resolvePreamble("", reader({})), "");
-			assert.strictEqual(resolvePreamble([], reader({})), "");
+		test("Should answer nothing for an absent or empty preamble", async () => {
+			assert.strictEqual(await resolvePreamble(undefined, reader({})), "");
+			assert.strictEqual(await resolvePreamble("", reader({})), "");
+			assert.strictEqual(await resolvePreamble([], reader({})), "");
 		});
 	});
 
@@ -65,8 +65,8 @@ suite("Typst Preview Context Test Suite", () => {
 			readFile: reader({}),
 		};
 
-		test("Should count every injected line so a diagnostic maps back", () => {
-			const built = buildCell(cell([]), context);
+		test("Should count every injected line so a diagnostic maps back", async () => {
+			const built = await buildCell(cell([]), context);
 			assert.ok(!isUnavailable(built));
 			// Three bindings and the page directive, and no `#set text` because
 			// nothing set a foreground.
@@ -74,23 +74,23 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(built.source.endsWith("\n#circle()"));
 		});
 
-		test("Should add the text fill line when a foreground is set", () => {
-			const built = buildCell(cell(['foreground: "#1a1a1a"']), context);
+		test("Should add the text fill line when a foreground is set", async () => {
+			const built = await buildCell(cell(['foreground: "#1a1a1a"']), context);
 			assert.ok(!isUnavailable(built));
 			assert.strictEqual(built.injectedLines, 5);
 			assert.ok(built.source.includes('#set text(fill: rgb("#1a1a1a"))'));
 		});
 
-		test("Should bind the foreground as none when nothing sets one", () => {
+		test("Should bind the foreground as none when nothing sets one", async () => {
 			// Consuming Typst code reads `_typst_render_foreground` whether or not
 			// the document sets a colour, so the binding is always written.
-			const built = buildCell(cell([]), context);
+			const built = await buildCell(cell([]), context);
 			assert.ok(!isUnavailable(built));
 			assert.ok(built.source.includes("#let _typst_render_foreground = none"));
 		});
 
-		test("Should replace the body with the contents of a file option", () => {
-			const built = buildCell(cell(["file: diagram.typ"]), {
+		test("Should replace the body with the contents of a file option", async () => {
+			const built = await buildCell(cell(["file: diagram.typ"]), {
 				...context,
 				readFile: reader({ "diagram.typ": "#rect()\n" }),
 			});
@@ -99,58 +99,90 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(!built.source.includes("#circle()"));
 		});
 
-		test("Should say so when a file option cannot be read", () => {
+		test("Should say so when a file option cannot be read", async () => {
 			// The filter renders nothing here. A blank image with no reason beside
 			// it would look like the block itself was empty.
-			const built = buildCell(cell(["file: missing.typ"]), context);
+			const built = await buildCell(cell(["file: missing.typ"]), context);
 			assert.ok(isUnavailable(built));
 			assert.ok(built.unavailable.includes("missing.typ"));
 		});
 
-		test("Should read the colours of the mode in force", () => {
+		test("Should read the colours of the mode in force", async () => {
 			const brand = splitBrand({
 				color: { background: { light: "#fdf6e3", dark: "#101418" } },
 			});
-			const dark = buildCell(cell(["background: auto"]), { ...context, brand, mode: "dark" });
+			const dark = await buildCell(cell(["background: auto"]), { ...context, brand, mode: "dark" });
 			assert.ok(!isUnavailable(dark));
 			assert.ok(dark.source.includes('#let _typst_render_background = rgb("#101418")'));
 		});
 
-		test("Should let a global level set the geometry", () => {
-			const built = buildCell(cell([]), { ...context, levels: [{ width: "6cm", margin: "1cm" }] });
+		test("Should let a global level set the geometry", async () => {
+			const built = await buildCell(cell([]), { ...context, levels: [{ width: "6cm", margin: "1cm" }] });
 			assert.ok(!isUnavailable(built));
 			assert.ok(built.source.includes("#set page(width: 6cm, height: auto, margin: 1cm, fill: none)"));
 		});
 
-		test("Should ignore a block-level root, which is a global-only option", () => {
+		test("Should ignore a block-level root, which is a global-only option", async () => {
 			// `root` never reaches the source, so a block writing it changes nothing.
-			const plain = buildCell(cell([]), context);
-			const rooted = buildCell(cell(["root: ../assets"]), context);
+			const plain = await buildCell(cell([]), context);
+			const rooted = await buildCell(cell(["root: ../assets"]), context);
 			assert.ok(!isUnavailable(plain) && !isUnavailable(rooted));
 			assert.strictEqual(rooted.source, plain.source);
 		});
 	});
 
-	suite("limitations", () => {
+	suite("resolveQuartoPath", () => {
+		test("Should read a leading slash as the project root", () => {
+			assert.strictEqual(resolveQuartoPath("/theme.typ", "/p/sub", "/p"), path.join("/p", "theme.typ"));
+		});
+
+		test("Should read every other path against the directory given", () => {
+			// This is the `preamble:` and `file:` rule, and it is not the rule `root`,
+			// `font-path` and `package-path` follow. Conflating the two would read a
+			// preamble from the wrong directory in any project whose documents are not
+			// at its root.
+			assert.strictEqual(resolveQuartoPath("theme.typ", "/p/sub", "/p"), path.join("/p/sub", "theme.typ"));
+		});
+
+		test("Should answer nothing when there is no directory to resolve against", () => {
+			assert.strictEqual(resolveQuartoPath("theme.typ", undefined, "/p"), undefined);
+			assert.strictEqual(resolveQuartoPath("/theme.typ", "/p/sub", undefined), undefined);
+		});
+	});
+
+	suite("cellNotes", () => {
+		/** The notes of a cell written with the given options and global levels. */
+		function notesOf(options: string[], levels: TypstGlobalLevel[] = []): string[] {
+			const merged = mergeGlobalConfigs(levels, brandColourReader(EMPTY_BRAND));
+			return cellNotes(resolveTypstOptions(cell(options), merged, brandColourReader(EMPTY_BRAND)));
+		}
+
 		test("Should say that the preview compiles to SVG for another format", () => {
-			assert.deepStrictEqual(limitations(cell(["format: pdf"])), ["the preview compiles to SVG, not to pdf"]);
-			assert.deepStrictEqual(limitations(cell(["format: html"])), ["the preview compiles to SVG, not to html"]);
+			assert.deepStrictEqual(notesOf(["format: pdf"]), ["the preview compiles to SVG, not to pdf"]);
+			assert.deepStrictEqual(notesOf(["format: html"]), ["the preview compiles to SVG, not to html"]);
 		});
 
 		test("Should say nothing about a format the preview does produce", () => {
-			assert.deepStrictEqual(limitations(cell(["format: svg"])), []);
-			assert.deepStrictEqual(limitations(cell([])), []);
+			assert.deepStrictEqual(notesOf(["format: svg"]), []);
+			assert.deepStrictEqual(notesOf([]), []);
+		});
+
+		test("Should read a format a global level set, not only one on the block", () => {
+			// `format`, `output` and `pages` are all global keys as well, so reading
+			// the block's own run alone would say nothing about a document that sets
+			// the format once in its `_quarto.yml`.
+			assert.deepStrictEqual(notesOf([], [{ format: "pdf" }]), ["the preview compiles to SVG, not to pdf"]);
 		});
 
 		test("Should say that an asis cell inherits a page the preview cannot apply", () => {
-			assert.deepStrictEqual(limitations(cell(["output: asis"])), [
+			assert.deepStrictEqual(notesOf(["output: asis"]), [
 				"an `output: asis` cell inherits the document page, which the preview cannot apply",
 			]);
 		});
 
 		test("Should say that only the first page is shown when pages selects some", () => {
-			assert.deepStrictEqual(limitations(cell(["pages: 2-3"])), ["the preview shows the first page only"]);
-			assert.deepStrictEqual(limitations(cell(["pages: all"])), []);
+			assert.deepStrictEqual(notesOf(["pages: 2-3"]), ["the preview shows the first page only"]);
+			assert.deepStrictEqual(notesOf(["pages: all"]), []);
 		});
 	});
 
@@ -180,22 +212,22 @@ suite("Typst Preview Context Test Suite", () => {
 		});
 	});
 
-	suite("readFrontMatter", () => {
+	suite("parseFrontMatter", () => {
 		test("Should parse the mapping between the delimiters", () => {
-			assert.deepStrictEqual(readFrontMatter("---\ntitle: A\n---\n\nBody\n"), { title: "A" });
+			assert.deepStrictEqual(parseFrontMatter("---\ntitle: A\n---\n\nBody\n"), { title: "A" });
 		});
 
 		test("Should parse a document written with CRLF", () => {
-			assert.deepStrictEqual(readFrontMatter("---\r\ntitle: A\r\n---\r\n"), { title: "A" });
+			assert.deepStrictEqual(parseFrontMatter("---\r\ntitle: A\r\n---\r\n"), { title: "A" });
 		});
 
 		test("Should answer nothing for a document with no front matter", () => {
-			assert.strictEqual(readFrontMatter("Body only.\n"), undefined);
-			assert.strictEqual(readFrontMatter("---\ntitle: A\n"), undefined);
+			assert.strictEqual(parseFrontMatter("Body only.\n"), undefined);
+			assert.strictEqual(parseFrontMatter("---\ntitle: A\n"), undefined);
 		});
 
 		test("Should answer nothing for front matter that does not parse", () => {
-			assert.strictEqual(readFrontMatter("---\na: [1,\n---\n"), undefined);
+			assert.strictEqual(parseFrontMatter("---\na: [1,\n---\n"), undefined);
 		});
 	});
 
@@ -223,14 +255,14 @@ suite("Typst Preview Context Test Suite", () => {
 		test("Should say so when the cursor is in no block", async () => {
 			const document = await documentOf("Prose only.\n");
 			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER, NO_SCHEMA_CACHE);
-			assert.ok(isUnavailableRequest(request));
+			assert.ok(isUnavailable(request));
 			assert.ok(request.unavailable.includes("cursor"));
 		});
 
 		test("Should assemble a plain block under the preview's own header", async () => {
 			const document = await documentOf("```typst\n#circle()\n```\n");
 			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, NO_SCHEMA_CACHE);
-			assert.ok(!isUnavailableRequest(request));
+			assert.ok(!isUnavailable(request));
 			assert.strictEqual(request.source, `${HEADER}\n#circle()\n`);
 			assert.strictEqual(request.block.kind, "plain");
 			// The header is the preview's own, so the brand of the document has no
@@ -243,7 +275,7 @@ suite("Typst Preview Context Test Suite", () => {
 			const text = "```{=typst}\n#let a = red\n```\n\n```{=typst}\n#text(fill: a)[Hi]\n```\n";
 			const document = await documentOf(text);
 			const request = await buildCompileRequest(document, new vscode.Position(5, 0), HEADER, NO_SCHEMA_CACHE);
-			assert.ok(!isUnavailableRequest(request));
+			assert.ok(!isUnavailable(request));
 			assert.strictEqual(request.source, `${HEADER}\n#let a = red\n#text(fill: a)[Hi]\n`);
 			assert.strictEqual(request.injectedLines, 2);
 		});
@@ -325,7 +357,7 @@ suite("Typst Preview Context Test Suite", () => {
 			write("doc.qmd", "Body\n");
 
 			const chain = await readMetadataChain(await open("doc.qmd"));
-			const brand = await readBrand(chain, directory);
+			const brand = await readBrand(chain);
 			assert.strictEqual(brandColourReader(brand)("light", "background"), "#fdf6e3");
 		});
 
@@ -335,7 +367,7 @@ suite("Typst Preview Context Test Suite", () => {
 			write("doc.qmd", "Body\n");
 
 			const chain = await readMetadataChain(await open("doc.qmd"));
-			const brand = await readBrand(chain, directory);
+			const brand = await readBrand(chain);
 			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
 		});
 
@@ -346,7 +378,22 @@ suite("Typst Preview Context Test Suite", () => {
 			write("sub/doc.qmd", "---\nbrand: theme.yml\n---\n\nBody\n");
 
 			const chain = await readMetadataChain(await open("sub/doc.qmd"));
-			const brand = await readBrand(chain, path.join(directory, "sub"));
+			const brand = await readBrand(chain);
+			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
+		});
+
+		test("Should resolve a brand path from _quarto.yml against the project root", async () => {
+			// Quarto splits the two cases: a `brand:` in the project configuration
+			// resolves from the project root, and one reaching the file metadata
+			// resolves from the directory of the document. Resolving both the same way
+			// would look for the file beside a document that never named it.
+			asProject();
+			write("_quarto.yml", "brand: theme.yml\n");
+			write("theme.yml", "color:\n  background: '#101418'\n");
+			write("sub/doc.qmd", "Body\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			const brand = await readBrand(chain);
 			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
 		});
 
@@ -356,7 +403,7 @@ suite("Typst Preview Context Test Suite", () => {
 			write("sub/doc.qmd", "---\nbrand: /theme.yml\n---\n\nBody\n");
 
 			const chain = await readMetadataChain(await open("sub/doc.qmd"));
-			const brand = await readBrand(chain, path.join(directory, "sub"));
+			const brand = await readBrand(chain);
 			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
 		});
 
@@ -366,7 +413,7 @@ suite("Typst Preview Context Test Suite", () => {
 			write("doc.qmd", "---\nbrand: false\n---\n\nBody\n");
 
 			const chain = await readMetadataChain(await open("doc.qmd"));
-			const brand = await readBrand(chain, directory);
+			const brand = await readBrand(chain);
 			assert.strictEqual(brandColourReader(brand)("light", "background"), undefined);
 		});
 
@@ -377,7 +424,7 @@ suite("Typst Preview Context Test Suite", () => {
 			write("doc.qmd", "---\nbrand:\n  light: light.yml\n  dark: dark.yml\n---\n\nBody\n");
 
 			const chain = await readMetadataChain(await open("doc.qmd"));
-			const read = brandColourReader(await readBrand(chain, directory));
+			const read = brandColourReader(await readBrand(chain));
 			assert.strictEqual(read("light", "background"), "#fdf6e3");
 			assert.strictEqual(read("dark", "background"), "#101418");
 		});
@@ -390,7 +437,7 @@ suite("Typst Preview Context Test Suite", () => {
 			write("_brand.yml", "color:\n  background: '#fdf6e3'\n");
 
 			const chain = await readMetadataChain(await open("loose.qmd"));
-			const brand = await readBrand(chain, directory);
+			const brand = await readBrand(chain);
 			assert.strictEqual(brandColourReader(brand)("light", "background"), undefined);
 		});
 	});

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -7,7 +7,6 @@ import { findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks"
 import { EMPTY_BRAND, brandColourReader, splitBrand } from "../../utils/typst/typstBrand";
 import { mergeGlobalConfigs, resolveTypstOptions, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
 import { buildCell, cellNotes, isUnavailable, resolvePreamble } from "../../utils/typst/typstSource";
-import type { SchemaCache } from "@quarto-wizard/schema";
 import {
 	buildCompileRequest,
 	isNewerThanPinned,
@@ -15,6 +14,7 @@ import {
 } from "../../providers/typstPreview/typstContext";
 import { readBrand, readMetadataChain, resolveQuartoPath } from "../../providers/typstPreview/typstMetadata";
 import { invalidateProjectRoots, setProjectRoots } from "../../utils/projectRootsRegistry";
+import { invalidateInstalledExtensionsCache } from "../../utils/installedExtensionsCache";
 import { parseFrontMatter } from "../../utils/yamlPosition";
 import { makeFolder, makeRoot } from "./projectFixtures";
 
@@ -235,33 +235,96 @@ suite("Typst Preview Context Test Suite", () => {
 		/** The page setup a preview injects above a plain block and a raw block. */
 		const HEADER = "#set page(width: auto, height: auto, margin: 0.5em)";
 
-		/**
-		 * A cache the cell path would read and the other two never touch.
-		 *
-		 * The paths under test here never reach the schema gate, so a stub is what
-		 * says that rather than a real cache quietly making it look reachable.
-		 */
-		const NO_SCHEMA_CACHE = {
-			get: () => {
-				throw new Error("the schema cache is only for a cell");
-			},
-		} as unknown as SchemaCache;
-
 		/** An open document holding the given text. */
 		async function documentOf(text: string): Promise<vscode.TextDocument> {
 			return vscode.workspace.openTextDocument({ language: "quarto", content: text });
 		}
 
+		/** A temporary project, with `typst-render` installed when asked. */
+		function project(withExtension: boolean): string {
+			const directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-gate-")));
+			fs.writeFileSync(path.join(directory, "_quarto.yml"), "project:\n  type: default\n");
+			if (withExtension) {
+				const manifest = path.join(directory, "_extensions", "mcanouil", "typst-render");
+				fs.mkdirSync(manifest, { recursive: true });
+				fs.writeFileSync(
+					path.join(manifest, "_extension.yml"),
+					"title: Typst Render\nauthor: Mickael Canouil\nversion: 0.21.0\ncontributes:\n  filters:\n    - typst-render.lua\n",
+				);
+			}
+			setProjectRoots([makeRoot(makeFolder("typst-gate", directory))]);
+			return directory;
+		}
+
+		/** The one cell document every gate test previews. */
+		const CELL = "```{typst}\n//| margin: 2mm\n#circle()\n```\n";
+
+		teardown(() => {
+			invalidateProjectRoots();
+			invalidateInstalledExtensionsCache();
+		});
+
+		test("Should assemble a cell when the project has typst-render installed", async () => {
+			const directory = project(true);
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER);
+				assert.ok(!isUnavailable(request));
+				// The filter's own contract, and not the preview's theme header: the
+				// bindings and the page directive come from the options in force.
+				assert.ok(request.source.includes("#let _typst_render_background = none"));
+				assert.ok(request.source.includes("margin: 2mm"));
+				assert.ok(!request.source.includes(HEADER));
+				// The option run is in the document but not in the compiled source, so
+				// a diagnostic has to have it added back.
+				assert.strictEqual(request.bodyLineOffset, 1);
+				assert.ok(request.brandMode === "light" || request.brandMode === "dark");
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should refuse a cell when the project has no typst-render", async () => {
+			// Never previewed with guessed options: an image compiled without the
+			// extension's own defaults is not the image the render produces.
+			const directory = project(false);
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER);
+				assert.ok(isUnavailable(request));
+				assert.ok(request.unavailable.includes("typst-render"));
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should still preview a plain block in a project with no typst-render", async () => {
+			// The gate is the cell's alone. A plain block is never executed by Quarto,
+			// so the extension has nothing to do with it.
+			const directory = project(false);
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), "```typst\n#circle()\n```\n");
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER);
+				assert.ok(!isUnavailable(request));
+				assert.strictEqual(request.source, `${HEADER}\n#circle()\n`);
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
 		test("Should say so when the cursor is in no block", async () => {
 			const document = await documentOf("Prose only.\n");
-			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER, NO_SCHEMA_CACHE);
+			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER);
 			assert.ok(isUnavailable(request));
 			assert.ok(request.unavailable.includes("cursor"));
 		});
 
 		test("Should assemble a plain block under the preview's own header", async () => {
 			const document = await documentOf("```typst\n#circle()\n```\n");
-			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, NO_SCHEMA_CACHE);
+			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER);
 			assert.ok(!isUnavailable(request));
 			assert.strictEqual(request.source, `${HEADER}\n#circle()\n`);
 			assert.strictEqual(request.block.kind, "plain");
@@ -274,7 +337,7 @@ suite("Typst Preview Context Test Suite", () => {
 		test("Should assemble a raw block under the raw blocks above it", async () => {
 			const text = "```{=typst}\n#let a = red\n```\n\n```{=typst}\n#text(fill: a)[Hi]\n```\n";
 			const document = await documentOf(text);
-			const request = await buildCompileRequest(document, new vscode.Position(5, 0), HEADER, NO_SCHEMA_CACHE);
+			const request = await buildCompileRequest(document, new vscode.Position(5, 0), HEADER);
 			assert.ok(!isUnavailable(request));
 			assert.strictEqual(request.source, `${HEADER}\n#let a = red\n#text(fill: a)[Hi]\n`);
 			assert.strictEqual(request.injectedLines, 2);

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -407,6 +407,62 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.deepStrictEqual(chain.levels, [{ margin: "1cm" }, { margin: "2cm" }, { margin: "3cm" }]);
 		});
 
+		test("Should splice a metadata-files target above the level that named it", async () => {
+			// Quarto merges the included metadata over the file that included it, so
+			// the target wins against its own declaring level and loses to every level
+			// above it.
+			asProject();
+			write(
+				"_quarto.yml",
+				"metadata-files:\n  - shared.yml\nextensions:\n  typst-render:\n    margin: 1cm\n    width: 6cm\n",
+			);
+			write("shared.yml", "extensions:\n  typst-render:\n    margin: 2cm\n");
+			write("sub/_metadata.yml", "extensions:\n  typst-render:\n    width: 9cm\n");
+			write("sub/doc.qmd", "Body\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			assert.deepStrictEqual(chain.levels, [{ margin: "1cm", width: "6cm" }, { margin: "2cm" }, { width: "9cm" }]);
+		});
+
+		test("Should not read a metadata-files target another document named", async () => {
+			// The registry aggregates every target declared anywhere under the project
+			// root, so a chain built from it would merge this file into a preview of
+			// the other document and show an image its render never produces.
+			asProject();
+			write("a/doc-a.qmd", "---\nmetadata-files:\n  - opts.yml\n---\n\nBody\n");
+			write("a/opts.yml", 'extensions:\n  typst-render:\n    background: "#000000"\n');
+			write("b/doc-b.qmd", "Body\n");
+			// Open the other document, so a registry-driven chain would have seen it.
+			await open("a/doc-a.qmd");
+
+			const chain = await readMetadataChain(await open("b/doc-b.qmd"));
+			assert.deepStrictEqual(chain.levels, []);
+		});
+
+		test("Should read a metadata-files target the document itself names", async () => {
+			asProject();
+			write("sub/opts.yml", "extensions:\n  typst-render:\n    margin: 3cm\n");
+			write("sub/doc.qmd", "---\nmetadata-files:\n  - opts.yml\n---\n\nBody\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			assert.deepStrictEqual(chain.levels, [{ margin: "3cm" }]);
+		});
+
+		test("Should resolve a brand a project metadata-files target names from the root", async () => {
+			// The target was pulled in by `_quarto.yml`, so it is project metadata and
+			// its `brand:` resolves from the project root, not from the directory of
+			// whichever document is being previewed.
+			asProject();
+			write("_quarto.yml", "metadata-files:\n  - shared.yml\n");
+			write("shared.yml", "brand: theme/x.yml\n");
+			write("theme/x.yml", "color:\n  background: '#101418'\n");
+			write("sub/doc.qmd", "Body\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			const brand = await readBrand(chain);
+			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
+		});
+
 		test("Should read the bare typst-render key of a level as well", async () => {
 			asProject();
 			write("doc.qmd", "---\ntypst-render:\n  margin: 2cm\n---\n\nBody\n");

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -99,6 +99,16 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(!built.source.includes("#circle()"));
 		});
 
+		test("Should compile the body and name no file when a file option is empty", async () => {
+			// An empty `file:` skips the read, so the body is what compiles. Reporting
+			// it as the external file would print a position with no name beside it
+			// and drop the option run correction that the body needs.
+			const built = await buildCell(cell(['file: ""']), context);
+			assert.ok(!isUnavailable(built));
+			assert.strictEqual(built.externalFile, undefined);
+			assert.ok(built.source.endsWith("#circle()"));
+		});
+
 		test("Should say so when a file option cannot be read", async () => {
 			// The filter renders nothing here. A blank image with no reason beside
 			// it would look like the block itself was empty.
@@ -241,11 +251,17 @@ suite("Typst Preview Context Test Suite", () => {
 		}
 
 		/** A temporary project, with `typst-render` installed when asked. */
-		function project(withExtension: boolean): string {
+		function project(withExtension: boolean | "ownerless"): string {
 			const directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-gate-")));
 			fs.writeFileSync(path.join(directory, "_quarto.yml"), "project:\n  type: default\n");
 			if (withExtension) {
-				const manifest = path.join(directory, "_extensions", "mcanouil", "typst-render");
+				// An extension installed from a repository sits under its owner, and a
+				// copy placed by hand sits straight under `_extensions`. Discovery
+				// reports the second with no owner, and the gate has to accept both.
+				const manifest =
+					withExtension === "ownerless"
+						? path.join(directory, "_extensions", "typst-render")
+						: path.join(directory, "_extensions", "mcanouil", "typst-render");
 				fs.mkdirSync(manifest, { recursive: true });
 				fs.writeFileSync(
 					path.join(manifest, "_extension.yml"),
@@ -280,6 +296,18 @@ suite("Typst Preview Context Test Suite", () => {
 				// a diagnostic has to have it added back.
 				assert.strictEqual(request.bodyLineOffset, 1);
 				assert.ok(request.brandMode === "light" || request.brandMode === "dark");
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should assemble a cell when typst-render is installed with no owner", async () => {
+			const directory = project("ownerless");
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER);
+				assert.ok(!isUnavailable(request));
 			} finally {
 				fs.rmSync(directory, { recursive: true, force: true });
 			}

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -1,0 +1,397 @@
+import * as assert from "assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { EMPTY_BRAND, brandColourReader, splitBrand } from "../../utils/typst/typstBrand";
+import { buildCell, isUnavailable, resolvePreamble } from "../../utils/typst/typstSource";
+import type { SchemaCache } from "@quarto-wizard/schema";
+import {
+	buildCompileRequest,
+	isNewerThanPinned,
+	isUnavailableRequest,
+	limitations,
+	PINNED_TYPST_RENDER_VERSION,
+} from "../../providers/typstPreview/typstContext";
+import { readBrand, readFrontMatter, readMetadataChain } from "../../providers/typstPreview/typstMetadata";
+import { invalidateProjectRoots, setProjectRoots } from "../../utils/projectRootsRegistry";
+import { makeFolder, makeRoot } from "./projectFixtures";
+
+/** The one cell of a document written as an option run over one line of code. */
+function cell(options: string[], code = "#circle()"): TypstBlock {
+	const body = [...options.map((option) => `//| ${option}`), code].join("\n");
+	return findTypstBlocks(`\`\`\`{typst}\n${body}\n\`\`\`\n`)[0];
+}
+
+/** A read that answers from a table rather than from disk. */
+function reader(files: Record<string, string>): (documentPath: string) => string | undefined {
+	return (documentPath) => files[documentPath];
+}
+
+suite("Typst Preview Context Test Suite", () => {
+	suite("resolvePreamble", () => {
+		test("Should keep an entry that is not a path as inline code", () => {
+			assert.strictEqual(resolvePreamble("#let a = 1", reader({})), "#let a = 1");
+		});
+
+		test("Should read an entry ending in .typ from disk", () => {
+			assert.strictEqual(resolvePreamble("shared.typ", reader({ "shared.typ": "#let a = 1\n" })), "#let a = 1\n");
+		});
+
+		test("Should join a list with newlines, in order", () => {
+			const resolved = resolvePreamble(["#let a = 1", "shared.typ"], reader({ "shared.typ": "#let b = 2" }));
+			assert.strictEqual(resolved, "#let a = 1\n#let b = 2");
+		});
+
+		test("Should drop an entry that cannot be read rather than failing", () => {
+			// The filter logs and carries on. A preview that refused the whole block
+			// would say nothing about the one entry that is wrong.
+			assert.strictEqual(resolvePreamble(["#let a = 1", "missing.typ"], reader({})), "#let a = 1");
+		});
+
+		test("Should answer nothing for an absent or empty preamble", () => {
+			assert.strictEqual(resolvePreamble(undefined, reader({})), "");
+			assert.strictEqual(resolvePreamble("", reader({})), "");
+			assert.strictEqual(resolvePreamble([], reader({})), "");
+		});
+	});
+
+	suite("buildCell", () => {
+		const context = {
+			levels: [],
+			brand: EMPTY_BRAND,
+			mode: "light" as const,
+			readFile: reader({}),
+		};
+
+		test("Should count every injected line so a diagnostic maps back", () => {
+			const built = buildCell(cell([]), context);
+			assert.ok(!isUnavailable(built));
+			// Three bindings and the page directive, and no `#set text` because
+			// nothing set a foreground.
+			assert.strictEqual(built.injectedLines, 4);
+			assert.ok(built.source.endsWith("\n#circle()"));
+		});
+
+		test("Should add the text fill line when a foreground is set", () => {
+			const built = buildCell(cell(['foreground: "#1a1a1a"']), context);
+			assert.ok(!isUnavailable(built));
+			assert.strictEqual(built.injectedLines, 5);
+			assert.ok(built.source.includes('#set text(fill: rgb("#1a1a1a"))'));
+		});
+
+		test("Should bind the foreground as none when nothing sets one", () => {
+			// Consuming Typst code reads `_typst_render_foreground` whether or not
+			// the document sets a colour, so the binding is always written.
+			const built = buildCell(cell([]), context);
+			assert.ok(!isUnavailable(built));
+			assert.ok(built.source.includes("#let _typst_render_foreground = none"));
+		});
+
+		test("Should replace the body with the contents of a file option", () => {
+			const built = buildCell(cell(["file: diagram.typ"]), {
+				...context,
+				readFile: reader({ "diagram.typ": "#rect()\n" }),
+			});
+			assert.ok(!isUnavailable(built));
+			assert.ok(built.source.endsWith("#rect()\n"));
+			assert.ok(!built.source.includes("#circle()"));
+		});
+
+		test("Should say so when a file option cannot be read", () => {
+			// The filter renders nothing here. A blank image with no reason beside
+			// it would look like the block itself was empty.
+			const built = buildCell(cell(["file: missing.typ"]), context);
+			assert.ok(isUnavailable(built));
+			assert.ok(built.unavailable.includes("missing.typ"));
+		});
+
+		test("Should read the colours of the mode in force", () => {
+			const brand = splitBrand({
+				color: { background: { light: "#fdf6e3", dark: "#101418" } },
+			});
+			const dark = buildCell(cell(["background: auto"]), { ...context, brand, mode: "dark" });
+			assert.ok(!isUnavailable(dark));
+			assert.ok(dark.source.includes('#let _typst_render_background = rgb("#101418")'));
+		});
+
+		test("Should let a global level set the geometry", () => {
+			const built = buildCell(cell([]), { ...context, levels: [{ width: "6cm", margin: "1cm" }] });
+			assert.ok(!isUnavailable(built));
+			assert.ok(built.source.includes("#set page(width: 6cm, height: auto, margin: 1cm, fill: none)"));
+		});
+
+		test("Should ignore a block-level root, which is a global-only option", () => {
+			// `root` never reaches the source, so a block writing it changes nothing.
+			const plain = buildCell(cell([]), context);
+			const rooted = buildCell(cell(["root: ../assets"]), context);
+			assert.ok(!isUnavailable(plain) && !isUnavailable(rooted));
+			assert.strictEqual(rooted.source, plain.source);
+		});
+	});
+
+	suite("limitations", () => {
+		test("Should say that the preview compiles to SVG for another format", () => {
+			assert.deepStrictEqual(limitations(cell(["format: pdf"])), ["the preview compiles to SVG, not to pdf"]);
+			assert.deepStrictEqual(limitations(cell(["format: html"])), ["the preview compiles to SVG, not to html"]);
+		});
+
+		test("Should say nothing about a format the preview does produce", () => {
+			assert.deepStrictEqual(limitations(cell(["format: svg"])), []);
+			assert.deepStrictEqual(limitations(cell([])), []);
+		});
+
+		test("Should say that an asis cell inherits a page the preview cannot apply", () => {
+			assert.deepStrictEqual(limitations(cell(["output: asis"])), [
+				"an `output: asis` cell inherits the document page, which the preview cannot apply",
+			]);
+		});
+
+		test("Should say that only the first page is shown when pages selects some", () => {
+			assert.deepStrictEqual(limitations(cell(["pages: 2-3"])), ["the preview shows the first page only"]);
+			assert.deepStrictEqual(limitations(cell(["pages: all"])), []);
+		});
+	});
+
+	suite("isNewerThanPinned", () => {
+		test("Should hold only for a version above the pinned one", () => {
+			assert.strictEqual(isNewerThanPinned("0.22.0", "0.21.0"), true);
+			assert.strictEqual(isNewerThanPinned("1.0.0", "0.21.0"), true);
+			assert.strictEqual(isNewerThanPinned("0.21.1", "0.21.0"), true);
+			assert.strictEqual(isNewerThanPinned("0.21.0", "0.21.0"), false);
+			assert.strictEqual(isNewerThanPinned("0.20.9", "0.21.0"), false);
+		});
+
+		test("Should compare part by part and not as text", () => {
+			// `"0.9.0" > "0.21.0"` holds as a string comparison and is wrong.
+			assert.strictEqual(isNewerThanPinned("0.9.0", "0.21.0"), false);
+		});
+
+		test("Should say nothing about a version it cannot compare", () => {
+			// A pre-release suffix is not worth a warning of its own, and neither is
+			// a version string that is not a number at all.
+			assert.strictEqual(isNewerThanPinned("0.22.0-beta", "0.21.0"), true);
+			assert.strictEqual(isNewerThanPinned("next", "0.21.0"), false);
+		});
+
+		test("Should pin the version the fixtures were recorded from", () => {
+			assert.strictEqual(PINNED_TYPST_RENDER_VERSION, "0.21.0");
+		});
+	});
+
+	suite("readFrontMatter", () => {
+		test("Should parse the mapping between the delimiters", () => {
+			assert.deepStrictEqual(readFrontMatter("---\ntitle: A\n---\n\nBody\n"), { title: "A" });
+		});
+
+		test("Should parse a document written with CRLF", () => {
+			assert.deepStrictEqual(readFrontMatter("---\r\ntitle: A\r\n---\r\n"), { title: "A" });
+		});
+
+		test("Should answer nothing for a document with no front matter", () => {
+			assert.strictEqual(readFrontMatter("Body only.\n"), undefined);
+			assert.strictEqual(readFrontMatter("---\ntitle: A\n"), undefined);
+		});
+
+		test("Should answer nothing for front matter that does not parse", () => {
+			assert.strictEqual(readFrontMatter("---\na: [1,\n---\n"), undefined);
+		});
+	});
+
+	suite("buildCompileRequest", () => {
+		/** The page setup a preview injects above a plain block and a raw block. */
+		const HEADER = "#set page(width: auto, height: auto, margin: 0.5em)";
+
+		/**
+		 * A cache the cell path would read and the other two never touch.
+		 *
+		 * The paths under test here never reach the schema gate, so a stub is what
+		 * says that rather than a real cache quietly making it look reachable.
+		 */
+		const NO_SCHEMA_CACHE = {
+			get: () => {
+				throw new Error("the schema cache is only for a cell");
+			},
+		} as unknown as SchemaCache;
+
+		/** An open document holding the given text. */
+		async function documentOf(text: string): Promise<vscode.TextDocument> {
+			return vscode.workspace.openTextDocument({ language: "quarto", content: text });
+		}
+
+		test("Should say so when the cursor is in no block", async () => {
+			const document = await documentOf("Prose only.\n");
+			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER, NO_SCHEMA_CACHE);
+			assert.ok(isUnavailableRequest(request));
+			assert.ok(request.unavailable.includes("cursor"));
+		});
+
+		test("Should assemble a plain block under the preview's own header", async () => {
+			const document = await documentOf("```typst\n#circle()\n```\n");
+			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, NO_SCHEMA_CACHE);
+			assert.ok(!isUnavailableRequest(request));
+			assert.strictEqual(request.source, `${HEADER}\n#circle()\n`);
+			assert.strictEqual(request.block.kind, "plain");
+			// The header is the preview's own, so the brand of the document has no
+			// part in it and there is no mode to report.
+			assert.strictEqual(request.brandMode, undefined);
+			assert.deepStrictEqual(request.notes, []);
+		});
+
+		test("Should assemble a raw block under the raw blocks above it", async () => {
+			const text = "```{=typst}\n#let a = red\n```\n\n```{=typst}\n#text(fill: a)[Hi]\n```\n";
+			const document = await documentOf(text);
+			const request = await buildCompileRequest(document, new vscode.Position(5, 0), HEADER, NO_SCHEMA_CACHE);
+			assert.ok(!isUnavailableRequest(request));
+			assert.strictEqual(request.source, `${HEADER}\n#let a = red\n#text(fill: a)[Hi]\n`);
+			assert.strictEqual(request.injectedLines, 2);
+		});
+	});
+
+	suite("readMetadataChain and readBrand", () => {
+		let directory: string;
+
+		/** Write a file inside the temporary project, making its directory. */
+		function write(relative: string, text: string): string {
+			const file = path.join(directory, relative);
+			fs.mkdirSync(path.dirname(file), { recursive: true });
+			fs.writeFileSync(file, text);
+			return file;
+		}
+
+		/** Open a document of the temporary project. */
+		async function open(relative: string): Promise<vscode.TextDocument> {
+			return vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, relative)));
+		}
+
+		setup(() => {
+			directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-chain-")));
+		});
+
+		teardown(() => {
+			invalidateProjectRoots();
+			fs.rmSync(directory, { recursive: true, force: true });
+		});
+
+		/** Treat the temporary directory as the one Quarto project root. */
+		function asProject(): void {
+			setProjectRoots([makeRoot(makeFolder("typst-chain", directory))]);
+		}
+
+		test("Should read the front matter of a document outside every project", async () => {
+			// A scratch file has no project root, so the chain is its front matter
+			// alone and nothing about it is guessed from the workspace.
+			setProjectRoots([]);
+			write("loose.qmd", "---\nextensions:\n  typst-render:\n    dpi: 300\n---\n\nBody\n");
+			const chain = await readMetadataChain(await open("loose.qmd"));
+			assert.deepStrictEqual(chain.levels, [{ dpi: 300 }]);
+			assert.strictEqual(chain.projectRoot, undefined);
+		});
+
+		test("Should order the chain from the project root down to the document", async () => {
+			// The order is the precedence order, so a level nearer the document
+			// overrides one further from it.
+			asProject();
+			write("_quarto.yml", "extensions:\n  typst-render:\n    margin: 1cm\n    width: 6cm\n");
+			write("sub/_metadata.yml", "extensions:\n  typst-render:\n    margin: 2cm\n");
+			write("sub/doc.qmd", "---\nextensions:\n  typst-render:\n    margin: 3cm\n---\n\nBody\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			assert.deepStrictEqual(chain.levels, [{ margin: "1cm", width: "6cm" }, { margin: "2cm" }, { margin: "3cm" }]);
+		});
+
+		test("Should walk every _metadata.yml between the root and the document", async () => {
+			asProject();
+			write("_metadata.yml", "extensions:\n  typst-render:\n    margin: 1cm\n");
+			write("a/_metadata.yml", "extensions:\n  typst-render:\n    margin: 2cm\n");
+			write("a/b/_metadata.yml", "extensions:\n  typst-render:\n    margin: 3cm\n");
+			write("a/b/doc.qmd", "Body\n");
+
+			const chain = await readMetadataChain(await open("a/b/doc.qmd"));
+			assert.deepStrictEqual(chain.levels, [{ margin: "1cm" }, { margin: "2cm" }, { margin: "3cm" }]);
+		});
+
+		test("Should read the bare typst-render key of a level as well", async () => {
+			asProject();
+			write("doc.qmd", "---\ntypst-render:\n  margin: 2cm\n---\n\nBody\n");
+			const chain = await readMetadataChain(await open("doc.qmd"));
+			assert.deepStrictEqual(chain.levels, [{ margin: "2cm" }]);
+		});
+
+		test("Should read the brand from the project root", async () => {
+			asProject();
+			write("_brand.yml", "color:\n  palette:\n    paper: '#fdf6e3'\n  background: paper\n");
+			write("doc.qmd", "Body\n");
+
+			const chain = await readMetadataChain(await open("doc.qmd"));
+			const brand = await readBrand(chain, directory);
+			assert.strictEqual(brandColourReader(brand)("light", "background"), "#fdf6e3");
+		});
+
+		test("Should read the brand from the _brand directory when the root has none", async () => {
+			asProject();
+			write("_brand/_brand.yml", "color:\n  background: '#101418'\n");
+			write("doc.qmd", "Body\n");
+
+			const chain = await readMetadataChain(await open("doc.qmd"));
+			const brand = await readBrand(chain, directory);
+			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
+		});
+
+		test("Should honour a brand path the document names, relative to itself", async () => {
+			asProject();
+			write("_brand.yml", "color:\n  background: '#ffffff'\n");
+			write("sub/theme.yml", "color:\n  background: '#101418'\n");
+			write("sub/doc.qmd", "---\nbrand: theme.yml\n---\n\nBody\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			const brand = await readBrand(chain, path.join(directory, "sub"));
+			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
+		});
+
+		test("Should read a leading slash in a brand path as the project root", async () => {
+			asProject();
+			write("theme.yml", "color:\n  background: '#101418'\n");
+			write("sub/doc.qmd", "---\nbrand: /theme.yml\n---\n\nBody\n");
+
+			const chain = await readMetadataChain(await open("sub/doc.qmd"));
+			const brand = await readBrand(chain, path.join(directory, "sub"));
+			assert.strictEqual(brandColourReader(brand)("light", "background"), "#101418");
+		});
+
+		test("Should read no brand at all when the document disables it", async () => {
+			asProject();
+			write("_brand.yml", "color:\n  background: '#fdf6e3'\n");
+			write("doc.qmd", "---\nbrand: false\n---\n\nBody\n");
+
+			const chain = await readMetadataChain(await open("doc.qmd"));
+			const brand = await readBrand(chain, directory);
+			assert.strictEqual(brandColourReader(brand)("light", "background"), undefined);
+		});
+
+		test("Should take each mode from its own file when brand names a pair", async () => {
+			asProject();
+			write("light.yml", "color:\n  background: '#fdf6e3'\n");
+			write("dark.yml", "color:\n  background: '#101418'\n");
+			write("doc.qmd", "---\nbrand:\n  light: light.yml\n  dark: dark.yml\n---\n\nBody\n");
+
+			const chain = await readMetadataChain(await open("doc.qmd"));
+			const read = brandColourReader(await readBrand(chain, directory));
+			assert.strictEqual(read("light", "background"), "#fdf6e3");
+			assert.strictEqual(read("dark", "background"), "#101418");
+		});
+
+		test("Should have no brand for a document outside every project", async () => {
+			// A brand is a property of a project, and there is no root to resolve a
+			// candidate path against.
+			setProjectRoots([]);
+			write("loose.qmd", "Body\n");
+			write("_brand.yml", "color:\n  background: '#fdf6e3'\n");
+
+			const chain = await readMetadataChain(await open("loose.qmd"));
+			const brand = await readBrand(chain, directory);
+			assert.strictEqual(brandColourReader(brand)("light", "background"), undefined);
+		});
+	});
+});

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -13,7 +13,7 @@ suite("Typst Preview Messages Test Suite", () => {
 		test("Should say which line count it is reporting", () => {
 			// The panel header counts document lines, so a bare "line 2" reads as a
 			// document line and points at the wrong text.
-			const text = errorText(diagnostic("error", "expected expression", 2, 4), 1);
+			const text = errorText(diagnostic("error", "expected expression", 2, 4), { injectedLines: 1 });
 			assert.strictEqual(text, "error at line 1, column 5 of the block: expected expression");
 		});
 
@@ -21,14 +21,38 @@ suite("Typst Preview Messages Test Suite", () => {
 			// Headlining a failed compile as a warning misstates why no image came
 			// back, and Typst puts its warnings first.
 			const stderr = diagnostic("warning", "unused variable", 2, 0) + diagnostic("error", "unknown variable", 3, 6);
-			assert.strictEqual(errorText(stderr, 1), "error at line 2, column 7 of the block: unknown variable");
+			assert.strictEqual(
+				errorText(stderr, { injectedLines: 1 }),
+				"error at line 2, column 7 of the block: unknown variable",
+			);
 		});
 
 		test("Should fall back to the only warning when there is no error", () => {
 			assert.strictEqual(
-				errorText(diagnostic("warning", "unused variable", 2, 0), 1),
+				errorText(diagnostic("warning", "unused variable", 2, 0), { injectedLines: 1 }),
 				"warning at line 1, column 1 of the block: unused variable",
 			);
+		});
+
+		test("Should add the option run back to a cell position", () => {
+			// A cell compiles its code and not its body, so the leading `//|` run is in
+			// the document but not in the source Typst read. Without it every position
+			// in a cell with options is short by the length of that run.
+			const text = errorText(diagnostic("error", "expected expression", 5, 0), {
+				injectedLines: 4,
+				bodyLineOffset: 2,
+			});
+			assert.strictEqual(text, "error at line 3, column 1 of the block: expected expression");
+		});
+
+		test("Should name the external file when one replaced the block body", () => {
+			// No line of the block corresponds to the failure at all, so naming the
+			// block would send the reader to a line that has nothing to do with it.
+			const text = errorText(diagnostic("error", "expected expression", 5, 0), {
+				injectedLines: 4,
+				externalFile: "diagram.typ",
+			});
+			assert.strictEqual(text, "error at line 1, column 1 of diagram.typ: expected expression");
 		});
 
 		test("Should say that a failure sits above the block rather than in it", () => {
@@ -36,7 +60,7 @@ suite("Typst Preview Messages Test Suite", () => {
 			// belong to one of those. Reporting line 1 of this block would name the
 			// wrong block and the wrong line, and saying nothing about where it is
 			// would leave the reader looking at a block that compiles.
-			const text = errorText(diagnostic("error", "unknown variable: accent", 2, 4), 5);
+			const text = errorText(diagnostic("error", "unknown variable: accent", 2, 4), { injectedLines: 5 });
 			assert.strictEqual(text, "error above this block: unknown variable: accent");
 		});
 
@@ -45,7 +69,10 @@ suite("Typst Preview Messages Test Suite", () => {
 			// Reporting "line 1, column 1" would assert a position that does not
 			// exist and mark a character that is not at fault.
 			const stderr = "error: failed to download package @preview/example:0.1.0\n";
-			assert.strictEqual(errorText(stderr, 1), "error: failed to download package @preview/example:0.1.0");
+			assert.strictEqual(
+				errorText(stderr, { injectedLines: 1 }),
+				"error: failed to download package @preview/example:0.1.0",
+			);
 		});
 
 		test("Should report a failure that points at another file", () => {
@@ -53,11 +80,11 @@ suite("Typst Preview Messages Test Suite", () => {
 			// a position in this block. Reporting nothing would contradict both the
 			// log and the missing image.
 			const stderr = diagnostic("error", "file not found", 4, 2, "preamble.typ");
-			assert.strictEqual(errorText(stderr, 1), "error outside this block: file not found");
+			assert.strictEqual(errorText(stderr, { injectedLines: 1 }), "error outside this block: file not found");
 		});
 
 		test("Should say so when the compiler reported nothing at all", () => {
-			assert.strictEqual(errorText("", 1), "Typst produced no image and reported nothing.");
+			assert.strictEqual(errorText("", { injectedLines: 1 }), "Typst produced no image and reported nothing.");
 		});
 	});
 

--- a/src/utils/typst/typstBrand.ts
+++ b/src/utils/typst/typstBrand.ts
@@ -1,0 +1,406 @@
+/**
+ * Enough of Quarto's `_brand.yml` reader to resolve one named colour.
+ *
+ * The filter reads `auto` colours through Quarto's own Lua brand module, which
+ * TypeScript cannot reach: it runs inside the Pandoc Lua interpreter and reads a
+ * brand Quarto has already parsed, validated and split. `packages/core` does not
+ * help either, because `operations/brand.ts` stages brand files and never reads
+ * a colour out of one.
+ *
+ * So the parts a colour needs are reimplemented here, from the Quarto source:
+ * the light and dark split at `src/core/brand/brand.ts:631-812`, the alias chain
+ * with its cycle guard at `:161-197`, and the accessor at
+ * `src/resources/filters/modules/brand/brand.lua:10-17`. Fonts, logos and
+ * defaults are not read, because no colour option needs them.
+ */
+
+import type { BrandColourReader, TypstBrandMode } from "./typstOptions";
+
+/**
+ * The named theme colours, `src/resources/types/zod/schema-types.ts:1476-1491`.
+ *
+ * The list matters twice. A name in it is followed to the value under
+ * `color.<name>`, and a name outside it is a colour value, so getting the list
+ * wrong turns an alias into a literal or a literal into a lookup.
+ */
+const NAMED_THEME_COLOURS: ReadonlySet<string> = new Set([
+	"foreground",
+	"background",
+	"primary",
+	"secondary",
+	"tertiary",
+	"success",
+	"info",
+	"warning",
+	"danger",
+	"light",
+	"dark",
+	"link",
+]);
+
+/** The recursion bound Quarto sets, `src/core/brand/brand.ts:197`. */
+const MAX_ALIAS_DEPTH = 100;
+
+/** One side of a `_brand.yml`, after the unified file has been split. */
+interface SingleBrand {
+	palette: Readonly<Record<string, string>>;
+	colours: Readonly<Record<string, string>>;
+}
+
+/**
+ * The parsed contents of a `_brand.yml`, one entry per mode.
+ *
+ * `fonts` sits outside the pair because a family is shared: the light and dark
+ * split at `src/core/brand/brand.ts:590-611` strips only `color` and
+ * `background-color` from a typography entry, so both sides keep the same one.
+ */
+export interface Brand {
+	light: SingleBrand;
+	dark: SingleBrand;
+	fonts: Readonly<Record<string, string>>;
+}
+
+/** The typography entries the filter carries, `typst-render.lua:339`. */
+const BRAND_TYPOGRAPHY_ENTRIES: readonly string[] = ["base", "headings"];
+
+/** A string value of a mapping, or undefined when the key holds anything else. */
+function stringAt(source: Record<string, unknown>, key: string): string | undefined {
+	const value = source[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * One named colour split across the two modes,
+ * `src/core/brand/brand.ts:533-540`.
+ *
+ * A plain string is the same colour on both sides. A map contributes only the
+ * side it names, so a brand that writes `dark:` alone leaves the light side with
+ * no entry for that name at all.
+ */
+function splitColour(value: unknown): { light?: string; dark?: string } {
+	if (typeof value === "string") {
+		return { light: value, dark: value };
+	}
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return {};
+	}
+	const map = value as Record<string, unknown>;
+	return { light: stringAt(map, "light"), dark: stringAt(map, "dark") };
+}
+
+/**
+ * A `_brand.yml` document split into its light and dark sides.
+ *
+ * The palette is shared, which is what makes an alias resolve the same way on
+ * both sides while the name it points at differs by mode.
+ */
+export function splitBrand(document: unknown): Brand {
+	const empty = (): SingleBrand => ({ palette: {}, colours: {} });
+	if (document === null || typeof document !== "object" || Array.isArray(document)) {
+		return { light: empty(), dark: empty(), fonts: {} };
+	}
+
+	const fonts = readFonts((document as Record<string, unknown>).typography);
+
+	const colour = (document as Record<string, unknown>).color;
+	if (colour === null || typeof colour !== "object" || Array.isArray(colour)) {
+		return { light: empty(), dark: empty(), fonts };
+	}
+
+	const colourMap = colour as Record<string, unknown>;
+	const palette: Record<string, string> = {};
+	const rawPalette = colourMap.palette;
+	if (rawPalette !== null && typeof rawPalette === "object" && !Array.isArray(rawPalette)) {
+		for (const [name, value] of Object.entries(rawPalette as Record<string, unknown>)) {
+			if (typeof value === "string") {
+				palette[name] = value;
+			}
+		}
+	}
+
+	const light: Record<string, string> = {};
+	const dark: Record<string, string> = {};
+	for (const name of NAMED_THEME_COLOURS) {
+		if (colourMap[name] === undefined) {
+			continue;
+		}
+		const sides = splitColour(colourMap[name]);
+		if (sides.light !== undefined) {
+			light[name] = sides.light;
+		}
+		if (sides.dark !== undefined) {
+			dark[name] = sides.dark;
+		}
+	}
+
+	return { light: { palette, colours: light }, dark: { palette, colours: dark }, fonts };
+}
+
+/**
+ * The font family of each typography entry the filter carries.
+ *
+ * An entry is a family name on its own or a mapping with a `family:` key, and
+ * `get_typography` turns the first into the second before reading it
+ * (`modules/brand/brand.lua:36`), so both spellings answer the same here.
+ */
+function readFonts(typography: unknown): Record<string, string> {
+	const fonts: Record<string, string> = {};
+	if (typography === null || typeof typography !== "object" || Array.isArray(typography)) {
+		return fonts;
+	}
+	const map = typography as Record<string, unknown>;
+	for (const name of BRAND_TYPOGRAPHY_ENTRIES) {
+		const entry = map[name];
+		if (typeof entry === "string" && entry !== "") {
+			fonts[name] = entry;
+			continue;
+		}
+		if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+			const family = stringAt(entry as Record<string, unknown>, "family");
+			if (family !== undefined && family !== "") {
+				fonts[name] = family;
+			}
+		}
+	}
+	return fonts;
+}
+
+/**
+ * A brand name followed to the colour value it stands for,
+ * `src/core/brand/brand.ts:161-197`.
+ *
+ * Three rules, tried in this order and repeated until one of them ends the walk:
+ * a name in the palette is replaced by what the palette holds, a named theme
+ * colour that the brand defines is replaced by what the brand holds, and
+ * anything else is the colour value itself.
+ *
+ * The palette is tried first, so a palette entry named after a theme colour
+ * shadows it, which is how a brand redefines `primary` away from its default.
+ *
+ * A cycle throws upstream. Here it resolves to undefined instead: a preview that
+ * threw would take out the whole compile over a brand file the render also
+ * rejects, and the panel would say nothing about which of the two was wrong.
+ */
+function followColour(brand: SingleBrand, name: string): string | undefined {
+	const seen = new Set<string>();
+	let current = name;
+
+	for (let depth = 0; depth < MAX_ALIAS_DEPTH; depth++) {
+		if (seen.has(current)) {
+			return undefined;
+		}
+		seen.add(current);
+
+		const alias = brand.palette[current];
+		if (alias !== undefined && alias !== "") {
+			current = alias;
+			continue;
+		}
+		const themed = NAMED_THEME_COLOURS.has(current) ? brand.colours[current] : undefined;
+		if (themed !== undefined && themed !== "") {
+			current = themed;
+			continue;
+		}
+		return current;
+	}
+
+	return undefined;
+}
+
+/**
+ * A reader over a parsed brand, matching `get_color_css`.
+ *
+ * A name the brand does not define answers undefined rather than the name
+ * itself. `processedData.color` upstream holds only the keys the file writes, so
+ * a lookup of a name the file never mentions misses, and `background: auto`
+ * against a brand with no background must fall back rather than compile
+ * `rgb("background")`.
+ */
+export function brandColourReader(brand: Brand): BrandColourReader {
+	return (mode: TypstBrandMode, name: string): string | undefined => {
+		const side = brand[mode];
+		if (side.palette[name] === undefined && side.colours[name] === undefined) {
+			return undefined;
+		}
+		return followColour(side, name);
+	};
+}
+
+/**
+ * The four paths Quarto looks for a brand at,
+ * `src/project/project-shared.ts:623-628`.
+ *
+ * They are relative to the project root, and they are tried in this order.
+ */
+export const BRAND_CANDIDATES: readonly string[] = [
+	"_brand.yml",
+	"_brand.yaml",
+	"_brand/_brand.yml",
+	"_brand/_brand.yaml",
+];
+
+/**
+ * What a `brand:` key asks for.
+ *
+ * `false` disables the brand outright, `true` means the project default, a
+ * string names one unified file, and a map names one file per mode.
+ */
+export type BrandOverride =
+	| { kind: "default" }
+	| { kind: "disabled" }
+	| { kind: "unified"; path: string }
+	| { kind: "split"; light?: string; dark?: string };
+
+/**
+ * The `brand:` key of a document or a project, `project-shared.ts:597-621`.
+ *
+ * An unreadable shape is the project default, which is what an absent key means
+ * as well. Quarto validates the key and reports it, and a preview that reported
+ * it too would say the same thing twice about a document Quarto is already
+ * refusing.
+ */
+export function readBrandOverride(value: unknown): BrandOverride {
+	if (value === undefined || value === null || value === true) {
+		return { kind: "default" };
+	}
+	if (value === false) {
+		return { kind: "disabled" };
+	}
+	if (typeof value === "string") {
+		return { kind: "unified", path: value };
+	}
+	if (typeof value === "object" && !Array.isArray(value)) {
+		const map = value as Record<string, unknown>;
+		if ("light" in map || "dark" in map) {
+			return { kind: "split", light: stringAt(map, "light"), dark: stringAt(map, "dark") };
+		}
+	}
+	return { kind: "default" };
+}
+
+/**
+ * Two single-mode brand files joined into one brand.
+ *
+ * A `brand:` map names one file per mode, and each file is read as a whole
+ * brand rather than split, so the light file contributes the light side only.
+ */
+export function joinBrands(light: unknown, dark: unknown): Brand {
+	const lightBrand = splitBrand(light);
+	const darkBrand = splitBrand(dark);
+	// The light file names the fonts, because the two files are read as whole
+	// brands and nothing upstream merges their typography either.
+	return { light: lightBrand.light, dark: darkBrand.dark, fonts: lightBrand.fonts };
+}
+
+/** A brand that defines nothing, which is what no brand file at all means. */
+export const EMPTY_BRAND: Brand = {
+	light: { palette: {}, colours: {} },
+	dark: { palette: {}, colours: {} },
+	fonts: {},
+};
+
+/**
+ * The semantic roles `_typst_render_brand` carries, `typst-render.lua:331-334`.
+ *
+ * Deliberately not every named theme colour: `light`, `dark` and `link` are left
+ * out upstream, and the palette is left out as well.
+ */
+const BRAND_COLOUR_ROLES: readonly string[] = [
+	"foreground",
+	"background",
+	"primary",
+	"secondary",
+	"tertiary",
+	"success",
+	"info",
+	"warning",
+	"danger",
+];
+
+/**
+ * A brand colour kept only when it is a CSS hex string,
+ * `typst-render.lua:348-355`.
+ *
+ * The dictionary carries `_brand.yml` values and not Typst expressions, so a
+ * consumer reads it the way it reads the file. Such a consumer takes hex only,
+ * and would read any other notation as the name of a palette entry.
+ */
+function hexOnly(css: string): string | undefined {
+	const digits = /^#([0-9a-fA-F]+)$/.exec(css);
+	if (digits === null) {
+		return undefined;
+	}
+	const count = digits[1].length;
+	return count === 3 || count === 4 || count === 6 || count === 8 ? css : undefined;
+}
+
+/**
+ * One brand entry, read from the wanted mode and then from the other,
+ * `typst-render.lua:380-398`.
+ *
+ * The scan is per entry and not per brand. Quarto marks a brand as carrying a
+ * dark mode as soon as any one role declares a dark value, so a role written for
+ * light only would otherwise vanish in dark mode.
+ */
+function lookupAcrossModes<T>(mode: TypstBrandMode, read: (side: TypstBrandMode) => T | undefined): T | undefined {
+	const other = mode === "light" ? "dark" : "light";
+	for (const side of [mode, other] as const) {
+		const value = read(side);
+		if (value !== undefined) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+/** A Typst string literal, `_modules/string.lua:264-271`. */
+function typstString(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")}"`;
+}
+
+/**
+ * A mapping as a Typst dictionary literal, `typst-render.lua:243-253`.
+ *
+ * Keys are sorted, so the literal is byte-identical between two runs over the
+ * same brand, which is what lets the compiled source be cached and compared. An
+ * empty mapping is `(:)`, because `()` is the empty array in Typst.
+ */
+function typstDictionary(entries: Readonly<Record<string, string>>): string {
+	const keys = Object.keys(entries).sort();
+	if (keys.length === 0) {
+		return "(:)";
+	}
+	return `(${keys.map((key) => `${typstString(key)}: ${entries[key]}`).join(", ")})`;
+}
+
+/**
+ * The `_typst_render_brand` dictionary for one mode,
+ * `typst-render.lua:407-457`.
+ *
+ * `color` and `typography` are always present, empty when the brand says nothing
+ * under them, so consuming Typst code has one shape to read.
+ */
+export function brandDictionary(brand: Brand, mode: TypstBrandMode): string {
+	const read = brandColourReader(brand);
+
+	const colours: Record<string, string> = {};
+	for (const role of BRAND_COLOUR_ROLES) {
+		const hex = lookupAcrossModes(mode, (side) => {
+			const value = read(side, role);
+			return value === undefined || value === "" ? undefined : hexOnly(value);
+		});
+		if (hex !== undefined) {
+			colours[role] = typstString(hex);
+		}
+	}
+
+	const typography: Record<string, string> = {};
+	for (const name of BRAND_TYPOGRAPHY_ENTRIES) {
+		const family = brand.fonts[name];
+		if (family !== undefined && family !== "") {
+			typography[name] = typstDictionary({ family: typstString(family) });
+		}
+	}
+
+	return typstDictionary({ color: typstDictionary(colours), typography: typstDictionary(typography) });
+}

--- a/src/utils/typst/typstBrand.ts
+++ b/src/utils/typst/typstBrand.ts
@@ -14,6 +14,7 @@
  * defaults are not read, because no colour option needs them.
  */
 
+import { mapping } from "./typstOptions";
 import type { BrandColourReader, TypstBrandMode } from "./typstOptions";
 
 /**
@@ -81,11 +82,8 @@ function splitColour(value: unknown): { light?: string; dark?: string } {
 	if (typeof value === "string") {
 		return { light: value, dark: value };
 	}
-	if (value === null || typeof value !== "object" || Array.isArray(value)) {
-		return {};
-	}
-	const map = value as Record<string, unknown>;
-	return { light: stringAt(map, "light"), dark: stringAt(map, "dark") };
+	const map = mapping(value);
+	return map === undefined ? {} : { light: stringAt(map, "light"), dark: stringAt(map, "dark") };
 }
 
 /**
@@ -95,26 +93,22 @@ function splitColour(value: unknown): { light?: string; dark?: string } {
  * both sides while the name it points at differs by mode.
  */
 export function splitBrand(document: unknown): Brand {
-	const empty = (): SingleBrand => ({ palette: {}, colours: {} });
-	if (document === null || typeof document !== "object" || Array.isArray(document)) {
-		return { light: empty(), dark: empty(), fonts: {} };
+	const map = mapping(document);
+	if (map === undefined) {
+		return EMPTY_BRAND;
 	}
 
-	const fonts = readFonts((document as Record<string, unknown>).typography);
+	const fonts = readFonts(map.typography);
 
-	const colour = (document as Record<string, unknown>).color;
-	if (colour === null || typeof colour !== "object" || Array.isArray(colour)) {
-		return { light: empty(), dark: empty(), fonts };
+	const colourMap = mapping(map.color);
+	if (colourMap === undefined) {
+		return { ...EMPTY_BRAND, fonts };
 	}
 
-	const colourMap = colour as Record<string, unknown>;
 	const palette: Record<string, string> = {};
-	const rawPalette = colourMap.palette;
-	if (rawPalette !== null && typeof rawPalette === "object" && !Array.isArray(rawPalette)) {
-		for (const [name, value] of Object.entries(rawPalette as Record<string, unknown>)) {
-			if (typeof value === "string") {
-				palette[name] = value;
-			}
+	for (const [name, value] of Object.entries(mapping(colourMap.palette) ?? {})) {
+		if (typeof value === "string") {
+			palette[name] = value;
 		}
 	}
 
@@ -145,21 +139,19 @@ export function splitBrand(document: unknown): Brand {
  */
 function readFonts(typography: unknown): Record<string, string> {
 	const fonts: Record<string, string> = {};
-	if (typography === null || typeof typography !== "object" || Array.isArray(typography)) {
+	const map = mapping(typography);
+	if (map === undefined) {
 		return fonts;
 	}
-	const map = typography as Record<string, unknown>;
 	for (const name of BRAND_TYPOGRAPHY_ENTRIES) {
 		const entry = map[name];
 		if (typeof entry === "string" && entry !== "") {
 			fonts[name] = entry;
 			continue;
 		}
-		if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
-			const family = stringAt(entry as Record<string, unknown>, "family");
-			if (family !== undefined && family !== "") {
-				fonts[name] = family;
-			}
+		const family = stringAt(mapping(entry) ?? {}, "family");
+		if (family !== undefined && family !== "") {
+			fonts[name] = family;
 		}
 	}
 	return fonts;
@@ -269,11 +261,9 @@ export function readBrandOverride(value: unknown): BrandOverride {
 	if (typeof value === "string") {
 		return { kind: "unified", path: value };
 	}
-	if (typeof value === "object" && !Array.isArray(value)) {
-		const map = value as Record<string, unknown>;
-		if ("light" in map || "dark" in map) {
-			return { kind: "split", light: stringAt(map, "light"), dark: stringAt(map, "dark") };
-		}
+	const map = mapping(value);
+	if (map !== undefined && ("light" in map || "dark" in map)) {
+		return { kind: "split", light: stringAt(map, "light"), dark: stringAt(map, "dark") };
 	}
 	return { kind: "default" };
 }
@@ -293,11 +283,11 @@ export function joinBrands(light: unknown, dark: unknown): Brand {
 }
 
 /** A brand that defines nothing, which is what no brand file at all means. */
-export const EMPTY_BRAND: Brand = {
+export const EMPTY_BRAND: Brand = Object.freeze({
 	light: { palette: {}, colours: {} },
 	dark: { palette: {}, colours: {} },
 	fonts: {},
-};
+});
 
 /**
  * The semantic roles `_typst_render_brand` carries, `typst-render.lua:331-334`.
@@ -334,25 +324,6 @@ function hexOnly(css: string): string | undefined {
 	return count === 3 || count === 4 || count === 6 || count === 8 ? css : undefined;
 }
 
-/**
- * One brand entry, read from the wanted mode and then from the other,
- * `typst-render.lua:380-398`.
- *
- * The scan is per entry and not per brand. Quarto marks a brand as carrying a
- * dark mode as soon as any one role declares a dark value, so a role written for
- * light only would otherwise vanish in dark mode.
- */
-function lookupAcrossModes<T>(mode: TypstBrandMode, read: (side: TypstBrandMode) => T | undefined): T | undefined {
-	const other = mode === "light" ? "dark" : "light";
-	for (const side of [mode, other] as const) {
-		const value = read(side);
-		if (value !== undefined) {
-			return value;
-		}
-	}
-	return undefined;
-}
-
 /** A Typst string literal, `_modules/string.lua:264-271`. */
 function typstString(value: string): string {
 	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")}"`;
@@ -383,12 +354,18 @@ function typstDictionary(entries: Readonly<Record<string, string>>): string {
 export function brandDictionary(brand: Brand, mode: TypstBrandMode): string {
 	const read = brandColourReader(brand);
 
+	// Each role is read from the wanted mode and then from the other
+	// (`typst-render.lua:380-398`). The scan is per role and not per brand: Quarto
+	// marks a brand as carrying a dark mode as soon as any one role declares a dark
+	// value, so a role written for light only would otherwise vanish in dark mode.
+	const hexAt = (side: TypstBrandMode, role: string): string | undefined => {
+		const value = read(side, role);
+		return value === undefined || value === "" ? undefined : hexOnly(value);
+	};
+	const other = mode === "light" ? "dark" : "light";
 	const colours: Record<string, string> = {};
 	for (const role of BRAND_COLOUR_ROLES) {
-		const hex = lookupAcrossModes(mode, (side) => {
-			const value = read(side, role);
-			return value === undefined || value === "" ? undefined : hexOnly(value);
-		});
+		const hex = hexAt(mode, role) ?? hexAt(other, role);
 		if (hex !== undefined) {
 			colours[role] = typstString(hex);
 		}

--- a/src/utils/typst/typstOptions.ts
+++ b/src/utils/typst/typstOptions.ts
@@ -29,7 +29,25 @@ export type TypstColour = string | { readonly light?: string; readonly dark?: st
 export type TypstOptionValue = string | number | boolean | readonly string[] | TypstColour | Record<string, string>;
 
 /**
+ * A value that is a YAML mapping, or undefined when it is anything else.
+ *
+ * A mapping is what almost every read here has to establish first, and the test
+ * has three parts that are all easy to leave out: `null` is an object, an array
+ * is an object, and neither carries the keys a mapping is asked for.
+ */
+export function mapping(value: unknown): Record<string, unknown> | undefined {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	return value as Record<string, unknown>;
+}
+
+/**
  * The merged option table of one block.
+ *
+ * The keys the source reads are typed, and the rest are reachable through the
+ * index signature: the filter forwards any option it does not consume as an
+ * HTML attribute, so the table is open by design.
  *
  * A key with a `nil` default is absent rather than undefined, because
  * `merge_options` copies with `pairs`, which skips a `nil` value
@@ -38,7 +56,24 @@ export type TypstOptionValue = string | number | boolean | readonly string[] | T
  * tests `opts.foreground` for truthiness, so an absent key and a key holding an
  * empty string are not the same thing.
  */
-export type ResolvedTypstOptions = Readonly<Record<string, TypstOptionValue>>;
+export interface ResolvedTypstOptions {
+	/** The page fill. Always present, because its default is the word `none`. */
+	readonly background?: TypstColour;
+	/** The text fill, absent unless a level or the block sets one. */
+	readonly foreground?: TypstColour;
+	readonly width?: TypstOptionValue;
+	readonly height?: TypstOptionValue;
+	readonly margin?: TypstOptionValue;
+	/** Inline Typst code, a `.typ` path, or a list of either. */
+	readonly preamble?: string | readonly string[];
+	/** A `.typ` path whose contents replace the block body. */
+	readonly file?: string;
+	/** The image format the render would produce, which the preview may not. */
+	readonly format?: TypstOptionValue;
+	readonly output?: TypstOptionValue;
+	readonly pages?: TypstOptionValue;
+	readonly [key: string]: TypstOptionValue | undefined;
+}
 
 /**
  * The filter's own defaults, `typst-render.lua:35-64`.
@@ -177,9 +212,10 @@ export function resolveColourConfig(
 
 	// Every table takes this branch upstream, a list included: the test there is
 	// against the `Inlines` shape a plain YAML scalar has, and a list is not it.
-	// A list therefore holds neither `light` nor `dark` and resolves to nothing.
+	// A list therefore holds neither `light` nor `dark` and resolves to nothing,
+	// which is why the list case is folded in here rather than tested for.
 	if (typeof raw === "object") {
-		const map = raw as Record<string, string | undefined>;
+		const map = mapping(raw) ?? {};
 		const light = map.light === undefined ? undefined : cssColourToTypst(String(map.light));
 		const dark = map.dark === undefined ? undefined : cssColourToTypst(String(map.dark));
 		if (light !== undefined && dark !== undefined) {
@@ -232,22 +268,11 @@ export const TYPST_RENDER = "typst-render";
  * document written the old way previews the way it renders.
  */
 export function extensionLevel(metadata: unknown): TypstGlobalLevel | undefined {
-	if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+	const map = mapping(metadata);
+	if (map === undefined) {
 		return undefined;
 	}
-	const map = metadata as Record<string, unknown>;
-	const extensions = map.extensions;
-	if (extensions !== null && typeof extensions === "object" && !Array.isArray(extensions)) {
-		const level = (extensions as Record<string, unknown>)[TYPST_RENDER];
-		if (level !== null && typeof level === "object" && !Array.isArray(level)) {
-			return level as TypstGlobalLevel;
-		}
-	}
-	const legacy = map[TYPST_RENDER];
-	if (legacy !== null && typeof legacy === "object" && !Array.isArray(legacy)) {
-		return legacy as TypstGlobalLevel;
-	}
-	return undefined;
+	return mapping(mapping(map.extensions)?.[TYPST_RENDER]) ?? mapping(map[TYPST_RENDER]);
 }
 
 /**
@@ -258,10 +283,7 @@ export function extensionLevel(metadata: unknown): TypstGlobalLevel | undefined 
  * follows the editor theme instead, so a dark editor shows a dark image.
  */
 export function documentBrandMode(metadata: unknown): TypstBrandMode | undefined {
-	if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
-		return undefined;
-	}
-	const value = (metadata as Record<string, unknown>)["brand-mode"];
+	const value = mapping(metadata)?.["brand-mode"];
 	if (value === undefined || value === null) {
 		return undefined;
 	}
@@ -276,13 +298,24 @@ function stringify(value: unknown): string {
 	if (Array.isArray(value)) {
 		return value.map(stringify).join("");
 	}
-	if (typeof value === "object") {
-		return Object.values(value as Record<string, unknown>)
-			.map(stringify)
-			.join("");
+	const map = mapping(value);
+	if (map !== undefined) {
+		return Object.values(map).map(stringify).join("");
 	}
 	return String(value);
 }
+
+/**
+ * The keys that take a boolean or one named word, and the word each takes.
+ *
+ * `typst-render.lua:1799-1854` writes the three out separately, and the three
+ * bodies are the same but for the word.
+ */
+const THREE_WAY_KEYS: Readonly<Record<string, string>> = {
+	echo: "fenced",
+	"code-fold": "show",
+	output: "asis",
+};
 
 /**
  * One global value, coerced by the rules at `typst-render.lua:1795-1886`.
@@ -291,24 +324,16 @@ function stringify(value: unknown): string {
  * `dpi` that is not a number at all.
  */
 function coerceGlobal(key: string, raw: unknown): TypstOptionValue | undefined {
-	if (key === "echo") {
+	// Three keys are a boolean with one extra word. Anything but that word and
+	// `true` is false, which is also what the warning upstream leaves behind for
+	// a `code-fold` spelled some fourth way.
+	const keyword = THREE_WAY_KEYS[key];
+	if (keyword !== undefined) {
 		if (typeof raw === "boolean") {
 			return raw;
 		}
 		const value = stringify(raw);
-		return value === "fenced" ? "fenced" : value === "true";
-	}
-	if (key === "code-fold") {
-		if (typeof raw === "boolean") {
-			return raw;
-		}
-		const value = stringify(raw);
-		if (value === "show") {
-			return "show";
-		}
-		// Anything but `true`, `false` and `show` is a warning upstream and
-		// disables the fold, which is the same answer `false` gives.
-		return value === "true";
+		return value === keyword ? keyword : value === "true";
 	}
 	if (key === "code-line-numbers") {
 		if (typeof raw === "boolean") {
@@ -320,13 +345,6 @@ function coerceGlobal(key: string, raw: unknown): TypstOptionValue | undefined {
 		}
 		// A value such as `1|3-4` is kept verbatim for Quarto's own pass.
 		return value;
-	}
-	if (key === "output") {
-		if (typeof raw === "boolean") {
-			return raw;
-		}
-		const value = stringify(raw);
-		return value === "asis" ? "asis" : value === "true";
 	}
 	if (key === "code-summary") {
 		// Upstream keeps Markdown markup here by writing the inlines back out.
@@ -387,10 +405,10 @@ export function resolveGlobalConfig(level: TypstGlobalLevel, brand: BrandColourR
 
 	// `input` is a map and nothing else. A string is a warning upstream and is
 	// dropped, which leaves whatever an outer level set.
-	const input = level.input;
-	if (input !== undefined && input !== null && typeof input === "object" && !Array.isArray(input)) {
+	const input = mapping(level.input);
+	if (input !== undefined) {
 		const map: Record<string, string> = {};
-		for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+		for (const [key, value] of Object.entries(input)) {
 			map[key] = stringify(value);
 		}
 		config.input = map;
@@ -451,25 +469,23 @@ export function resolveTypstOptions(
 	delete blockOptions["cache-refresh"];
 
 	// `input` is a comma-separated string per block and a map globally, so the
-	// merge would otherwise replace the map with the string.
-	const blockInput = typeof blockOptions.input === "string" ? blockOptions.input : undefined;
-	if (blockInput !== undefined) {
-		delete blockOptions.input;
-	}
+	// merge would otherwise replace the map with the string. The filter keeps the
+	// block string aside under a key of its own and passes it to the compiler.
+	// Nothing here emits `--input`, so it is dropped rather than carried under an
+	// invented key that no reader knows about.
+	delete blockOptions.input;
 
-	const merged: Record<string, TypstOptionValue> = { ...TYPST_DEFAULTS, ...global, ...blockOptions };
-	if (blockInput !== undefined) {
-		merged._block_input = blockInput;
-	}
+	const merged: Record<string, TypstOptionValue | undefined> = { ...TYPST_DEFAULTS, ...global, ...blockOptions };
 
 	for (const key of ["background", "foreground"] as const) {
 		const raw = block.options[key];
 		if (raw === "auto") {
-			const resolved = resolveColourConfig("auto", key, brand);
+			// The fallback is `DEFAULTS[key]`, which differs between the two: `none`
+			// for the background and nil for the foreground. Assigning nil in Lua
+			// removes the key, so an `auto` foreground with no brand leaves no key at
+			// all while an `auto` background falls back to the default fill.
+			const resolved = resolveColourConfig("auto", key, brand) ?? TYPST_DEFAULTS[key];
 			if (resolved === undefined) {
-				// `DEFAULTS[key]` is `nil` for `foreground`, and assigning `nil` in Lua
-				// removes the key, so an `auto` foreground with no brand leaves no key
-				// at all rather than an empty one.
 				delete merged[key];
 			} else {
 				merged[key] = resolved;

--- a/src/utils/typst/typstOptions.ts
+++ b/src/utils/typst/typstOptions.ts
@@ -1,0 +1,489 @@
+/**
+ * The option machinery of the `typst-render` filter, ported to TypeScript.
+ *
+ * Every value here is read from `_extensions/typst-render/typst-render.lua` of
+ * `mcanouil/quarto-typst-render`, at the version pinned in
+ * `src/test/fixtures/typstPreview/README.md`. The schema is not the source: its
+ * `default:` values are documentation, they disagree with the filter in places,
+ * and they omit `foreground`, `file` and `format` entirely.
+ *
+ * The port is bug-compatible. Where the filter does something surprising, the
+ * surprise is reproduced and the line it comes from is named, because a preview
+ * that corrects the filter shows an image the render does not produce.
+ */
+
+import type { TypstBlock } from "./typstBlocks";
+
+/** Which side of a light and dark pair a colour is read from. */
+export type TypstBrandMode = "light" | "dark";
+
+/**
+ * A colour option after the global pass.
+ *
+ * A string is one colour for both modes. The pair form comes from a `light:`
+ * and `dark:` map, or from an `auto` colour whose brand differs between the two.
+ */
+export type TypstColour = string | { readonly light?: string; readonly dark?: string };
+
+/** One option value, in any of the shapes the filter carries. */
+export type TypstOptionValue = string | number | boolean | readonly string[] | TypstColour | Record<string, string>;
+
+/**
+ * The merged option table of one block.
+ *
+ * A key with a `nil` default is absent rather than undefined, because
+ * `merge_options` copies with `pairs`, which skips a `nil` value
+ * (`typst-render.lua:66-68`). `format`, `foreground`, `file` and `input` are the
+ * four the acceptance criteria name, and the difference is visible: the filter
+ * tests `opts.foreground` for truthiness, so an absent key and a key holding an
+ * empty string are not the same thing.
+ */
+export type ResolvedTypstOptions = Readonly<Record<string, TypstOptionValue>>;
+
+/**
+ * The filter's own defaults, `typst-render.lua:35-64`.
+ *
+ * The keys the filter defaults to `nil` are absent here for the reason above:
+ * `format`, `foreground`, `file`, `output-filename`, `input`, `code-summary`,
+ * `output-location`, `classes`, `label`, `layout-ncol` and `align`.
+ */
+export const TYPST_DEFAULTS: ResolvedTypstOptions = Object.freeze({
+	dpi: 144,
+	width: "auto",
+	height: "auto",
+	margin: "0.5em",
+	background: "none",
+	preamble: "",
+	cache: true,
+	"cache-refresh": false,
+	"output-directory": "./assets/typst-render",
+	"output-source": false,
+	echo: false,
+	"code-fold": false,
+	"code-line-numbers": false,
+	eval: true,
+	include: true,
+	output: true,
+	pages: "all",
+});
+
+/**
+ * The keys the global pass reads, `typst-render.lua:1788-1794`.
+ *
+ * `font-path`, `preamble`, `input`, `background` and `foreground` are read
+ * after this list by rules of their own, and are not repeated here. `file`,
+ * `output-filename`, `label`, `cap` and `alt` are block-only and are read at no
+ * global level at all.
+ *
+ * `root`, `font-path` and `package-path` run the other way: they are read from
+ * the global configuration alone (`typst-render.lua:1284-1293` and `:1332`) and
+ * never from the merged table, so a block writing `root:` has no effect. Nothing
+ * here has to enforce that, because none of the three reaches the source.
+ */
+const GLOBAL_KEYS: readonly string[] = [
+	"format",
+	"dpi",
+	"width",
+	"height",
+	"margin",
+	"cache",
+	"cache-refresh",
+	"echo",
+	"code-fold",
+	"code-summary",
+	"code-line-numbers",
+	"eval",
+	"include",
+	"output",
+	"output-location",
+	"classes",
+	"root",
+	"package-path",
+	"pages",
+	"layout-ncol",
+	"align",
+	"output-directory",
+	"output-source",
+];
+
+/**
+ * A CSS colour as a Typst colour literal, `typst-render.lua:315-326`.
+ *
+ * A hex value is wrapped, because Typst has no bare hex literal. Bare CSS
+ * functional notation is wrapped as well, so Typst's string-form constructor
+ * parses it. Everything else passes through, which is what lets a Typst
+ * expression such as `luma(80%)` be written in the option directly.
+ */
+export function cssColourToTypst(cssColour: string): string {
+	if (cssColour.startsWith("#")) {
+		return `rgb("${cssColour}")`;
+	}
+	// A Typst-form argument list carries a quote and a bare CSS one never does,
+	// which is the whole test upstream makes. Wrapping `rgb("#fff")` again would
+	// produce `rgb("rgb("#fff")")`, which does not compile.
+	const args = /^rgb\((.+)\)$/.exec(cssColour) ?? /^hsl\((.+)\)$/.exec(cssColour);
+	if (args !== null && !/['"]/.test(args[1])) {
+		return `rgb("${cssColour}")`;
+	}
+	return cssColour;
+}
+
+/**
+ * One side of a colour option, `typst-render.lua:517-526`.
+ *
+ * A pair that holds only the other mode falls back to it rather than to the
+ * default. A brand commonly writes one side only, and a block that then rendered
+ * with no colour at all would look like the option was ignored.
+ */
+export function resolveColourValue(config: TypstColour | undefined, mode: TypstBrandMode): string | undefined {
+	if (typeof config === "string") {
+		return config;
+	}
+	if (config === undefined) {
+		return undefined;
+	}
+	const other = mode === "light" ? "dark" : "light";
+	return config[mode] ?? config[other];
+}
+
+/**
+ * The brand colours one document resolves to.
+ *
+ * Mirrors `get_color_css` of Quarto's own Lua brand module, which is what the
+ * filter calls. It is a function rather than a table so a caller with no brand
+ * at all passes one that always answers undefined.
+ */
+export type BrandColourReader = (mode: TypstBrandMode, name: string) => string | undefined;
+
+/**
+ * A colour option as the filter stores it, `typst-render.lua:465-511`.
+ *
+ * Handles the three shapes a global level can write: a `light:` and `dark:` map,
+ * the word `auto`, and a colour string. Returns undefined when the option
+ * resolves to nothing, which leaves the merged value in place.
+ *
+ * `auto` returns a pair only when the two modes disagree. A brand that names the
+ * same colour on both sides is one colour, and carrying it as a pair would send
+ * the filter down its dual-rendering path for no difference in output.
+ */
+export function resolveColourConfig(
+	raw: TypstOptionValue | undefined,
+	colourName: string,
+	brand: BrandColourReader,
+): TypstColour | undefined {
+	if (raw === undefined) {
+		return undefined;
+	}
+
+	// Every table takes this branch upstream, a list included: the test there is
+	// against the `Inlines` shape a plain YAML scalar has, and a list is not it.
+	// A list therefore holds neither `light` nor `dark` and resolves to nothing.
+	if (typeof raw === "object") {
+		const map = raw as Record<string, string | undefined>;
+		const light = map.light === undefined ? undefined : cssColourToTypst(String(map.light));
+		const dark = map.dark === undefined ? undefined : cssColourToTypst(String(map.dark));
+		if (light !== undefined && dark !== undefined) {
+			return { light, dark };
+		}
+		return light ?? dark;
+	}
+
+	const value = String(raw);
+
+	if (value === "auto") {
+		const light = brand("light", colourName);
+		const dark = brand("dark", colourName);
+		const haveLight = light !== undefined && light !== "";
+		const haveDark = dark !== undefined && dark !== "";
+		if (haveLight && haveDark && light !== dark) {
+			return { light: cssColourToTypst(light), dark: cssColourToTypst(dark) };
+		}
+		if (haveLight) {
+			return cssColourToTypst(light);
+		}
+		if (haveDark) {
+			return cssColourToTypst(dark);
+		}
+		// The filter warns and falls back to the default here. The preview has no
+		// place to warn from, and the panel header names the resolved mode, so the
+		// fallback alone is reproduced.
+		return undefined;
+	}
+
+	return value === "" ? undefined : cssColourToTypst(value);
+}
+
+/**
+ * A global level as the filter reads it.
+ *
+ * The values are whatever the YAML held, so this is the shape of one
+ * `extensions.typst-render:` mapping and not of a merged table.
+ */
+export type TypstGlobalLevel = Readonly<Record<string, unknown>>;
+
+/** The extension name, which is both the metadata key and the schema name. */
+export const TYPST_RENDER = "typst-render";
+
+/**
+ * The `typst-render` mapping of one metadata level, `typst-render.lua:1783`.
+ *
+ * `extensions.typst-render:` is the supported spelling. A bare top-level
+ * `typst-render:` is a legacy fallback that the filter still reads, so a
+ * document written the old way previews the way it renders.
+ */
+export function extensionLevel(metadata: unknown): TypstGlobalLevel | undefined {
+	if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+		return undefined;
+	}
+	const map = metadata as Record<string, unknown>;
+	const extensions = map.extensions;
+	if (extensions !== null && typeof extensions === "object" && !Array.isArray(extensions)) {
+		const level = (extensions as Record<string, unknown>)[TYPST_RENDER];
+		if (level !== null && typeof level === "object" && !Array.isArray(level)) {
+			return level as TypstGlobalLevel;
+		}
+	}
+	const legacy = map[TYPST_RENDER];
+	if (legacy !== null && typeof legacy === "object" && !Array.isArray(legacy)) {
+		return legacy as TypstGlobalLevel;
+	}
+	return undefined;
+}
+
+/**
+ * The `brand-mode:` a document sets, `typst-render.lua:1772-1773`.
+ *
+ * Undefined when the document sets none, which is where the preview deviates
+ * from the filter on purpose: the filter defaults to light, and the preview
+ * follows the editor theme instead, so a dark editor shows a dark image.
+ */
+export function documentBrandMode(metadata: unknown): TypstBrandMode | undefined {
+	if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+		return undefined;
+	}
+	const value = (metadata as Record<string, unknown>)["brand-mode"];
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	return stringify(value) === "dark" ? "dark" : "light";
+}
+
+/** A YAML scalar as the filter's `pandoc.utils.stringify` would leave it. */
+function stringify(value: unknown): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	if (Array.isArray(value)) {
+		return value.map(stringify).join("");
+	}
+	if (typeof value === "object") {
+		return Object.values(value as Record<string, unknown>)
+			.map(stringify)
+			.join("");
+	}
+	return String(value);
+}
+
+/**
+ * One global value, coerced by the rules at `typst-render.lua:1795-1886`.
+ *
+ * Returns undefined when the filter leaves the key unset, which happens for a
+ * `dpi` that is not a number at all.
+ */
+function coerceGlobal(key: string, raw: unknown): TypstOptionValue | undefined {
+	if (key === "echo") {
+		if (typeof raw === "boolean") {
+			return raw;
+		}
+		const value = stringify(raw);
+		return value === "fenced" ? "fenced" : value === "true";
+	}
+	if (key === "code-fold") {
+		if (typeof raw === "boolean") {
+			return raw;
+		}
+		const value = stringify(raw);
+		if (value === "show") {
+			return "show";
+		}
+		// Anything but `true`, `false` and `show` is a warning upstream and
+		// disables the fold, which is the same answer `false` gives.
+		return value === "true";
+	}
+	if (key === "code-line-numbers") {
+		if (typeof raw === "boolean") {
+			return raw;
+		}
+		const value = stringify(raw);
+		if (value === "true" || value === "false") {
+			return value === "true";
+		}
+		// A value such as `1|3-4` is kept verbatim for Quarto's own pass.
+		return value;
+	}
+	if (key === "output") {
+		if (typeof raw === "boolean") {
+			return raw;
+		}
+		const value = stringify(raw);
+		return value === "asis" ? "asis" : value === "true";
+	}
+	if (key === "code-summary") {
+		// Upstream keeps Markdown markup here by writing the inlines back out.
+		// A file read with `js-yaml` never holds inlines, so the string it parsed
+		// already is the markup.
+		return typeof raw === "string" ? raw : stringify(raw);
+	}
+
+	const fallback = TYPST_DEFAULTS[key];
+	if (typeof fallback === "number") {
+		const parsed = Number(stringify(raw));
+		return Number.isNaN(parsed) ? undefined : parsed;
+	}
+	if (typeof fallback === "boolean") {
+		return typeof raw === "boolean" ? raw : stringify(raw) === "true";
+	}
+	return stringify(raw);
+}
+
+/**
+ * The global configuration one level contributes, `typst-render.lua:1785-1944`.
+ *
+ * A level is one `extensions.typst-render:` mapping, from `_quarto.yml`, a
+ * `metadata-files:` target, a `_metadata.yml` or the document front matter. The
+ * levels are merged by the caller, lowest first, because the filter sees only
+ * the one mapping Quarto has already merged for it.
+ */
+export function resolveGlobalConfig(level: TypstGlobalLevel, brand: BrandColourReader): ResolvedTypstOptions {
+	const config: Record<string, TypstOptionValue> = {};
+
+	for (const key of GLOBAL_KEYS) {
+		if (level[key] === undefined || level[key] === null) {
+			continue;
+		}
+		const value = coerceGlobal(key, level[key]);
+		if (value !== undefined) {
+			config[key] = value;
+		}
+	}
+
+	// `font-path` and `preamble` take a string or a list, and both are stored as
+	// a list. A `preamble` that stringifies to nothing becomes an empty list, so
+	// `preamble: ""` clears an inherited one rather than being ignored.
+	const fontPath = level["font-path"];
+	if (fontPath !== undefined && fontPath !== null) {
+		config["font-path"] = Array.isArray(fontPath) ? fontPath.map(stringify) : [stringify(fontPath)];
+	}
+
+	const preamble = level.preamble;
+	if (preamble !== undefined && preamble !== null) {
+		if (Array.isArray(preamble)) {
+			config.preamble = preamble.map(stringify);
+		} else {
+			const value = stringify(preamble);
+			config.preamble = value === "" ? [] : [value];
+		}
+	}
+
+	// `input` is a map and nothing else. A string is a warning upstream and is
+	// dropped, which leaves whatever an outer level set.
+	const input = level.input;
+	if (input !== undefined && input !== null && typeof input === "object" && !Array.isArray(input)) {
+		const map: Record<string, string> = {};
+		for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+			map[key] = stringify(value);
+		}
+		config.input = map;
+	}
+
+	for (const key of ["background", "foreground"] as const) {
+		if (level[key] === undefined || level[key] === null) {
+			continue;
+		}
+		const resolved = resolveColourConfig(level[key] as TypstOptionValue, key, brand);
+		if (resolved !== undefined) {
+			config[key] = resolved;
+		}
+	}
+
+	return config;
+}
+
+/**
+ * The global configuration of a whole metadata chain.
+ *
+ * The levels arrive lowest first, and each one is resolved on its own before
+ * the merge. Resolving the merged mapping instead would read a `light:` and
+ * `dark:` map that two levels each half-wrote as though one level had written
+ * both halves.
+ */
+export function mergeGlobalConfigs(
+	levels: readonly TypstGlobalLevel[],
+	brand: BrandColourReader,
+): ResolvedTypstOptions {
+	const merged: Record<string, TypstOptionValue> = {};
+	for (const level of levels) {
+		Object.assign(merged, resolveGlobalConfig(level, brand));
+	}
+	return merged;
+}
+
+/**
+ * The merged options of one cell, `typst-render.lua:1976-2009`.
+ *
+ * Three passes, in the filter's own order: the block's `input` string is set
+ * aside so the merge cannot overwrite the global map with it, the three tables
+ * are merged, and only then are the block's own colours resolved.
+ *
+ * The colour pass is deliberately last and deliberately reads the block table
+ * rather than the merged one. A value inherited from a global level is already a
+ * Typst expression, and wrapping `rgb("#faf6ee")` a second time does not compile.
+ */
+export function resolveTypstOptions(
+	block: TypstBlock,
+	global: ResolvedTypstOptions,
+	brand: BrandColourReader,
+): ResolvedTypstOptions {
+	const blockOptions: Record<string, string | boolean> = { ...block.options };
+
+	// Per-block `cache-refresh` is a warning upstream and is dropped, because the
+	// sweep it controls runs once for the whole document.
+	delete blockOptions["cache-refresh"];
+
+	// `input` is a comma-separated string per block and a map globally, so the
+	// merge would otherwise replace the map with the string.
+	const blockInput = typeof blockOptions.input === "string" ? blockOptions.input : undefined;
+	if (blockInput !== undefined) {
+		delete blockOptions.input;
+	}
+
+	const merged: Record<string, TypstOptionValue> = { ...TYPST_DEFAULTS, ...global, ...blockOptions };
+	if (blockInput !== undefined) {
+		merged._block_input = blockInput;
+	}
+
+	for (const key of ["background", "foreground"] as const) {
+		const raw = block.options[key];
+		if (raw === "auto") {
+			const resolved = resolveColourConfig("auto", key, brand);
+			if (resolved === undefined) {
+				// `DEFAULTS[key]` is `nil` for `foreground`, and assigning `nil` in Lua
+				// removes the key, so an `auto` foreground with no brand leaves no key
+				// at all rather than an empty one.
+				delete merged[key];
+			} else {
+				merged[key] = resolved;
+			}
+			continue;
+		}
+		// The guard is against the default, so a block writing `background: none`
+		// is left as the bare word `none` rather than being wrapped. The merge has
+		// already put it in place, so this pass only decides whether to rewrite it
+		// as a Typst expression, and `none` already is one.
+		if (typeof raw === "string" && raw !== TYPST_DEFAULTS[key]) {
+			merged[key] = cssColourToTypst(raw);
+		}
+	}
+
+	return merged;
+}

--- a/src/utils/typst/typstOptions.ts
+++ b/src/utils/typst/typstOptions.ts
@@ -355,7 +355,11 @@ function coerceGlobal(key: string, raw: unknown): TypstOptionValue | undefined {
 
 	const fallback = TYPST_DEFAULTS[key];
 	if (typeof fallback === "number") {
-		const parsed = Number(stringify(raw));
+		// `Number("")` and `Number(" ")` are both zero, while `tonumber` upstream
+		// answers nil for either and the key keeps its default. Reading `dpi: ""` as
+		// zero would compile at no resolution at all.
+		const text = stringify(raw).trim();
+		const parsed = text === "" ? Number.NaN : Number(text);
 		return Number.isNaN(parsed) ? undefined : parsed;
 	}
 	if (typeof fallback === "boolean") {

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -313,6 +313,23 @@ export function isUnavailable<T extends object>(result: T | Unavailable): result
 export interface AssembledCell extends AssembledSource {
 	/** What the panel should say about the block beside the image. */
 	notes: string[];
+	/**
+	 * How many lines of the block body sit above the first compiled line.
+	 *
+	 * A cell compiles its `code` and not its `body`, so the leading `//|` run is
+	 * in the document but not in the source Typst reads. A diagnostic that lost
+	 * only the injected lines would name a line of the block that is short by the
+	 * length of that run.
+	 */
+	bodyLineOffset: number;
+	/**
+	 * The `file:` whose contents replaced the body, when one did.
+	 *
+	 * A diagnostic then has no line of the block at all: it names a position in
+	 * that file, and reporting it against the block would send the reader to a
+	 * line that has nothing to do with the failure.
+	 */
+	externalFile?: string;
 }
 
 /**
@@ -369,6 +386,12 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 		return { unavailable: `The file option names \`${options.file}\`, and it could not be read.` };
 	}
 
+	// The compiled code starts below the block's own option run, and a `file:`
+	// replaces the body outright, so the panel is told where the lines it is about
+	// to be handed actually live.
+	const bodyLineOffset =
+		code === undefined ? block.body.slice(0, block.body.length - block.code.length).split("\n").length - 1 : 0;
+
 	const assembled = buildCellSource(block, {
 		// The fallback is `DEFAULTS.background`, which `resolve_opts_colours` applies
 		// at `typst-render.lua:884`. Only the background has one: a cell with no
@@ -382,5 +405,5 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 		preamble,
 		code,
 	});
-	return { ...assembled, notes: cellNotes(options) };
+	return { ...assembled, notes: cellNotes(options), bodyLineOffset, externalFile: options.file };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -7,7 +7,6 @@ import {
 	resolveTypstOptions,
 	type ResolvedTypstOptions,
 	type TypstBrandMode,
-	type TypstColour,
 	type TypstGlobalLevel,
 } from "./typstOptions";
 
@@ -226,7 +225,7 @@ function cellBody(body: string): string {
  * render. A cell that reads it is out of scope for the first version and the
  * panel says so.
  */
-export function buildCellSource(block: TypstBlock, options: CellSourceOptions): AssembledSource {
+function buildCellSource(block: TypstBlock, options: CellSourceOptions): AssembledSource {
 	const above = [
 		`#let _typst_render_background = ${options.background}`,
 		`#let _typst_render_foreground = ${options.foreground ?? "none"}`,
@@ -263,38 +262,32 @@ export function buildCellSource(block: TypstBlock, options: CellSourceOptions): 
  * The reads are injected, so this module keeps importing no `vscode` and a test
  * needs no file on disk.
  */
-export function resolvePreamble(
+export async function resolvePreamble(
 	value: string | readonly string[] | undefined,
-	readFile: (documentPath: string) => string | undefined,
-): string {
+	readFile: ReadFile,
+): Promise<string> {
 	if (value === undefined || value === "") {
 		return "";
 	}
 	const entries = typeof value === "string" ? [value] : value;
-	const parts: string[] = [];
-	for (const entry of entries) {
-		if (entry === "") {
-			continue;
-		}
-		if (!entry.endsWith(".typ")) {
-			parts.push(entry);
-			continue;
-		}
-		const content = readFile(entry);
-		if (content !== undefined) {
-			parts.push(content);
-		}
-	}
-	return parts.join("\n");
+	// The entries are independent, so they are read together rather than one
+	// after another. Their order in the source is the order they are written in,
+	// which `Promise.all` preserves.
+	const resolved = await Promise.all(entries.map(async (entry) => (entry.endsWith(".typ") ? readFile(entry) : entry)));
+	// An entry that cannot be read is dropped rather than failing the whole
+	// preview, which is what the filter does as well.
+	return resolved.filter((part): part is string => part !== undefined && part !== "").join("\n");
 }
+
+/** A `preamble:` or `file:` path read as text, or undefined when it cannot be. */
+export type ReadFile = (documentPath: string) => Promise<string | undefined>;
 
 /**
  * Everything outside a cell that decides what it compiles to.
  *
  * The levels arrive lowest first, and the caller is what knows where they came
- * from. The reads are injected for the same reason `resolvePreamble` injects
- * them: this module imports no `vscode`, and a fixture drives the whole pipeline
- * from strings alone.
+ * from. The read is injected, so this module imports no `vscode` and a fixture
+ * drives the whole pipeline from strings alone.
  */
 export interface CellContext {
 	/** The `extensions.typst-render:` mapping of each level, lowest first. */
@@ -303,51 +296,52 @@ export interface CellContext {
 	brand: Brand;
 	/** Which side of the brand the compile reads. */
 	mode: TypstBrandMode;
-	/** A `preamble:` or `file:` path read as text, or undefined when it cannot be. */
-	readFile: (documentPath: string) => string | undefined;
+	readFile: ReadFile;
 }
 
-/** A cell that cannot be compiled, and the one line that says why. */
-export interface UnavailableCell {
+/** Something the preview cannot do, and the one line that says why. */
+export interface Unavailable {
 	unavailable: string;
 }
 
-/** The result of assembling one cell. */
-export type CellResult = AssembledSource | UnavailableCell;
-
-/** Whether assembling a cell reported why it could not be done. */
-export function isUnavailable(result: CellResult): result is UnavailableCell {
+/** Whether a result reported why it could not be produced. */
+export function isUnavailable<T extends object>(result: T | Unavailable): result is Unavailable {
 	return "unavailable" in result;
 }
 
+/** One cell assembled, with what the preview does not reproduce about it. */
+export interface AssembledCell extends AssembledSource {
+	/** What the panel should say about the block beside the image. */
+	notes: string[];
+}
+
 /**
- * One merged option written into the source.
+ * What the preview does not reproduce about a cell.
  *
- * The filter formats the geometry with `%s`, which stringifies whatever the
- * option held, so a value that is not a string reaches Typst as its own text and
- * fails there with the value in the message. The merge always leaves a value,
- * because the three geometry keys all carry a default.
+ * Each of these compiles to something, so refusing them would be worse than
+ * showing the image and saying what is missing from it.
+ *
+ * Read from the merged options and not from the block's own `//|` run, because
+ * every one of the three is a global key as well: a `format: pdf` written in
+ * `_quarto.yml` applies to a block that never mentions it.
  */
-function optionText(options: ResolvedTypstOptions, key: string): string {
-	return String(options[key]);
-}
-
-/** One merged option as a colour, which is the only shape the two colour keys take. */
-function optionColour(options: ResolvedTypstOptions, key: string): TypstColour | undefined {
-	const value = options[key];
-	if (typeof value === "string") {
-		return value;
+export function cellNotes(options: ResolvedTypstOptions): string[] {
+	const notes: string[] = [];
+	const format = options.format;
+	if (format === "pdf" || format === "html") {
+		// The preview always compiles to SVG, because that is what a webview, a
+		// hover and a decoration can all show.
+		notes.push(`the preview compiles to SVG, not to ${format}`);
 	}
-	return typeof value === "object" && !Array.isArray(value) ? (value as TypstColour) : undefined;
-}
-
-/** The `preamble:` option, which the global pass stores as a list. */
-function optionPreamble(options: ResolvedTypstOptions): string | readonly string[] | undefined {
-	const value = options.preamble;
-	if (typeof value === "string") {
-		return value;
+	if (options.output === "asis") {
+		// An `asis` cell is emitted into the document Typst is already laying out,
+		// so it inherits a page the preview has no way to reproduce.
+		notes.push("an `output: asis` cell inherits the document page, which the preview cannot apply");
 	}
-	return Array.isArray(value) ? (value as readonly string[]) : undefined;
+	if (typeof options.pages === "string" && options.pages !== "all") {
+		notes.push("the preview shows the first page only");
+	}
+	return notes;
 }
 
 /**
@@ -357,35 +351,36 @@ function optionPreamble(options: ResolvedTypstOptions): string | readonly string
  * are resolved and merged, the block options are merged over them, the colours
  * of the mode in force are picked out, and the parts are assembled.
  */
-export function buildCell(block: TypstBlock, context: CellContext): CellResult {
+export async function buildCell(block: TypstBlock, context: CellContext): Promise<AssembledCell | Unavailable> {
 	const brand = brandColourReader(context.brand);
 	const global = mergeGlobalConfigs(context.levels, brand);
 	const options = resolveTypstOptions(block, global, brand);
 
+	// The preamble and the `file:` are independent reads, so they run together.
+	const [preamble, code] = await Promise.all([
+		resolvePreamble(options.preamble, context.readFile),
+		options.file === undefined || options.file === "" ? undefined : context.readFile(options.file),
+	]);
+
 	// A `file:` replaces the cell body entirely. The filter logs and renders
 	// nothing when the read fails, which in a preview would be a blank image with
 	// no reason beside it.
-	let code: string | undefined;
-	const file = options.file;
-	if (typeof file === "string" && file !== "") {
-		code = context.readFile(file);
-		if (code === undefined) {
-			return { unavailable: `The file option names \`${file}\`, and it could not be read.` };
-		}
+	if (options.file !== undefined && options.file !== "" && code === undefined) {
+		return { unavailable: `The file option names \`${options.file}\`, and it could not be read.` };
 	}
 
-	return buildCellSource(block, {
+	const assembled = buildCellSource(block, {
 		// The fallback is `DEFAULTS.background`, which `resolve_opts_colours` applies
 		// at `typst-render.lua:884`. Only the background has one: a cell with no
 		// foreground writes no text fill line at all.
-		background:
-			resolveColourValue(optionColour(options, "background"), context.mode) ?? String(TYPST_DEFAULTS.background),
-		foreground: resolveColourValue(optionColour(options, "foreground"), context.mode),
-		width: optionText(options, "width"),
-		height: optionText(options, "height"),
-		margin: optionText(options, "margin"),
+		background: resolveColourValue(options.background, context.mode) ?? String(TYPST_DEFAULTS.background),
+		foreground: resolveColourValue(options.foreground, context.mode),
+		width: String(options.width),
+		height: String(options.height),
+		margin: String(options.margin),
 		brand: brandDictionary(context.brand, context.mode),
-		preamble: resolvePreamble(optionPreamble(options), context.readFile),
+		preamble,
 		code,
 	});
+	return { ...assembled, notes: cellNotes(options) };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -405,5 +405,9 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 		preamble,
 		code,
 	});
-	return { ...assembled, notes: cellNotes(options), bodyLineOffset, externalFile: options.file };
+	// Named only when the file actually replaced the body. An empty `file:` skips
+	// the read and compiles the body, and reporting it as the external file would
+	// print a position "of " with no name and drop the option run correction.
+	const externalFile = code === undefined ? undefined : options.file;
+	return { ...assembled, notes: cellNotes(options), bodyLineOffset, externalFile };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -1,4 +1,15 @@
 import { precedingRawBlocks, type TypstBlock } from "./typstBlocks";
+import { brandColourReader, brandDictionary, type Brand } from "./typstBrand";
+import {
+	TYPST_DEFAULTS,
+	mergeGlobalConfigs,
+	resolveColourValue,
+	resolveTypstOptions,
+	type ResolvedTypstOptions,
+	type TypstBrandMode,
+	type TypstColour,
+	type TypstGlobalLevel,
+} from "./typstOptions";
 
 /** The source of one compile, and how far it pushed the block body down. */
 export interface AssembledSource {
@@ -154,4 +165,227 @@ export function themeHeader(kind: TypstThemeKind, foreground: string, background
 	}
 	const colour = text === AUTO ? typstColour(THEME_TEXT[kind]) : text;
 	return { header: `${geometry}\n#set text(fill: ${colour})`, foreground: colour };
+}
+
+/**
+ * Everything a ```` ```{typst} ```` cell needs, once the disk has been read.
+ *
+ * A cell keeps the colour contract of the `typst-render` filter and never takes
+ * the preview's own theme header: the filter writes the page fill and the text
+ * fill itself, from the options in force, and a second set of directives above
+ * them would show an image the render does not produce.
+ */
+export interface CellSourceOptions {
+	/** The page fill, already a Typst expression. */
+	background: string;
+	/** The text fill, or undefined when the options set none. */
+	foreground?: string;
+	/** The page width, `auto` unless an option says otherwise. */
+	width: string;
+	/** The page height. */
+	height: string;
+	/** The page margin, which is what keeps a glyph off the edge of the image. */
+	margin: string;
+	/** The `_typst_render_brand` dictionary literal for the mode in force. */
+	brand: string;
+	/** The preamble, resolved from inline code and `.typ` files, or empty. */
+	preamble: string;
+	/**
+	 * The contents of a `file:` option, which replace the cell body entirely
+	 * (`typst-render.lua:2047-2052`). Absent when the cell has no `file:`.
+	 */
+	code?: string;
+}
+
+/**
+ * The body of a cell as Pandoc hands it to the filter.
+ *
+ * A `CodeBlock` carries no trailing line ending, because the closing fence is
+ * not part of the block. The scanner keeps the one before that fence, so it
+ * comes off here rather than in the scanner, where the other two kinds need it.
+ *
+ * A `file:` substitution is not passed through here. The filter reads that file
+ * whole, trailing line ending included, and the compiled source keeps it.
+ */
+function cellBody(body: string): string {
+	return body.replace(/\r?\n$/, "");
+}
+
+/**
+ * The source of one ```` ```{typst} ```` cell.
+ *
+ * A port of `build_typst_source` at `typst-render.lua:943-962`, together with
+ * the bindings it injects at `:907-915` and the page directive it builds at
+ * `:920-925`. The parts are joined with newlines in the filter's own order, and
+ * the order is load-bearing: the author's preamble sits below the `#set`
+ * directives so it can override them, and above the code so the code can use it.
+ *
+ * One part is deliberately not emitted. `build_define_preamble` at `:946-949`
+ * writes the `typst_define()` payload of the R and Python helpers, which the
+ * preview cannot see: it lives in metadata Quarto's engine produces during a
+ * render. A cell that reads it is out of scope for the first version and the
+ * panel says so.
+ */
+export function buildCellSource(block: TypstBlock, options: CellSourceOptions): AssembledSource {
+	const above = [
+		`#let _typst_render_background = ${options.background}`,
+		`#let _typst_render_foreground = ${options.foreground ?? "none"}`,
+		`#let _typst_render_brand = ${options.brand}`,
+		`#set page(width: ${options.width}, height: ${options.height}, margin: ${options.margin}, fill: ${options.background})`,
+	];
+	if (options.foreground !== undefined) {
+		above.push(`#set text(fill: ${options.foreground})`);
+	}
+	if (options.preamble !== "") {
+		above.push(options.preamble);
+	}
+
+	// Joined and not terminated, which is where a cell differs from the other two
+	// kinds. `table.concat(parts, '\n')` puts exactly one line ending between two
+	// parts, so a preamble file that ends with a newline of its own contributes a
+	// blank line, and a preview that dropped it would not match the render.
+	const prefix = above.join("\n");
+	// The block is taken rather than only its code so a caller cannot pass the
+	// body of one cell beside the options of another.
+	const code = options.code ?? cellBody(block.code);
+	return { source: `${prefix}\n${code}`, injectedLines: prefix.split("\n").length };
+}
+
+/**
+ * A `preamble:` option resolved to Typst code,
+ * `typst-render.lua:701-749`.
+ *
+ * An entry ending in `.typ` is a path and is read; every other entry is inline
+ * Typst code. A list is resolved entry by entry and joined with newlines, and an
+ * entry that cannot be read is dropped rather than failing the whole preview,
+ * which is what the filter does as well.
+ *
+ * The reads are injected, so this module keeps importing no `vscode` and a test
+ * needs no file on disk.
+ */
+export function resolvePreamble(
+	value: string | readonly string[] | undefined,
+	readFile: (documentPath: string) => string | undefined,
+): string {
+	if (value === undefined || value === "") {
+		return "";
+	}
+	const entries = typeof value === "string" ? [value] : value;
+	const parts: string[] = [];
+	for (const entry of entries) {
+		if (entry === "") {
+			continue;
+		}
+		if (!entry.endsWith(".typ")) {
+			parts.push(entry);
+			continue;
+		}
+		const content = readFile(entry);
+		if (content !== undefined) {
+			parts.push(content);
+		}
+	}
+	return parts.join("\n");
+}
+
+/**
+ * Everything outside a cell that decides what it compiles to.
+ *
+ * The levels arrive lowest first, and the caller is what knows where they came
+ * from. The reads are injected for the same reason `resolvePreamble` injects
+ * them: this module imports no `vscode`, and a fixture drives the whole pipeline
+ * from strings alone.
+ */
+export interface CellContext {
+	/** The `extensions.typst-render:` mapping of each level, lowest first. */
+	levels: readonly TypstGlobalLevel[];
+	/** The parsed `_brand.yml`, or an empty brand when the project has none. */
+	brand: Brand;
+	/** Which side of the brand the compile reads. */
+	mode: TypstBrandMode;
+	/** A `preamble:` or `file:` path read as text, or undefined when it cannot be. */
+	readFile: (documentPath: string) => string | undefined;
+}
+
+/** A cell that cannot be compiled, and the one line that says why. */
+export interface UnavailableCell {
+	unavailable: string;
+}
+
+/** The result of assembling one cell. */
+export type CellResult = AssembledSource | UnavailableCell;
+
+/** Whether assembling a cell reported why it could not be done. */
+export function isUnavailable(result: CellResult): result is UnavailableCell {
+	return "unavailable" in result;
+}
+
+/**
+ * One merged option written into the source.
+ *
+ * The filter formats the geometry with `%s`, which stringifies whatever the
+ * option held, so a value that is not a string reaches Typst as its own text and
+ * fails there with the value in the message. The merge always leaves a value,
+ * because the three geometry keys all carry a default.
+ */
+function optionText(options: ResolvedTypstOptions, key: string): string {
+	return String(options[key]);
+}
+
+/** One merged option as a colour, which is the only shape the two colour keys take. */
+function optionColour(options: ResolvedTypstOptions, key: string): TypstColour | undefined {
+	const value = options[key];
+	if (typeof value === "string") {
+		return value;
+	}
+	return typeof value === "object" && !Array.isArray(value) ? (value as TypstColour) : undefined;
+}
+
+/** The `preamble:` option, which the global pass stores as a list. */
+function optionPreamble(options: ResolvedTypstOptions): string | readonly string[] | undefined {
+	const value = options.preamble;
+	if (typeof value === "string") {
+		return value;
+	}
+	return Array.isArray(value) ? (value as readonly string[]) : undefined;
+}
+
+/**
+ * One ```` ```{typst} ```` cell, from its context to its compiled source.
+ *
+ * The whole pipeline of the filter, in the filter's own order: the global levels
+ * are resolved and merged, the block options are merged over them, the colours
+ * of the mode in force are picked out, and the parts are assembled.
+ */
+export function buildCell(block: TypstBlock, context: CellContext): CellResult {
+	const brand = brandColourReader(context.brand);
+	const global = mergeGlobalConfigs(context.levels, brand);
+	const options = resolveTypstOptions(block, global, brand);
+
+	// A `file:` replaces the cell body entirely. The filter logs and renders
+	// nothing when the read fails, which in a preview would be a blank image with
+	// no reason beside it.
+	let code: string | undefined;
+	const file = options.file;
+	if (typeof file === "string" && file !== "") {
+		code = context.readFile(file);
+		if (code === undefined) {
+			return { unavailable: `The file option names \`${file}\`, and it could not be read.` };
+		}
+	}
+
+	return buildCellSource(block, {
+		// The fallback is `DEFAULTS.background`, which `resolve_opts_colours` applies
+		// at `typst-render.lua:884`. Only the background has one: a cell with no
+		// foreground writes no text fill line at all.
+		background:
+			resolveColourValue(optionColour(options, "background"), context.mode) ?? String(TYPST_DEFAULTS.background),
+		foreground: resolveColourValue(optionColour(options, "foreground"), context.mode),
+		width: optionText(options, "width"),
+		height: optionText(options, "height"),
+		margin: optionText(options, "margin"),
+		brand: brandDictionary(context.brand, context.mode),
+		preamble: resolvePreamble(optionPreamble(options), context.readFile),
+		code,
+	});
 }

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -5,6 +5,8 @@
  * to a structured key path by tracking indentation levels.
  */
 
+import * as yaml from "js-yaml";
+
 /**
  * A half-open text range: [start, end).
  */
@@ -515,6 +517,36 @@ export function getYamlFrontMatterRange(text: string): TextRange | undefined {
 	}
 
 	return undefined;
+}
+
+/**
+ * Parse the YAML front matter of a Quarto document.
+ *
+ * Built on `getYamlFrontMatterRange` so that the metadata a reader sees and the
+ * blocks a scanner finds agree on where the front matter ends.  A rule of its
+ * own here would close on any line starting `---`, while the scanner needs a
+ * line that trims to exactly `---`, and the two would disagree on the same
+ * document.
+ *
+ * @param text - The full document text.
+ * @returns The parsed mapping, or `undefined` when the document has no closed
+ *   front matter, when it is empty, or when it does not parse.
+ */
+export function parseFrontMatter(text: string): unknown {
+	const range = getYamlFrontMatterRange(text);
+	if (range === undefined) {
+		return undefined;
+	}
+	const bodyStart = text.indexOf("\n") + 1;
+	const bodyEnd = text.lastIndexOf("\n", range.end - 1) + 1;
+	if (bodyEnd <= bodyStart) {
+		return undefined;
+	}
+	try {
+		return yaml.load(text.slice(bodyStart, bodyEnd));
+	} catch {
+		return undefined;
+	}
 }
 
 /**


### PR DESCRIPTION
A ```` ```{typst} ```` cell is executed by the `typst-render` extension, so a preview that compiled its body alone would show an image the render does not produce. This resolves the same options the filter resolves, from the same metadata chain, and assembles the same source.

Every ported value is read from the filter's own Lua, not from its schema: the schema's `default:` values are documentation, they disagree with the filter in places, and they omit `foreground`, `file` and `format` entirely.

Twelve golden fixtures carry the fidelity load. Each `expected.typ` is output the filter itself wrote through its own `output-source: true`, and the port is compared against it byte for byte. They are recorded output and not expectations written by hand, which is what makes them a drift guard: a fixture refreshed against a newer filter disagrees with the port and names the block that moved. `src/test/fixtures/typstPreview/README.md` states the refresh procedure and pins the version, and the extension reports in the log when the installed version is above it.

The three block kinds now go through one entry point. A plain block and a raw block keep the preview's own theme header. A cell keeps the colour contract of `typst-render` instead: the filter writes the page fill and the text fill itself, and a second set of directives above them would show the wrong image. What the preview cannot reproduce about a block is one list, shown beside the image.

Two rules are easy to conflate and are kept apart. `preamble:` and `file:` resolve against the document directory, with a leading `/` meaning the project root. `root`, `font-path` and `package-path` are global only and reach no source at all.

A cell is never previewed with guessed options: when the project has not installed the extension, the panel says so. Plain and raw blocks are unaffected.

One deliberate deviation from the filter. It always defaults to the light brand mode; the preview follows the editor theme instead, so a dark editor shows a dark image. An explicit `brand-mode:` still wins, and the panel header names the mode a cell resolved with.

The `typst_define()` payload of the R and Python helpers is out of scope for the first version, because it lives in metadata Quarto's engine produces during a render.