### PR TITLE
feat: drive the Typst preview from one controller

### DIFF
--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -190,6 +190,25 @@ How long one Typst compile may run, in milliseconds. The default of 20000 covers
 }
 ```
 
+### Preview Debounce Delay
+
+**Setting**: `quartoWizard.typstPreview.debounceMs`
+
+How long the Typst block preview waits after an edit before it compiles again, in milliseconds. Raise it when a block is slow to compile and the preview gets in the way of typing. `0` compiles on every keystroke. Moving the cursor to another block is not an edit and always updates after 250 milliseconds, and saving the document compiles at once.
+
+| Property | Value  |
+| -------- | ------ |
+| Type     | Number |
+| Default  | `300`  |
+| Minimum  | `0`    |
+| Maximum  | `5000` |
+
+```json
+{
+  "quartoWizard.typstPreview.debounceMs": 300
+}
+```
+
 ## Workspace vs User Settings
 
 All Quarto Wizard settings are scoped to "resource", meaning they can be configured at:
@@ -215,6 +234,7 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.lint.unknownAttributes": false,
   "quartoWizard.typstPreview.foreground": "auto",
   "quartoWizard.typstPreview.background": "auto",
-  "quartoWizard.typstPreview.timeoutMs": 20000
+  "quartoWizard.typstPreview.timeoutMs": 20000,
+  "quartoWizard.typstPreview.debounceMs": 300
 }
 ```

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -45,6 +45,7 @@ See [Configuration Reference](configuration.qmd) for all available options.
 | `quartoWizard.typstPreview.foreground` | `auto`                                     | Text colour injected above a previewed block.         |
 | `quartoWizard.typstPreview.background` | `auto`                                     | Page colour injected above a previewed block.         |
 | `quartoWizard.typstPreview.timeoutMs`  | `20000`                                    | Time limit for one preview compile.                   |
+| `quartoWizard.typstPreview.debounceMs` | `300`                                      | Delay between an edit and the next preview compile.   |
 
 ## Extension Schema
 

--- a/package.json
+++ b/package.json
@@ -768,6 +768,17 @@
 					"markdownDescription": "How long one Typst compile may run, in milliseconds. The default of 20000 covers a first-use package download, which is by far the slowest compile a preview makes. Raise it on a slow connection, and lower it to fail faster when no package is ever downloaded.",
 					"title": "Preview Timeout",
 					"description": "Time limit for one preview compile."
+				},
+				"quartoWizard.typstPreview.debounceMs": {
+					"order": 23,
+					"scope": "resource",
+					"type": "number",
+					"minimum": 0,
+					"maximum": 5000,
+					"default": 300,
+					"markdownDescription": "How long the Typst block preview waits after an edit before it compiles again, in milliseconds. Raise it when a block is slow to compile and the preview gets in the way of typing. `0` compiles on every keystroke. Moving the cursor to another block is not an edit and always updates after 250 milliseconds, and saving the document compiles at once.",
+					"title": "Preview Debounce Delay",
+					"description": "Delay between an edit and the next preview compile."
 				}
 			}
 		}

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -54,10 +54,16 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			panel?.clear();
 			return;
 		}
-		const surface = usePanel();
+		// Only a request the user made opens a panel. An edit renders into the one
+		// already there, and never builds one, so a result that outlived the panel
+		// it was compiled for does not reopen it.
+		const surface = asked ? usePanel() : panel;
+		if (surface === undefined) {
+			return;
+		}
 		if (asked) {
-			// Only a request the user made brings the panel forward. Doing it on an
-			// edit would pull the tab back over whatever they moved to.
+			// The user asked, so the panel comes forward. Doing it on an edit would
+			// pull the tab back over whatever they moved to.
 			surface.reveal();
 		}
 		if (result.svg === undefined) {

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
-import { TypstPreviewController, type TypstPreviewResult } from "./typstPreviewController";
+import { TypstPreviewController, type TypstPreviewUpdate } from "./typstPreviewController";
 import { TypstPreviewPanel } from "./typstPreviewPanel";
 
 /**
@@ -47,15 +47,15 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	const controller = new TypstPreviewController({ hasSurface: () => panel !== undefined, show });
 	context.subscriptions.push(controller);
 
-	/** Render one result, opening the panel when there is none yet. */
-	const render = (result: TypstPreviewResult | undefined): void => {
+	/** Render one update, opening the panel when there is none yet. */
+	const render = ({ result, asked }: TypstPreviewUpdate): void => {
 		if (result === undefined) {
 			// The document went away, so there is no block left to describe.
 			panel?.clear();
 			return;
 		}
 		const surface = usePanel();
-		if (result.asked) {
+		if (asked) {
 			// Only a request the user made brings the panel forward. Doing it on an
 			// edit would pull the tab back over whatever they moved to.
 			surface.reveal();

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,208 +1,25 @@
 import * as vscode from "vscode";
-import * as path from "node:path";
-import { getErrorMessage } from "@quarto-wizard/core";
-import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
-import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
-import { buildCompileRequest, type CompileRequest } from "./typstContext";
-import { DEFAULT_TIMEOUT_MS, TypstCompiler, invalidateTypstBinary, resolveTypstBinary } from "./typstCompiler";
+import { TypstPreviewController, type TypstPreviewResult } from "./typstPreviewController";
 import { TypstPreviewPanel } from "./typstPreviewPanel";
-
-/** Read the source from stdin, write the image to stdout. */
-const ARGV = ["compile", "--format", "svg", "-", "-"];
-
-/** Where the lines of a compile live, so a diagnostic can be placed. */
-export interface ErrorPlace {
-	/** How many lines sit above the compiled code in the assembled source. */
-	injectedLines: number;
-	/** How many lines of the block body sit above the first compiled line. */
-	bodyLineOffset?: number;
-	/** The file whose contents were compiled instead of the block body. */
-	externalFile?: string;
-}
-
-/**
- * The active colour theme as the pure modules name it.
- *
- * Exported for its tests. `HighContrast` is the dark one and `HighContrastLight`
- * the light one, which is the pairing a mapping written from the names alone
- * gets wrong.
- */
-export function themeKindOf(kind: vscode.ColorThemeKind): TypstThemeKind {
-	switch (kind) {
-		case vscode.ColorThemeKind.Light:
-			return "light";
-		case vscode.ColorThemeKind.HighContrast:
-			return "high-contrast";
-		case vscode.ColorThemeKind.HighContrastLight:
-			return "high-contrast-light";
-		default:
-			return "dark";
-	}
-}
-
-/** What the settings say about previewing one document. */
-interface TypstPreviewSettings {
-	foreground: string;
-	background: string;
-	timeoutMs: number;
-}
-
-/** The bounds `package.json` declares, repeated here because it cannot enforce them. */
-const MIN_TIMEOUT_MS = 1000;
-const MAX_TIMEOUT_MS = 300000;
-
-/**
- * A usable colour setting, whatever the setting holds.
- *
- * Exported for its tests. `package.json` declares the type, and a hand-edited
- * `settings.json` ignores it, so a value that is not a string reaches the
- * header and is trimmed there.
- */
-export function previewColour(value: unknown): string {
-	// The header trims the value, so a value that is not a string throws where
-	// nothing catches it, and the panel opens and then stays empty.
-	return typeof value === "string" ? value : "auto";
-}
-
-/**
- * A usable compile timeout, whatever the setting holds.
- *
- * Exported for its tests. The bounds in `package.json` only guide the settings
- * user interface, so a hand-edited `settings.json` reaches `setTimeout`
- * unchecked, and `0` there fails every preview before Typst has read anything.
- */
-export function previewTimeoutMs(value: unknown): number {
-	if (typeof value !== "number" || !Number.isFinite(value)) {
-		return DEFAULT_TIMEOUT_MS;
-	}
-	return Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, value));
-}
-
-/**
- * The settings in force for one document.
- *
- * They are resource scoped, so a multi-root workspace can hold a different
- * answer per folder, and the document is what says which folder that is.
- */
-function previewSettings(document: vscode.TextDocument): TypstPreviewSettings {
-	const config = vscode.workspace.getConfiguration("quartoWizard.typstPreview", document.uri);
-	return {
-		foreground: previewColour(config.get("foreground")),
-		background: previewColour(config.get("background")),
-		timeoutMs: previewTimeoutMs(config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS)),
-	};
-}
-
-/** The text colour the settings and the active theme resolve to. */
-function resolvedForeground(document: vscode.TextDocument): string {
-	const settings = previewSettings(document);
-	return themeHeader(themeKindOf(vscode.window.activeColorTheme.kind), settings.foreground, settings.background)
-		.foreground;
-}
-
-/**
- * The one line a failure shows inside the panel.
- *
- * Exported for its tests. The choice of which diagnostic to show carries most
- * of the behaviour, and it is not reachable through the command.
- */
-export function errorText(stderr: string, place: ErrorPlace): string {
-	const diagnostics = parseTypstStderr(stderr, place.injectedLines);
-	// A warning can sit above the error that stopped the compile, so the first
-	// diagnostic is not the one to show. Headlining a failure as a warning
-	// misstates why there is no image.
-	//
-	// Among the errors it is the first that is shown, which is the earliest in
-	// the compiled source. A block compiled under a broken one reports errors of
-	// its own, and those are consequences: showing one of them would send the
-	// reader to a line that is only wrong because the source above it is.
-	const mapped = diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
-	if (mapped) {
-		if (mapped.aboveBody) {
-			// A raw block compiles under every raw block before it, so the failure
-			// can belong to one of those. There is no line of this block to name,
-			// but saying nothing about where it is would leave the reader looking
-			// at a block that compiles.
-			return `${mapped.severity} above this block: ${mapped.message}`;
-		}
-		if (mapped.line === undefined) {
-			// A package that would not download, or an input Typst could not read.
-			// Naming a position here would point at a character that has nothing to
-			// do with the failure.
-			return `${mapped.severity}: ${mapped.message}`;
-		}
-		const column = (mapped.column ?? 0) + 1;
-		if (place.externalFile !== undefined) {
-			// The body was replaced by that file, so no line of the block corresponds
-			// to the failure at all. Naming the block would send the reader to a line
-			// that has nothing to do with it.
-			return `${mapped.severity} at line ${mapped.line + 1}, column ${column} of ${place.externalFile}: ${mapped.message}`;
-		}
-		// The line is counted inside the block, while the panel header counts
-		// document lines, so it says which of the two it means. A cell compiles its
-		// code and not its body, so the leading option run is added back: without it
-		// every position in a cell with options is short by the length of that run.
-		const line = mapped.line + (place.bodyLineOffset ?? 0) + 1;
-		return `${mapped.severity} at line ${line}, column ${column} of the block: ${mapped.message}`;
-	}
-
-	// Nothing mapped, which means every diagnostic pointed at another file, such
-	// as an imported one. There is no position to show, but there is still a
-	// message, and reporting none would contradict the missing image.
-	const messages = typstMessages(stderr);
-	const outside = messages.find((message) => message.severity === "error") ?? messages[0];
-	return outside === undefined
-		? "Typst produced no image and reported nothing."
-		: `${outside.severity} outside this block: ${outside.message}`;
-}
-
-/** What the panel shows about the block it is displaying. */
-function headerText(document: vscode.TextDocument, request: CompileRequest): string {
-	const parts = [`${path.basename(document.fileName)} · line ${request.block.fenceLine + 1}`];
-	if (request.brandMode !== undefined) {
-		// A cell resolves its `auto` colours against one side of the brand, and
-		// which side it took is not visible in the image when the two are close.
-		parts.push(`${request.brandMode} brand`);
-	}
-	// Everything the preview does not reproduce about this block. Saying so beside
-	// the image is what stops a divergence being read as a defect.
-	parts.push(...request.notes);
-	return parts.join(" · ");
-}
 
 /**
  * Register the Typst block preview.
  *
- * The feature is inert unless the workspace is trusted and Quarto ships a Typst
- * binary. Neither condition is worth a prompt: the extension does many other
- * things, and a user who never writes a Typst block should never hear about it.
+ * The controller owns the state and every event, and this owns the one surface
+ * that renders it. The feature is inert unless the workspace is trusted and
+ * Quarto ships a Typst binary. Neither condition is worth a prompt: the
+ * extension does many other things, and a user who never writes a Typst block
+ * should never hear about it.
  */
 export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	let panel: TypstPreviewPanel | undefined;
-	let compiler: TypstCompiler | undefined;
-	// The compiler reads its timeout once, and the setting is resource scoped, so
-	// the value it was built with is kept to know when it no longer applies.
-	let compilerTimeoutMs: number | undefined;
-	// The colour the image on screen was compiled with, so a theme change can
-	// tell a new colour from a theme that resolves to the same one.
-	let shownForeground: string | undefined;
-	// One message per session, so a machine that cannot run the preview at all
-	// does not report the same thing on every request.
-	let reportedUnavailable = false;
-	// The compiler supersedes its own running child, so the caller has nothing to
-	// cancel. This source is never cancelled, and exists only because `compile`
-	// takes a token and the API has no ready-made one that never fires.
-	const uncancelled = new vscode.CancellationTokenSource();
-	context.subscriptions.push(uncancelled);
 
 	/** Keep a panel, and forget it when the user closes it. */
 	const holdPanel = (held: TypstPreviewPanel): TypstPreviewPanel => {
 		panel = held;
 		held.onDidDispose(() => {
 			panel = undefined;
-			// There is no image on screen any more, so no colour describes one.
-			shownForeground = undefined;
 		});
 		return held;
 	};
@@ -210,29 +27,13 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	const usePanel = (): TypstPreviewPanel => panel ?? holdPanel(TypstPreviewPanel.create(context.extensionUri));
 
 	/**
-	 * The compiler for these settings.
-	 *
-	 * The timeout is read once at construction and the setting is resource
-	 * scoped, so the compiler is replaced when the value it was built with no
-	 * longer applies. Nothing is lost by replacing it mid-run, because the next
-	 * compile supersedes whatever is running anyway.
-	 */
-	const useCompiler = (binary: string, timeoutMs: number): TypstCompiler => {
-		if (compiler === undefined || compilerTimeoutMs !== timeoutMs) {
-			compiler?.dispose();
-			compiler = new TypstCompiler(binary, { timeoutMs });
-			compilerTimeoutMs = timeoutMs;
-		}
-		return compiler;
-	};
-
-	/**
 	 * Put a message in front of the reader.
 	 *
 	 * An open panel takes the message itself, which is both quieter and closer to
 	 * the thing the reader is looking at than a notification would be. It is
 	 * revealed as well: a message written into a background tab is a command that
-	 * appears to do nothing.
+	 * appears to do nothing. With no panel open there is nothing to write into,
+	 * and a notification is the only place left.
 	 */
 	const show = (message: string): void => {
 		if (panel) {
@@ -243,153 +44,65 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		void showMessageWithLogs(message, "warning");
 	};
 
-	/** Say why there is nothing to show. */
-	const report = (message: string): void => {
-		logMessage(`Typst preview: ${message}`, "debug");
-		show(message);
-	};
+	const controller = new TypstPreviewController({ hasSurface: () => panel !== undefined, show });
+	context.subscriptions.push(controller);
 
-	/**
-	 * Say once that the feature cannot run here at all.
-	 *
-	 * The log line is not part of what is said once. The binary probe caches its
-	 * result and logs only on the first attempt, so without this every later
-	 * attempt on an unavailable machine would leave no trace at all, and the log
-	 * would stop being enough to diagnose an inert preview.
-	 */
-	const reportUnavailable = (message: string): void => {
-		logMessage(`Typst preview: ${message}`, "debug");
-		if (reportedUnavailable) {
+	/** Render one result, opening the panel when there is none yet. */
+	const render = (result: TypstPreviewResult | undefined): void => {
+		if (result === undefined) {
+			// The document went away, so there is no block left to describe.
+			panel?.clear();
 			return;
 		}
-		reportedUnavailable = true;
-		show(message);
-	};
-
-	/**
-	 * Compile the block under the cursor into the panel.
-	 *
-	 * @param asked - Whether the user asked for this. A restore did not, and at
-	 *   that moment the editors are often not back yet, so saying that no block
-	 *   is under the cursor would be an error message on most window reloads.
-	 */
-	const preview = async (asked: boolean): Promise<void> => {
-		const explain = (message: string): void => {
-			if (asked) {
-				report(message);
-			}
-		};
-
-		if (!vscode.workspace.isTrusted) {
-			reportUnavailable("The Typst preview needs a trusted workspace, because it runs the Typst compiler.");
-			return;
-		}
-
-		const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			explain("Open a Quarto document to preview a Typst block.");
-			return;
-		}
-
-		const document = editor.document;
-		const settings = previewSettings(document);
-		// The header applies to a plain block and a raw block. A cell keeps the
-		// colour contract of the filter instead, and drops it.
-		const { header, foreground } = themeHeader(
-			themeKindOf(vscode.window.activeColorTheme.kind),
-			settings.foreground,
-			settings.background,
-		);
-		const request = await buildCompileRequest(document, editor.selection.active, header);
-		if (isUnavailable(request)) {
-			explain(request.unavailable);
-			return;
-		}
-
-		const binary = await resolveTypstBinary();
-		if (binary === undefined) {
-			reportUnavailable("The Typst preview needs the Typst binary that ships inside Quarto, and it was not found.");
-			return;
-		}
-
 		const surface = usePanel();
-		surface.reveal();
-
-		try {
-			const result = await useCompiler(binary, settings.timeoutMs).compile(request.source, ARGV, uncancelled.token);
-			if (result.svg === undefined) {
-				logMessage(`Typst preview: the compiler reported:\n${result.stderr}`, "debug");
-				surface.showError(errorText(result.stderr, request));
-				return;
-			}
-			if (result.stderr.length > 0) {
-				logMessage(`Typst preview: the compiler warned:\n${result.stderr}`, "debug");
-			}
-			// Recorded here and nowhere else. A failed compile leaves the last good
-			// image on screen, so the colour that image was compiled with is still
-			// the colour the reader is looking at.
-			shownForeground = foreground;
-			surface.show(result.svg, headerText(document, request));
-		} catch (error) {
-			if (error instanceof vscode.CancellationError) {
-				return;
-			}
-			const message = getErrorMessage(error);
-			logMessage(`Typst preview: ${message}`, "error");
-			surface.showError(message);
+		if (result.asked) {
+			// Only a request the user made brings the panel forward. Doing it on an
+			// edit would pull the tab back over whatever they moved to.
+			surface.reveal();
+		}
+		if (result.svg === undefined) {
+			surface.clear();
+		} else {
+			surface.show(result.svg, result.header);
+		}
+		if (result.error !== undefined) {
+			// Posted after the image, so it lands on top of it rather than underneath.
+			surface.showError(result.error);
 		}
 	};
 
-	context.subscriptions.push(vscode.commands.registerCommand("quartoWizard.previewTypstBlock", () => preview(true)));
+	context.subscriptions.push(controller.onDidChangeResult(render));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("quartoWizard.previewTypstBlock", () => {
+			const editor = vscode.window.activeTextEditor;
+			if (editor === undefined) {
+				show("Open a Quarto document to preview a Typst block.");
+				return;
+			}
+			controller.request(editor.document, editor.selection.active);
+		}),
+	);
 
 	// A window reload restores the panel. Recompile into it rather than restoring
 	// a serialised image, which would be stale the moment the document changed.
+	// The restore is not something the user asked for, and at that moment the
+	// editors are often not back yet, so a missing block says nothing.
 	context.subscriptions.push(
 		vscode.window.registerWebviewPanelSerializer(TypstPreviewPanel.viewType, {
-			deserializeWebviewPanel: async (restored: vscode.WebviewPanel) => {
+			deserializeWebviewPanel: (restored: vscode.WebviewPanel) => {
 				if (panel) {
 					restored.dispose();
-					return;
+					return Promise.resolve();
 				}
 				holdPanel(new TypstPreviewPanel(restored, context.extensionUri));
-				await preview(false);
+				controller.refresh();
+				return Promise.resolve();
 			},
 		}),
 	);
 
-	// The text colour is derived from the theme kind and baked into the image, so
-	// a theme change leaves the panel showing the wrong one. The panel background
-	// is a CSS variable and needs no help, and two themes of the same kind
-	// resolve to the same colour, so only a colour that actually changed is worth
-	// a compile.
-	context.subscriptions.push(
-		vscode.window.onDidChangeActiveColorTheme(() => {
-			const editor = vscode.window.activeTextEditor;
-			if (panel === undefined || editor === undefined || resolvedForeground(editor.document) === shownForeground) {
-				return;
-			}
-			void preview(false);
-		}),
-	);
-
-	// Installing or removing the Quarto extension changes where the binary is, or
-	// whether there is one at all.
-	context.subscriptions.push(
-		vscode.extensions.onDidChange(() => {
-			invalidateTypstBinary();
-			compiler?.dispose();
-			compiler = undefined;
-			compilerTimeoutMs = undefined;
-			reportedUnavailable = false;
-		}),
-	);
-
-	context.subscriptions.push({
-		dispose: () => {
-			compiler?.dispose();
-			panel?.dispose();
-		},
-	});
+	context.subscriptions.push({ dispose: () => panel?.dispose() });
 
 	logMessage("Typst preview registered.", "debug");
 }

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -9,6 +9,7 @@ import {
 	type Unavailable,
 } from "../../utils/typst/typstSource";
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
+import { EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
 import { getInstalledExtensionsCached } from "../../utils/installedExtensionsCache";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
 import { logMessage } from "../../utils/log";
@@ -41,6 +42,14 @@ const TYPST_RENDER_OWNER = "mcanouil";
 export interface CompileRequest {
 	/** The block under the cursor. */
 	block: TypstBlock;
+	/**
+	 * Where the block sits in the document, counted from the top.
+	 *
+	 * This is the identity of the block across an edit. Every offset it carries
+	 * moves when the text above it changes, so two requests for the same block
+	 * agree on nothing else.
+	 */
+	blockIndex: number;
 	/** The whole source to send to the compiler. */
 	source: string;
 	/** How many lines sit above the block body, for mapping a diagnostic back. */
@@ -127,6 +136,103 @@ function reportDrift(version: string | undefined): void {
 	);
 }
 
+/** Everything a cell reads from disk, which no document version predicts. */
+export interface CellContext {
+	/** The installed `typst-render`, absent when the project has none. */
+	installed?: { version?: string };
+	/** The metadata the document compiles under. */
+	chain: MetadataChain;
+	/** The brand the document resolves its `auto` colours against. */
+	brand: Brand;
+}
+
+/**
+ * The disk half of one cell, read together so a caller can cache it whole.
+ *
+ * The gate comes before the metadata chain, because it needs only the project
+ * root and it rejects every cell in a project that never installed the
+ * extension. Reading the chain first would spend the whole directory walk to
+ * say no.
+ */
+export async function readCellContext(document: vscode.TextDocument, text: string): Promise<CellContext> {
+	const projectRoot = await findOwningProjectRoot(document.uri);
+	const installed = await installedTypstRender(projectRoot);
+	if (installed === undefined) {
+		return { chain: { levels: [], metadata: {} }, brand: EMPTY_BRAND };
+	}
+	const chain = await readMetadataChain(document, text, projectRoot);
+	return { installed, chain, brand: await readBrand(chain) };
+}
+
+/**
+ * What a request would otherwise read again on every keystroke.
+ *
+ * The blocks of a document are a function of its text alone, so its version is
+ * the whole key. What a cell reads from disk is not a function of the document
+ * at all: the version says when the document moved, and a watcher says when the
+ * disk did, so the two halves are forgotten by different events.
+ */
+export class TypstContextCache {
+	private readonly blocks = new Map<string, { version: number; blocks: TypstBlock[] }>();
+	private readonly cells = new Map<string, { version: number; context: Promise<CellContext> }>();
+
+	/** The blocks of one document version. */
+	blocksOf(document: vscode.TextDocument, text: string): TypstBlock[] {
+		const key = document.uri.toString();
+		const held = this.blocks.get(key);
+		if (held?.version === document.version) {
+			return held.blocks;
+		}
+		const blocks = findTypstBlocks(text);
+		this.blocks.set(key, { version: document.version, blocks });
+		return blocks;
+	}
+
+	/** What one document version's cells read from disk. */
+	cellContext(document: vscode.TextDocument, text: string): Promise<CellContext> {
+		const key = document.uri.toString();
+		const held = this.cells.get(key);
+		if (held?.version === document.version) {
+			return held.context;
+		}
+		// The promise is held and not its value, so two requests arriving inside one
+		// directory walk share it rather than walking twice. A rejected read is
+		// forgotten, or one unreadable file would answer every later request.
+		const context = readCellContext(document, text).catch((error: unknown) => {
+			if (this.cells.get(key)?.context === context) {
+				this.cells.delete(key);
+			}
+			throw error;
+		});
+		this.cells.set(key, { version: document.version, context });
+		return context;
+	}
+
+	/** Forget one document, which a closed document no longer needs. */
+	forget(uri: vscode.Uri): void {
+		const key = uri.toString();
+		this.blocks.delete(key);
+		this.cells.delete(key);
+	}
+
+	/**
+	 * Forget everything read from disk.
+	 *
+	 * Every document is forgotten and not only the one under the changed file. A
+	 * `_metadata.yml` reaches every document below it and a `.typ` reaches every
+	 * document that names it, so working out which entries a change reaches costs
+	 * more than the one directory walk that rebuilds them.
+	 */
+	forgetFiles(): void {
+		this.cells.clear();
+	}
+
+	clear(): void {
+		this.blocks.clear();
+		this.cells.clear();
+	}
+}
+
 /**
  * The compile one block asks for.
  *
@@ -135,21 +241,27 @@ function reportDrift(version: string | undefined): void {
  * the filter writes the page fill and the text fill itself, from the options in
  * force, and a second set of directives above them would show an image the
  * render does not produce.
+ *
+ * @param cache - What a caller repeating the request remembers. A caller with
+ *   no cache reads the document and the disk again, which is what a one-off
+ *   request wants.
  */
 export async function buildCompileRequest(
 	document: vscode.TextDocument,
 	position: vscode.Position,
 	header: string,
+	cache?: TypstContextCache,
 ): Promise<CompileRequest | Unavailable> {
 	const text = document.getText();
 	// The whole list is kept, because a raw block compiles with the raw blocks
 	// above it and scanning the document a second time would say the same thing
 	// twice.
-	const blocks = findTypstBlocks(text);
+	const blocks = cache === undefined ? findTypstBlocks(text) : cache.blocksOf(document, text);
 	const block = blockAtOffset(blocks, document.offsetAt(position));
 	if (block === undefined) {
 		return { unavailable: "Put the cursor inside a Typst block to preview it." };
 	}
+	const blockIndex = blocks.indexOf(block);
 
 	if (block.kind !== "cell") {
 		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
@@ -157,14 +269,11 @@ export async function buildCompileRequest(
 		// imports, show rules and set directives the preview cannot apply. Saying so
 		// beside the image is what stops a divergence being read as a defect.
 		const notes = block.kind === "raw" ? ["the document template is not applied to a raw passthrough"] : [];
-		return { block, ...assembled, notes, bodyLineOffset: 0 };
+		return { block, blockIndex, ...assembled, notes, bodyLineOffset: 0 };
 	}
 
-	// The gate comes before the metadata chain, because it needs only the project
-	// root and it rejects every cell in a project that never installed the
-	// extension. Reading the chain first would spend the whole walk to say no.
-	const projectRoot = await findOwningProjectRoot(document.uri);
-	const installed = await installedTypstRender(projectRoot);
+	const { installed, chain, brand } =
+		cache === undefined ? await readCellContext(document, text) : await cache.cellContext(document, text);
 	if (installed === undefined) {
 		// Never previewed with guessed options. A cell compiled without the
 		// extension's own defaults would show an image the render does not
@@ -175,8 +284,6 @@ export async function buildCompileRequest(
 	}
 	reportDrift(installed.version);
 
-	const chain = await readMetadataChain(document, text, projectRoot);
-	const brand = await readBrand(chain);
 	// The one deliberate deviation from the filter. It always defaults to light,
 	// and the preview follows the editor theme instead, so a dark editor shows a
 	// dark image. An explicit `brand-mode:` still wins.
@@ -192,7 +299,7 @@ export async function buildCompileRequest(
 		return built;
 	}
 
-	return { block, ...built, brandMode };
+	return { block, blockIndex, ...built, brandMode };
 }
 
 /**

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -11,6 +11,7 @@ import {
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
 import { EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
 import { getInstalledExtensionsCached } from "../../utils/installedExtensionsCache";
+import { getYamlFrontMatterRange } from "../../utils/yamlPosition";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
 import { logMessage } from "../../utils/log";
 import { readBrand, readMetadataChain, readSourceText, resolveQuartoPath, type MetadataChain } from "./typstMetadata";
@@ -165,16 +166,28 @@ export async function readCellContext(document: vscode.TextDocument, text: strin
 }
 
 /**
+ * The front matter of a document, which is all the metadata chain reads of it.
+ *
+ * Everything else in the text reaches the chain through nothing at all, so two
+ * versions of a document that share this share their whole metadata.
+ */
+function frontMatterText(text: string): string {
+	const range = getYamlFrontMatterRange(text);
+	return range === undefined ? "" : text.slice(range.start, range.end);
+}
+
+/**
  * What a request would otherwise read again on every keystroke.
  *
- * The blocks of a document are a function of its text alone, so its version is
- * the whole key. What a cell reads from disk is not a function of the document
- * at all: the version says when the document moved, and a watcher says when the
- * disk did, so the two halves are forgotten by different events.
+ * The two halves are keyed differently because they depend on different things.
+ * The blocks are a function of the whole text, so the document version is the
+ * whole key. The metadata chain reads the front matter and then the disk, so it
+ * survives every edit that leaves the front matter alone, and a watcher is what
+ * forgets it when the disk moves.
  */
 export class TypstContextCache {
 	private readonly blocks = new Map<string, { version: number; blocks: TypstBlock[] }>();
-	private readonly cells = new Map<string, { version: number; context: Promise<CellContext> }>();
+	private readonly cells = new Map<string, { frontMatter: string; context: Promise<CellContext> }>();
 
 	/** The blocks of one document version. */
 	blocksOf(document: vscode.TextDocument, text: string): TypstBlock[] {
@@ -188,11 +201,12 @@ export class TypstContextCache {
 		return blocks;
 	}
 
-	/** What one document version's cells read from disk. */
+	/** What one document's cells read from disk. */
 	cellContext(document: vscode.TextDocument, text: string): Promise<CellContext> {
 		const key = document.uri.toString();
+		const frontMatter = frontMatterText(text);
 		const held = this.cells.get(key);
-		if (held?.version === document.version) {
+		if (held?.frontMatter === frontMatter) {
 			return held.context;
 		}
 		// The promise is held and not its value, so two requests arriving inside one
@@ -204,7 +218,7 @@ export class TypstContextCache {
 			}
 			throw error;
 		});
-		this.cells.set(key, { version: document.version, context });
+		this.cells.set(key, { frontMatter, context });
 		return context;
 	}
 
@@ -242,21 +256,20 @@ export class TypstContextCache {
  * force, and a second set of directives above them would show an image the
  * render does not produce.
  *
- * @param cache - What a caller repeating the request remembers. A caller with
- *   no cache reads the document and the disk again, which is what a one-off
- *   request wants.
+ * @param cache - What a caller repeating the request remembers. A caller that
+ *   asks once builds an empty one, which reads the document and the disk.
  */
 export async function buildCompileRequest(
 	document: vscode.TextDocument,
 	position: vscode.Position,
 	header: string,
-	cache?: TypstContextCache,
+	cache: TypstContextCache,
 ): Promise<CompileRequest | Unavailable> {
 	const text = document.getText();
 	// The whole list is kept, because a raw block compiles with the raw blocks
 	// above it and scanning the document a second time would say the same thing
 	// twice.
-	const blocks = cache === undefined ? findTypstBlocks(text) : cache.blocksOf(document, text);
+	const blocks = cache.blocksOf(document, text);
 	const block = blockAtOffset(blocks, document.offsetAt(position));
 	if (block === undefined) {
 		return { unavailable: "Put the cursor inside a Typst block to preview it." };
@@ -272,8 +285,7 @@ export async function buildCompileRequest(
 		return { block, blockIndex, ...assembled, notes, bodyLineOffset: 0 };
 	}
 
-	const { installed, chain, brand } =
-		cache === undefined ? await readCellContext(document, text) : await cache.cellContext(document, text);
+	const { installed, chain, brand } = await cache.cellContext(document, text);
 	if (installed === undefined) {
 		// Never previewed with guessed options. A cell compiled without the
 		// extension's own defaults would show an image the render does not

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -46,9 +46,15 @@ export interface CompileRequest {
 	/**
 	 * Where the block sits in the document, counted from the top.
 	 *
-	 * This is the identity of the block across an edit. Every offset it carries
-	 * moves when the text above it changes, so two requests for the same block
-	 * agree on nothing else.
+	 * This is how two requests agree that they mean the same block. Every offset
+	 * a block carries moves when the text above it changes, and the place in the
+	 * order does not, so the offsets cannot answer that question.
+	 *
+	 * It is not an identity that survives everything: adding or removing a block
+	 * above this one shifts it, and until the cursor moves again a recompile can
+	 * take its neighbour. The window is narrow, because adding a block above is
+	 * itself an edit at a place the cursor is at, and the cursor moving is what
+	 * resolves the block again.
 	 */
 	blockIndex: number;
 	/** The whole source to send to the compiler. */

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -358,6 +358,8 @@ export class TypstPreviewController implements vscode.Disposable {
 	private readonly selectionDebounce: DebouncedFunction<() => void>;
 	private readonly contextDebounce: DebouncedFunction<() => void>;
 	private documentDebounce: DebouncedFunction<() => void> | undefined;
+	/** The delay the document debouncer was built with, which the setting can move. */
+	private documentDelayMs: number | undefined;
 	private compiler: TypstCompilerLike | undefined;
 	/** What the compiler was built for, so it is replaced when that changes. */
 	private compilerKey: string | undefined;
@@ -391,7 +393,7 @@ export class TypstPreviewController implements vscode.Disposable {
 
 	/** Preview the block under a position, because the user asked for it. */
 	request(document: vscode.TextDocument, position: vscode.Position): void {
-		void this.run(document, position, true);
+		this.start(document, position, true);
 	}
 
 	/** Preview the block under the cursor again, because something changed. */
@@ -400,7 +402,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		if (editor === undefined || !isRelevantDocument(editor.document)) {
 			return;
 		}
-		void this.run(editor.document, editor.selection.active, false);
+		this.start(editor.document, editor.selection.active, false);
 	}
 
 	/**
@@ -427,7 +429,25 @@ export class TypstPreviewController implements vscode.Disposable {
 		if (block === undefined) {
 			return;
 		}
-		void this.run(document, document.positionAt(block.fenceStart), false);
+		this.start(document, document.positionAt(block.fenceStart), false);
+	}
+
+	/**
+	 * Start one preview, and let nothing it does escape as a rejection.
+	 *
+	 * No caller awaits a preview, so a throw on the way to the compiler would be
+	 * an unhandled rejection: no log line, no message, and a preview that looks
+	 * inert. A metadata file or a brand file that cannot be read is exactly that
+	 * case, because the context cache rethrows rather than remembering a failure.
+	 */
+	private start(document: vscode.TextDocument, position: vscode.Position, asked: boolean): void {
+		void this.run(document, position, asked).catch((error: unknown) => {
+			const message = getErrorMessage(error);
+			logMessage(`Typst preview: ${message}`, "error");
+			if (asked) {
+				this.options.show(message);
+			}
+		});
 	}
 
 	dispose(): void {
@@ -469,6 +489,12 @@ export class TypstPreviewController implements vscode.Disposable {
 			this.reportUnavailable("The Typst preview needs a trusted workspace, because it runs the Typst compiler.");
 			return;
 		}
+
+		// Raised by the first request and not by the first result. A cell in a
+		// project that has not installed the extension never produces a result, and
+		// the manifest watcher is what lets it start working once the extension is
+		// installed, so waiting for a result would keep that case broken for good.
+		this.watchFiles();
 
 		const settings = previewSettings(document);
 		// The header applies to a plain block and a raw block. A cell keeps the
@@ -549,6 +575,13 @@ export class TypstPreviewController implements vscode.Disposable {
 		asked: boolean,
 		failure?: string,
 	): void {
+		if (!asked && !this.options.hasSurface()) {
+			// A compile runs for up to the timeout and the reader can close the last
+			// surface meanwhile. The result is nobody's, and publishing it would have
+			// a surface build itself to render it, which reopens what was just closed.
+			return;
+		}
+
 		if (compiled.svg === undefined) {
 			if (failure === undefined) {
 				logMessage(`Typst preview: the compiler reported:\n${compiled.stderr}`, "debug");
@@ -572,7 +605,6 @@ export class TypstPreviewController implements vscode.Disposable {
 			header: headerText(document, request),
 			error: compiled.svg === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};
-		this.watchFiles();
 		this.resultEmitter.fire({ result: this.result, asked });
 	}
 
@@ -656,11 +688,15 @@ export class TypstPreviewController implements vscode.Disposable {
 
 	/** Rebuild the preview after an edit, at the delay the settings ask for. */
 	private scheduleDocument(document: vscode.TextDocument): void {
-		// The delay is fixed when a debouncer is built, so it is read once and kept
-		// rather than on every keystroke. A configuration change forgets it, which
-		// is the only event that can move it.
-		if (this.documentDebounce === undefined) {
-			this.documentDebounce = debounce(() => this.refresh(), documentDelayOf(document));
+		// The delay is fixed when a debouncer is built and the setting is resource
+		// scoped, so the debouncer is rebuilt when the document being edited asks
+		// for a different one. A multi-root workspace can hold one delay per folder,
+		// and keeping the first would give the second folder the wrong one.
+		const delayMs = documentDelayOf(document);
+		if (this.documentDebounce === undefined || this.documentDelayMs !== delayMs) {
+			this.documentDebounce?.cancel();
+			this.documentDelayMs = delayMs;
+			this.documentDebounce = debounce(() => this.refresh(), delayMs);
 		}
 		this.documentDebounce();
 	}
@@ -669,6 +705,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	private forgetDocumentDelay(): void {
 		this.documentDebounce?.cancel();
 		this.documentDebounce = undefined;
+		this.documentDelayMs = undefined;
 	}
 
 	private wireEvents(): void {

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -7,8 +7,16 @@ import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnost
 import { debounce, type DebouncedFunction } from "../../utils/debounce";
 import { generateHashKey } from "../../utils/hash";
 import { logMessage } from "../../utils/log";
+import { isQmdFile } from "../../utils/metadataFilesRegistry";
+import { EXTENSION_MANIFEST_GLOB } from "../../utils/quartoProjectDiscovery";
 import { buildCompileRequest, TypstContextCache, type CompileRequest } from "./typstContext";
-import { DEFAULT_TIMEOUT_MS, TypstCompiler, resolveTypstBinary, type TypstCompileResult } from "./typstCompiler";
+import {
+	DEFAULT_TIMEOUT_MS,
+	TypstCompiler,
+	invalidateTypstBinary,
+	resolveTypstBinary,
+	type TypstCompileResult,
+} from "./typstCompiler";
 
 /**
  * The one owner of the preview state.
@@ -37,9 +45,18 @@ const CONTEXT_DEBOUNCE_MS = 300;
  *
  * Enough to hold every block of a document under an edit and its undo history,
  * and small enough that a session of many documents does not grow without
- * bound. An entry is one image, which is tens of kilobytes.
+ * bound.
  */
 const CACHE_LIMIT = 32;
+
+/**
+ * How many bytes of image the remembered results may hold together.
+ *
+ * The count alone is not a bound. One compile may produce up to the compiler's
+ * own output limit, which is measured in megabytes, so a cache of a few dense
+ * pages would hold far more of the extension host than the count suggests.
+ */
+const CACHE_LIMIT_BYTES = 16 * 1024 * 1024;
 
 /** The bounds `package.json` declares, repeated here because it cannot enforce them. */
 const MIN_TIMEOUT_MS = 1000;
@@ -60,6 +77,20 @@ export interface ErrorPlace {
 	externalFile?: string;
 }
 
+/**
+ * One change of the preview, as the surfaces hear about it.
+ *
+ * `asked` describes the request and not the block, so it is not part of the
+ * result: a surface reading `current()` later would find it describing a
+ * request that is long over.
+ */
+export interface TypstPreviewUpdate {
+	/** What is being previewed, absent when there is nothing any more. */
+	result?: TypstPreviewResult;
+	/** Whether the user asked for this, rather than an edit driving it. */
+	asked: boolean;
+}
+
 /** What a surface needs to render the current preview. */
 export interface TypstPreviewResult {
 	/** The document the block belongs to. */
@@ -74,8 +105,6 @@ export interface TypstPreviewResult {
 	header: string;
 	/** The one line a failure shows, absent when the compile produced an image. */
 	error?: string;
-	/** Whether the user asked for this preview, rather than an edit driving it. */
-	asked: boolean;
 }
 
 /** What the controller needs of a compiler, which is what makes it stubbable. */
@@ -102,12 +131,11 @@ export interface TypstPreviewControllerOptions {
 	createCompiler?: (binary: string, timeoutMs: number) => TypstCompilerLike;
 }
 
-/** What the settings say about previewing one document. */
+/** What the settings say about compiling one document. */
 interface TypstPreviewSettings {
 	foreground: string;
 	background: string;
 	timeoutMs: number;
-	debounceMs: number;
 }
 
 /**
@@ -185,8 +213,13 @@ function previewSettings(document: vscode.TextDocument): TypstPreviewSettings {
 		foreground: previewColour(config.get("foreground")),
 		background: previewColour(config.get("background")),
 		timeoutMs: previewTimeoutMs(config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS)),
-		debounceMs: previewDebounceMs(config.get<number>("debounceMs", DEFAULT_DEBOUNCE_MS)),
 	};
+}
+
+/** How long an edit waits before the preview follows it. */
+function documentDelayOf(document: vscode.TextDocument): number {
+	const config = vscode.workspace.getConfiguration("quartoWizard.typstPreview", document.uri);
+	return previewDebounceMs(config.get<number>("debounceMs", DEFAULT_DEBOUNCE_MS));
 }
 
 /**
@@ -261,20 +294,37 @@ export function headerText(document: vscode.TextDocument, request: CompileReques
 
 /** Whether a document is one this feature previews at all. */
 function isRelevantDocument(document: vscode.TextDocument): boolean {
-	return document.languageId === "quarto" || document.fileName.endsWith(".qmd");
+	return document.languageId === "quarto" || isQmdFile(document.fileName);
 }
+
+/**
+ * The metadata files a preview reads beside the block.
+ *
+ * `_quarto` and `_metadata` are the chain, and `_brand` is where an `auto`
+ * colour resolves from. The glob and the name test below are both built from
+ * this, because two hand-kept lists of one set drift apart in silence.
+ */
+const CONTEXT_FILE_NAMES = ["quarto", "metadata", "brand"] as const;
+
+/** Every metadata file of the chain, at any depth, including `_brand/_brand.yml`. */
+const CONTEXT_FILE_GLOB = `**/_{${CONTEXT_FILE_NAMES.join(",")}}.{yml,yaml}`;
+
+/** A `preamble:` or a `file:`, which a cell compiles in place of its own body. */
+const TYPST_FILE_GLOB = "**/*.typ";
 
 /**
  * Whether a document is one a preview reads beside the block.
  *
- * These are the files the metadata chain, the brand and a `preamble:` come
- * from. An unsaved edit to one of them drives the preview the way an unsaved
- * edit to the document itself already does, because the chain prefers the copy
- * open in the editor.
+ * An unsaved edit to one of these drives the preview the way an unsaved edit to
+ * the document itself already does, because the chain prefers the copy open in
+ * the editor. An extension manifest is not among them: nothing reads one from
+ * the editor, so the watcher over the installed manifests is what covers it.
  */
 function isContextDocument(document: vscode.TextDocument): boolean {
-	const name = path.basename(document.fileName);
-	return /^_(quarto|metadata|brand)\.ya?ml$/.test(name) || name.endsWith(".typ") || /^_extension\.ya?ml$/.test(name);
+	const name = path.basename(document.fileName).toLowerCase();
+	return (
+		CONTEXT_FILE_NAMES.some((stem) => name === `_${stem}.yml` || name === `_${stem}.yaml`) || name.endsWith(".typ")
+	);
 }
 
 /**
@@ -287,7 +337,7 @@ function isContextDocument(document: vscode.TextDocument): boolean {
 export class TypstPreviewController implements vscode.Disposable {
 	private readonly disposables: vscode.Disposable[] = [];
 	private readonly contexts = new TypstContextCache();
-	private readonly resultEmitter = new vscode.EventEmitter<TypstPreviewResult | undefined>();
+	private readonly resultEmitter = new vscode.EventEmitter<TypstPreviewUpdate>();
 	/**
 	 * The compiled results, most recently used last.
 	 *
@@ -308,10 +358,13 @@ export class TypstPreviewController implements vscode.Disposable {
 	private readonly selectionDebounce: DebouncedFunction<() => void>;
 	private readonly contextDebounce: DebouncedFunction<() => void>;
 	private documentDebounce: DebouncedFunction<() => void> | undefined;
-	private documentDelayMs: number | undefined;
 	private compiler: TypstCompilerLike | undefined;
-	private compilerBinary: string | undefined;
-	private compilerTimeoutMs: number | undefined;
+	/** What the compiler was built for, so it is replaced when that changes. */
+	private compilerKey: string | undefined;
+	/** How many bytes of image the cache is holding. */
+	private cacheBytes = 0;
+	/** Whether the file watchers are up, which the first published result raises. */
+	private watching = false;
 	/** Rises with every request, so a result that arrives out of order is dropped. */
 	private requestVersion = 0;
 	private result: TypstPreviewResult | undefined;
@@ -319,7 +372,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	private reportedUnavailable = false;
 	private disposed = false;
 
-	/** Fires when the preview changes, with nothing when there is none any more. */
+	/** Fires when the preview changes, carrying nothing when there is none. */
 	readonly onDidChangeResult = this.resultEmitter.event;
 
 	constructor(private readonly options: TypstPreviewControllerOptions) {
@@ -377,11 +430,6 @@ export class TypstPreviewController implements vscode.Disposable {
 		void this.run(document, document.positionAt(block.fenceStart), false);
 	}
 
-	/** Forget every compiled image, so the next request compiles again. */
-	clearCache(): void {
-		this.cache.clear();
-	}
-
 	dispose(): void {
 		if (this.disposed) {
 			return;
@@ -400,7 +448,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.compiler = undefined;
 		this.uncancelled.dispose();
 		this.resultEmitter.dispose();
-		this.cache.clear();
+		this.forgetImages();
 		this.contexts.clear();
 		this.result = undefined;
 	}
@@ -416,13 +464,6 @@ export class TypstPreviewController implements vscode.Disposable {
 		// has. A closed document raised its own event already, so publishing a
 		// result for it here would bring back a preview that was taken away.
 		const stale = (): boolean => this.disposed || version !== this.requestVersion || document.isClosed;
-		/** Say why there is nothing to show, and only to a reader who asked. */
-		const explain = (message: string): void => {
-			logMessage(`Typst preview: ${message}`, "debug");
-			if (asked) {
-				this.options.show(message);
-			}
-		};
 
 		if (!vscode.workspace.isTrusted) {
 			this.reportUnavailable("The Typst preview needs a trusted workspace, because it runs the Typst compiler.");
@@ -442,7 +483,13 @@ export class TypstPreviewController implements vscode.Disposable {
 			return;
 		}
 		if (isUnavailable(request)) {
-			explain(request.unavailable);
+			// Said only to a reader who asked. An edit or a cursor move that lands
+			// outside every block is not a question, so answering it would put a
+			// message in front of someone who did nothing.
+			logMessage(`Typst preview: ${request.unavailable}`, "debug");
+			if (asked) {
+				this.options.show(request.unavailable);
+			}
 			return;
 		}
 
@@ -502,59 +549,55 @@ export class TypstPreviewController implements vscode.Disposable {
 		asked: boolean,
 		failure?: string,
 	): void {
-		const header = headerText(document, request);
-		if (compiled.svg !== undefined) {
-			if (compiled.stderr.length > 0) {
-				logMessage(`Typst preview: the compiler warned:\n${compiled.stderr}`, "debug");
+		if (compiled.svg === undefined) {
+			if (failure === undefined) {
+				logMessage(`Typst preview: the compiler reported:\n${compiled.stderr}`, "debug");
 			}
-			this.result = {
-				uri: document.uri,
-				block: request.block,
-				blockIndex: request.blockIndex,
-				svg: compiled.svg,
-				header,
-				asked,
-			};
-			this.resultEmitter.fire(this.result);
-			return;
+		} else if (compiled.stderr.length > 0) {
+			logMessage(`Typst preview: the compiler warned:\n${compiled.stderr}`, "debug");
 		}
 
-		if (failure === undefined) {
-			logMessage(`Typst preview: the compiler reported:\n${compiled.stderr}`, "debug");
-		}
-		// The last good image of this block stays behind the error, because a parse
-		// error is the normal state of a block halfway through an edit and clearing
-		// the image would make the surface flash empty on almost every keystroke.
-		// The image of another block is not kept: an error of one block over the
-		// image of another says nothing true about either of them.
-		const same =
-			this.result !== undefined &&
-			this.result.uri.toString() === document.uri.toString() &&
-			this.result.blockIndex === request.blockIndex;
+		// A failure keeps the last good image of this same block behind it, because
+		// a parse error is the normal state of a block halfway through an edit and
+		// clearing the image would make the surface flash empty on almost every
+		// keystroke. The image of another block is not kept: an error of one block
+		// over the image of another says nothing true about either of them.
+		const sameBlock =
+			this.result?.uri.toString() === document.uri.toString() && this.result?.blockIndex === request.blockIndex;
 		this.result = {
 			uri: document.uri,
 			block: request.block,
 			blockIndex: request.blockIndex,
-			svg: same ? this.result?.svg : undefined,
-			header,
-			error: failure ?? errorText(compiled.stderr, request),
-			asked,
+			svg: compiled.svg ?? (sameBlock ? this.result?.svg : undefined),
+			header: headerText(document, request),
+			error: compiled.svg === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};
-		this.resultEmitter.fire(this.result);
+		this.watchFiles();
+		this.resultEmitter.fire({ result: this.result, asked });
 	}
 
-	/** Remember one compile, and forget the one used longest ago. */
+	/** Remember one compile, and forget those used longest ago to make room. */
 	private remember(key: string, compiled: TypstCompileResult): void {
 		this.cache.set(key, compiled);
-		if (this.cache.size <= CACHE_LIMIT) {
-			return;
-		}
+		this.cacheBytes += compiled.svg?.length ?? 0;
 		// A `Map` iterates in insertion order and every hit is re-inserted, so the
-		// first key is the one used longest ago.
-		const oldest = this.cache.keys().next();
-		if (!oldest.done) {
+		// first key is the one used longest ago. Both bounds matter: the count keeps
+		// a session of small blocks from growing without end, and the byte total
+		// keeps a handful of dense pages from holding the extension host.
+		while (this.cache.size > CACHE_LIMIT || (this.cacheBytes > CACHE_LIMIT_BYTES && this.cache.size > 1)) {
+			const oldest = this.cache.keys().next();
+			if (oldest.done) {
+				return;
+			}
+			this.cacheBytes -= this.cache.get(oldest.value)?.svg?.length ?? 0;
 			this.cache.delete(oldest.value);
 		}
+	}
+
+	/** Forget every compiled image, so the next request compiles again. */
+	private forgetImages(): void {
+		this.cache.clear();
+		this.cacheBytes = 0;
 	}
 
 	private resolveBinary(): Promise<string | undefined> {
@@ -570,11 +613,11 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * compile supersedes whatever is running anyway.
 	 */
 	private useCompiler(binary: string, timeoutMs: number): TypstCompilerLike {
-		if (this.compiler === undefined || this.compilerBinary !== binary || this.compilerTimeoutMs !== timeoutMs) {
+		const key = `${binary} ${timeoutMs}`;
+		if (this.compiler === undefined || this.compilerKey !== key) {
 			this.compiler?.dispose();
 			this.compiler = this.options.createCompiler?.(binary, timeoutMs) ?? new TypstCompiler(binary, { timeoutMs });
-			this.compilerBinary = binary;
-			this.compilerTimeoutMs = timeoutMs;
+			this.compilerKey = key;
 		}
 		return this.compiler;
 	}
@@ -596,36 +639,46 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.options.show(message);
 	}
 
-	/** Forget the compiler, so the next request builds one from a fresh probe. */
+	/**
+	 * Forget the compiler and where its binary was, so the next request probes.
+	 *
+	 * The probe memoises its answer for the session, so forgetting the compiler
+	 * alone would rebuild it around the path Quarto had before it was installed,
+	 * removed or moved.
+	 */
 	private forgetCompiler(): void {
+		invalidateTypstBinary();
 		this.compiler?.dispose();
 		this.compiler = undefined;
-		this.compilerBinary = undefined;
-		this.compilerTimeoutMs = undefined;
+		this.compilerKey = undefined;
 		this.reportedUnavailable = false;
 	}
 
 	/** Rebuild the preview after an edit, at the delay the settings ask for. */
 	private scheduleDocument(document: vscode.TextDocument): void {
-		const delayMs = previewSettings(document).debounceMs;
-		// The delay is fixed when a debouncer is built and the setting is resource
-		// scoped, so the debouncer is rebuilt when the value it holds no longer
-		// applies. A pending rebuild is not lost: it is asked for again below.
-		if (this.documentDebounce === undefined || this.documentDelayMs !== delayMs) {
-			this.documentDebounce?.cancel();
-			this.documentDelayMs = delayMs;
-			this.documentDebounce = debounce(() => this.refresh(), delayMs);
+		// The delay is fixed when a debouncer is built, so it is read once and kept
+		// rather than on every keystroke. A configuration change forgets it, which
+		// is the only event that can move it.
+		if (this.documentDebounce === undefined) {
+			this.documentDebounce = debounce(() => this.refresh(), documentDelayOf(document));
 		}
 		this.documentDebounce();
 	}
 
+	/** Drop the debouncer, so the next edit reads the delay again. */
+	private forgetDocumentDelay(): void {
+		this.documentDebounce?.cancel();
+		this.documentDebounce = undefined;
+	}
+
 	private wireEvents(): void {
 		this.disposables.push(
-			// The cursor moving is what says which block is being looked at, and it
-			// moves on every keystroke as well, so this is what keeps the block under
-			// an edit current.
+			// The cursor moving is what says which block is being looked at. A cursor
+			// still inside the block on screen has nothing to say: it moves on every
+			// keystroke as well, and typing is what the document delay is for, so
+			// following it here would make that setting mean nothing below 250 ms.
 			vscode.window.onDidChangeTextEditorSelection((event) => {
-				if (isRelevantDocument(event.textEditor.document)) {
+				if (this.options.hasSurface() && isRelevantDocument(event.textEditor.document) && this.movedBlock(event)) {
 					this.selectionDebounce();
 				}
 			}),
@@ -658,7 +711,7 @@ export class TypstPreviewController implements vscode.Disposable {
 				this.contexts.forget(document.uri);
 				if (this.result?.uri.toString() === document.uri.toString()) {
 					this.result = undefined;
-					this.resultEmitter.fire(undefined);
+					this.resultEmitter.fire({ asked: false });
 				}
 			}),
 		);
@@ -675,6 +728,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.disposables.push(
 			vscode.workspace.onDidChangeConfiguration((event) => {
 				if (event.affectsConfiguration("quartoWizard.typstPreview")) {
+					this.forgetDocumentDelay();
 					this.recompile();
 				}
 			}),
@@ -685,14 +739,29 @@ export class TypstPreviewController implements vscode.Disposable {
 			// or whether there is one at all.
 			vscode.extensions.onDidChange(() => this.forgetCompiler()),
 		);
+	}
 
-		this.watch("**/_{quarto,metadata,brand}.{yml,yaml}");
-		this.watch("**/_brand/_brand.{yml,yaml}");
-		this.watch("**/*.typ");
+	/**
+	 * Watch the files a preview reads beside the block.
+	 *
+	 * Raised by the first published result rather than at registration. These are
+	 * workspace-wide watchers, and until something is being previewed every event
+	 * they deliver reaches a `recompile` that has nothing to recompile, so a
+	 * session that never opens the preview should not pay for them.
+	 */
+	private watchFiles(): void {
+		if (this.watching) {
+			return;
+		}
+		this.watching = true;
+		// One glob covers `_brand/_brand.yml` as well, because a leading `**/`
+		// matches the directory as readily as any other.
+		this.watch(CONTEXT_FILE_GLOB);
+		this.watch(TYPST_FILE_GLOB);
 		// The gate answer is held with the rest of the context, so a project that
 		// installs the extension while the preview is open stops reporting a cell as
 		// unpreviewable without waiting for a cache to expire.
-		this.watch("**/_extensions/**/_extension.{yml,yaml}");
+		this.watch(EXTENSION_MANIFEST_GLOB);
 	}
 
 	/** Rebuild the preview when a file it reads beside the block changes. */
@@ -705,7 +774,29 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.disposables.push(watcher);
 	}
 
+	/**
+	 * Whether a selection change asks a question the result does not answer.
+	 *
+	 * The cursor is compared against the block on screen. Its offsets are those
+	 * of the version it was read from, which is enough here: an edit inside the
+	 * block moves its end by what was typed, and the cursor moves with it.
+	 */
+	private movedBlock(event: vscode.TextEditorSelectionChangeEvent): boolean {
+		const shown = this.result;
+		if (shown === undefined || shown.uri.toString() !== event.textEditor.document.uri.toString()) {
+			return true;
+		}
+		const offset = event.textEditor.document.offsetAt(event.selections[0].active);
+		return offset < shown.block.fenceStart || offset > shown.block.bodyEnd;
+	}
+
 	private handleDocumentChange(event: vscode.TextDocumentChangeEvent): void {
+		if (!this.options.hasSurface()) {
+			// Nothing is showing a preview, so nothing would render the result. The
+			// document change events of a whole session arrive here, so this is the
+			// one place where the cost of a keystroke is worth naming.
+			return;
+		}
 		if (isContextDocument(event.document)) {
 			// The chain prefers the copy open in the editor, so an unsaved edit to one
 			// of these files is what the next request would read.

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -47,7 +47,7 @@ const CONTEXT_DEBOUNCE_MS = 300;
  * and small enough that a session of many documents does not grow without
  * bound.
  */
-const CACHE_LIMIT = 32;
+export const CACHE_LIMIT = 32;
 
 /**
  * How many bytes of image the remembered results may hold together.
@@ -828,16 +828,19 @@ export class TypstPreviewController implements vscode.Disposable {
 	}
 
 	private handleDocumentChange(event: vscode.TextDocumentChangeEvent): void {
+		if (isContextDocument(event.document)) {
+			// The chain prefers the copy open in the editor, so an unsaved edit to one
+			// of these files is what the next request would read. This is asked ahead
+			// of the surface, because what it forgets outlives the surface: an edit
+			// made while the panel is closed is still what the next request reads, and
+			// the recompile behind it does nothing until there is something to show.
+			this.contextDebounce();
+			return;
+		}
 		if (!this.options.hasSurface()) {
 			// Nothing is showing a preview, so nothing would render the result. The
 			// document change events of a whole session arrive here, so this is the
 			// one place where the cost of a keystroke is worth naming.
-			return;
-		}
-		if (isContextDocument(event.document)) {
-			// The chain prefers the copy open in the editor, so an unsaved edit to one
-			// of these files is what the next request would read.
-			this.contextDebounce();
 			return;
 		}
 		if (!isRelevantDocument(event.document) || event.contentChanges.length === 0) {

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -129,6 +129,8 @@ export interface TypstPreviewControllerOptions {
 	resolveBinary?: () => Promise<string | undefined>;
 	/** The compiler for one binary and one timeout. Injected for the same reason. */
 	createCompiler?: (binary: string, timeoutMs: number) => TypstCompilerLike;
+	/** How many bytes of image to hold. Lowered by the test that bounds it. */
+	cacheLimitBytes?: number;
 }
 
 /** What the settings say about compiling one document. */
@@ -365,7 +367,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	private compilerKey: string | undefined;
 	/** How many bytes of image the cache is holding. */
 	private cacheBytes = 0;
-	/** Whether the file watchers are up, which the first published result raises. */
+	/** Whether the file watchers are up, which the first request raises. */
 	private watching = false;
 	/** Rises with every request, so a result that arrives out of order is dropped. */
 	private requestVersion = 0;
@@ -616,7 +618,8 @@ export class TypstPreviewController implements vscode.Disposable {
 		// first key is the one used longest ago. Both bounds matter: the count keeps
 		// a session of small blocks from growing without end, and the byte total
 		// keeps a handful of dense pages from holding the extension host.
-		while (this.cache.size > CACHE_LIMIT || (this.cacheBytes > CACHE_LIMIT_BYTES && this.cache.size > 1)) {
+		const limitBytes = this.options.cacheLimitBytes ?? CACHE_LIMIT_BYTES;
+		while (this.cache.size > CACHE_LIMIT || (this.cacheBytes > limitBytes && this.cache.size > 1)) {
 			const oldest = this.cache.keys().next();
 			if (oldest.done) {
 				return;
@@ -781,10 +784,14 @@ export class TypstPreviewController implements vscode.Disposable {
 	/**
 	 * Watch the files a preview reads beside the block.
 	 *
-	 * Raised by the first published result rather than at registration. These are
-	 * workspace-wide watchers, and until something is being previewed every event
-	 * they deliver reaches a `recompile` that has nothing to recompile, so a
-	 * session that never opens the preview should not pay for them.
+	 * Raised by the first request rather than at registration. These are
+	 * workspace-wide watchers, and until a preview is asked for every event they
+	 * deliver reaches a `recompile` that has nothing to recompile, so a session
+	 * that never opens the preview should not pay for them.
+	 *
+	 * A request and not a result, because a cell in a project that has not
+	 * installed the extension produces no result, and the manifest watcher is
+	 * what lets it start working once the extension is installed.
 	 */
 	private watchFiles(): void {
 		if (this.watching) {

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -1,0 +1,729 @@
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { getErrorMessage } from "@quarto-wizard/core";
+import { invalidatesPreview, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
+import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
+import { debounce, type DebouncedFunction } from "../../utils/debounce";
+import { generateHashKey } from "../../utils/hash";
+import { logMessage } from "../../utils/log";
+import { buildCompileRequest, TypstContextCache, type CompileRequest } from "./typstContext";
+import { DEFAULT_TIMEOUT_MS, TypstCompiler, resolveTypstBinary, type TypstCompileResult } from "./typstCompiler";
+
+/**
+ * The one owner of the preview state.
+ *
+ * The surfaces are thin renderers of whatever it publishes, so there is one
+ * answer to what is being previewed rather than one per surface, and one place
+ * that decides when a compile is worth running.
+ */
+
+/** Read the source from stdin, write the image to stdout. */
+const ARGV = ["compile", "--format", "svg", "-", "-"];
+
+/**
+ * How long after the cursor moves the preview follows it.
+ *
+ * Shorter than the document delay on purpose: moving the cursor between blocks
+ * is a deliberate act and usually answers from the cache, while typing is not.
+ */
+const SELECTION_DEBOUNCE_MS = 250;
+
+/** How long after a file the preview reads changes it is rebuilt. */
+const CONTEXT_DEBOUNCE_MS = 300;
+
+/**
+ * How many compiled results are remembered.
+ *
+ * Enough to hold every block of a document under an edit and its undo history,
+ * and small enough that a session of many documents does not grow without
+ * bound. An entry is one image, which is tens of kilobytes.
+ */
+const CACHE_LIMIT = 32;
+
+/** The bounds `package.json` declares, repeated here because it cannot enforce them. */
+const MIN_TIMEOUT_MS = 1000;
+const MAX_TIMEOUT_MS = 300000;
+const MIN_DEBOUNCE_MS = 0;
+const MAX_DEBOUNCE_MS = 5000;
+
+/** The document change delay `package.json` declares. */
+export const DEFAULT_DEBOUNCE_MS = 300;
+
+/** Where the lines of a compile live, so a diagnostic can be placed. */
+export interface ErrorPlace {
+	/** How many lines sit above the compiled code in the assembled source. */
+	injectedLines: number;
+	/** How many lines of the block body sit above the first compiled line. */
+	bodyLineOffset?: number;
+	/** The file whose contents were compiled instead of the block body. */
+	externalFile?: string;
+}
+
+/** What a surface needs to render the current preview. */
+export interface TypstPreviewResult {
+	/** The document the block belongs to. */
+	uri: vscode.Uri;
+	/** The block that was previewed. */
+	block: TypstBlock;
+	/** Where that block sits in the document, which is its identity across an edit. */
+	blockIndex: number;
+	/** The image on screen, which is the last one this block compiled to. */
+	svg?: string;
+	/** What the surface says about the block beside the image. */
+	header: string;
+	/** The one line a failure shows, absent when the compile produced an image. */
+	error?: string;
+	/** Whether the user asked for this preview, rather than an edit driving it. */
+	asked: boolean;
+}
+
+/** What the controller needs of a compiler, which is what makes it stubbable. */
+export interface TypstCompilerLike {
+	compile(source: string, argv: string[], token: vscode.CancellationToken): Promise<TypstCompileResult>;
+	dispose(): void;
+}
+
+/** How the controller reaches the parts of the world it does not own. */
+export interface TypstPreviewControllerOptions {
+	/**
+	 * Whether a surface is showing a preview now.
+	 *
+	 * A background edit is only worth a compile when something is displaying the
+	 * result. A request the user asked for compiles either way, because the
+	 * surface it opens is the answer.
+	 */
+	hasSurface: () => boolean;
+	/** Put a message in front of the reader. */
+	show: (message: string) => void;
+	/** The Typst binary. Injected so that no test spawns Typst. */
+	resolveBinary?: () => Promise<string | undefined>;
+	/** The compiler for one binary and one timeout. Injected for the same reason. */
+	createCompiler?: (binary: string, timeoutMs: number) => TypstCompilerLike;
+}
+
+/** What the settings say about previewing one document. */
+interface TypstPreviewSettings {
+	foreground: string;
+	background: string;
+	timeoutMs: number;
+	debounceMs: number;
+}
+
+/**
+ * The active colour theme as the pure modules name it.
+ *
+ * Exported for its tests. `HighContrast` is the dark one and `HighContrastLight`
+ * the light one, which is the pairing a mapping written from the names alone
+ * gets wrong.
+ */
+export function themeKindOf(kind: vscode.ColorThemeKind): TypstThemeKind {
+	switch (kind) {
+		case vscode.ColorThemeKind.Light:
+			return "light";
+		case vscode.ColorThemeKind.HighContrast:
+			return "high-contrast";
+		case vscode.ColorThemeKind.HighContrastLight:
+			return "high-contrast-light";
+		default:
+			return "dark";
+	}
+}
+
+/**
+ * A usable colour setting, whatever the setting holds.
+ *
+ * Exported for its tests. `package.json` declares the type, and a hand-edited
+ * `settings.json` ignores it, so a value that is not a string reaches the
+ * header and is trimmed there.
+ */
+export function previewColour(value: unknown): string {
+	// The header trims the value, so a value that is not a string throws where
+	// nothing catches it, and the panel opens and then stays empty.
+	return typeof value === "string" ? value : "auto";
+}
+
+/** A number setting held inside its bounds, whatever the setting holds. */
+function boundedNumber(value: unknown, fallback: number, lowest: number, highest: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return fallback;
+	}
+	return Math.min(highest, Math.max(lowest, value));
+}
+
+/**
+ * A usable compile timeout, whatever the setting holds.
+ *
+ * Exported for its tests. The bounds in `package.json` only guide the settings
+ * user interface, so a hand-edited `settings.json` reaches `setTimeout`
+ * unchecked, and `0` there fails every preview before Typst has read anything.
+ */
+export function previewTimeoutMs(value: unknown): number {
+	return boundedNumber(value, DEFAULT_TIMEOUT_MS, MIN_TIMEOUT_MS, MAX_TIMEOUT_MS);
+}
+
+/**
+ * A usable document change delay, whatever the setting holds.
+ *
+ * Exported for its tests. Zero is allowed and means a compile per keystroke,
+ * which a fast machine can carry, and the upper bound stops a mistyped value
+ * from looking like a preview that never updates.
+ */
+export function previewDebounceMs(value: unknown): number {
+	return boundedNumber(value, DEFAULT_DEBOUNCE_MS, MIN_DEBOUNCE_MS, MAX_DEBOUNCE_MS);
+}
+
+/**
+ * The settings in force for one document.
+ *
+ * They are resource scoped, so a multi-root workspace can hold a different
+ * answer per folder, and the document is what says which folder that is.
+ */
+function previewSettings(document: vscode.TextDocument): TypstPreviewSettings {
+	const config = vscode.workspace.getConfiguration("quartoWizard.typstPreview", document.uri);
+	return {
+		foreground: previewColour(config.get("foreground")),
+		background: previewColour(config.get("background")),
+		timeoutMs: previewTimeoutMs(config.get<number>("timeoutMs", DEFAULT_TIMEOUT_MS)),
+		debounceMs: previewDebounceMs(config.get<number>("debounceMs", DEFAULT_DEBOUNCE_MS)),
+	};
+}
+
+/**
+ * The one line a failure shows inside the surface.
+ *
+ * Exported for its tests. The choice of which diagnostic to show carries most
+ * of the behaviour, and it is not reachable through the command.
+ */
+export function errorText(stderr: string, place: ErrorPlace): string {
+	const diagnostics = parseTypstStderr(stderr, place.injectedLines);
+	// A warning can sit above the error that stopped the compile, so the first
+	// diagnostic is not the one to show. Headlining a failure as a warning
+	// misstates why there is no image.
+	//
+	// Among the errors it is the first that is shown, which is the earliest in
+	// the compiled source. A block compiled under a broken one reports errors of
+	// its own, and those are consequences: showing one of them would send the
+	// reader to a line that is only wrong because the source above it is.
+	const mapped = diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
+	if (mapped) {
+		if (mapped.aboveBody) {
+			// A raw block compiles under every raw block before it, so the failure
+			// can belong to one of those. There is no line of this block to name,
+			// but saying nothing about where it is would leave the reader looking
+			// at a block that compiles.
+			return `${mapped.severity} above this block: ${mapped.message}`;
+		}
+		if (mapped.line === undefined) {
+			// A package that would not download, or an input Typst could not read.
+			// Naming a position here would point at a character that has nothing to
+			// do with the failure.
+			return `${mapped.severity}: ${mapped.message}`;
+		}
+		const column = (mapped.column ?? 0) + 1;
+		if (place.externalFile !== undefined) {
+			// The body was replaced by that file, so no line of the block corresponds
+			// to the failure at all. Naming the block would send the reader to a line
+			// that has nothing to do with it.
+			return `${mapped.severity} at line ${mapped.line + 1}, column ${column} of ${place.externalFile}: ${mapped.message}`;
+		}
+		// The line is counted inside the block, while the panel header counts
+		// document lines, so it says which of the two it means. A cell compiles its
+		// code and not its body, so the leading option run is added back: without it
+		// every position in a cell with options is short by the length of that run.
+		const line = mapped.line + (place.bodyLineOffset ?? 0) + 1;
+		return `${mapped.severity} at line ${line}, column ${column} of the block: ${mapped.message}`;
+	}
+
+	// Nothing mapped, which means every diagnostic pointed at another file, such
+	// as an imported one. There is no position to show, but there is still a
+	// message, and reporting none would contradict the missing image.
+	const messages = typstMessages(stderr);
+	const outside = messages.find((message) => message.severity === "error") ?? messages[0];
+	return outside === undefined
+		? "Typst produced no image and reported nothing."
+		: `${outside.severity} outside this block: ${outside.message}`;
+}
+
+/** What the surface says about the block it is displaying. */
+export function headerText(document: vscode.TextDocument, request: CompileRequest): string {
+	const parts = [`${path.basename(document.fileName)} · line ${request.block.fenceLine + 1}`];
+	if (request.brandMode !== undefined) {
+		// A cell resolves its `auto` colours against one side of the brand, and
+		// which side it took is not visible in the image when the two are close.
+		parts.push(`${request.brandMode} brand`);
+	}
+	// Everything the preview does not reproduce about this block. Saying so beside
+	// the image is what stops a divergence being read as a defect.
+	parts.push(...request.notes);
+	return parts.join(" · ");
+}
+
+/** Whether a document is one this feature previews at all. */
+function isRelevantDocument(document: vscode.TextDocument): boolean {
+	return document.languageId === "quarto" || document.fileName.endsWith(".qmd");
+}
+
+/**
+ * Whether a document is one a preview reads beside the block.
+ *
+ * These are the files the metadata chain, the brand and a `preamble:` come
+ * from. An unsaved edit to one of them drives the preview the way an unsaved
+ * edit to the document itself already does, because the chain prefers the copy
+ * open in the editor.
+ */
+function isContextDocument(document: vscode.TextDocument): boolean {
+	const name = path.basename(document.fileName);
+	return /^_(quarto|metadata|brand)\.ya?ml$/.test(name) || name.endsWith(".typ") || /^_extension\.ya?ml$/.test(name);
+}
+
+/**
+ * The state of the Typst preview, and every event that changes it.
+ *
+ * Nothing here spawns Typst until a surface is showing a preview or the user
+ * asks for one, so a session that never opens the preview pays for the event
+ * subscriptions alone.
+ */
+export class TypstPreviewController implements vscode.Disposable {
+	private readonly disposables: vscode.Disposable[] = [];
+	private readonly contexts = new TypstContextCache();
+	private readonly resultEmitter = new vscode.EventEmitter<TypstPreviewResult | undefined>();
+	/**
+	 * The compiled results, most recently used last.
+	 *
+	 * Keyed by what decides the image: the source, the arguments and the binary.
+	 * A failure is remembered as well, because an unchanged broken block is the
+	 * normal state halfway through an edit and recompiling it says the same thing
+	 * at the cost of a process.
+	 */
+	private readonly cache = new Map<string, TypstCompileResult>();
+	/**
+	 * The token every compile is given.
+	 *
+	 * The compiler supersedes its own running child, so the caller has nothing to
+	 * cancel. This exists only because `compile` takes a token and the API has no
+	 * ready-made one that never fires.
+	 */
+	private readonly uncancelled = new vscode.CancellationTokenSource();
+	private readonly selectionDebounce: DebouncedFunction<() => void>;
+	private readonly contextDebounce: DebouncedFunction<() => void>;
+	private documentDebounce: DebouncedFunction<() => void> | undefined;
+	private documentDelayMs: number | undefined;
+	private compiler: TypstCompilerLike | undefined;
+	private compilerBinary: string | undefined;
+	private compilerTimeoutMs: number | undefined;
+	/** Rises with every request, so a result that arrives out of order is dropped. */
+	private requestVersion = 0;
+	private result: TypstPreviewResult | undefined;
+	/** Said once per session, because an unavailable machine stays unavailable. */
+	private reportedUnavailable = false;
+	private disposed = false;
+
+	/** Fires when the preview changes, with nothing when there is none any more. */
+	readonly onDidChangeResult = this.resultEmitter.event;
+
+	constructor(private readonly options: TypstPreviewControllerOptions) {
+		this.selectionDebounce = debounce(() => this.refresh(), SELECTION_DEBOUNCE_MS);
+		this.contextDebounce = debounce(() => {
+			this.contexts.forgetFiles();
+			this.recompile();
+		}, CONTEXT_DEBOUNCE_MS);
+		this.wireEvents();
+	}
+
+	/** What is being previewed, which is what a surface renders. */
+	current(): TypstPreviewResult | undefined {
+		return this.result;
+	}
+
+	/** Preview the block under a position, because the user asked for it. */
+	request(document: vscode.TextDocument, position: vscode.Position): void {
+		void this.run(document, position, true);
+	}
+
+	/** Preview the block under the cursor again, because something changed. */
+	refresh(): void {
+		const editor = vscode.window.activeTextEditor;
+		if (editor === undefined || !isRelevantDocument(editor.document)) {
+			return;
+		}
+		void this.run(editor.document, editor.selection.active, false);
+	}
+
+	/**
+	 * Compile the block that is on screen again, wherever the cursor is now.
+	 *
+	 * This is what a theme, a setting or a file the preview reads changing asks
+	 * for. Those change the image of the block being looked at, and the cursor
+	 * may have moved on to a document with no block in it at all, so following the
+	 * cursor here would leave the panel showing an image nothing recompiled.
+	 *
+	 * The block is found again by its place in the document rather than by the
+	 * offsets it carried, which move under every edit above it.
+	 */
+	recompile(): void {
+		const shown = this.result;
+		if (shown === undefined) {
+			return;
+		}
+		const document = vscode.workspace.textDocuments.find((open) => open.uri.toString() === shown.uri.toString());
+		if (document === undefined) {
+			return;
+		}
+		const block = this.contexts.blocksOf(document, document.getText())[shown.blockIndex];
+		if (block === undefined) {
+			return;
+		}
+		void this.run(document, document.positionAt(block.fenceStart), false);
+	}
+
+	/** Forget every compiled image, so the next request compiles again. */
+	clearCache(): void {
+		this.cache.clear();
+	}
+
+	dispose(): void {
+		if (this.disposed) {
+			return;
+		}
+		this.disposed = true;
+		this.selectionDebounce.cancel();
+		this.contextDebounce.cancel();
+		this.documentDebounce?.cancel();
+		for (const disposable of this.disposables) {
+			disposable.dispose();
+		}
+		this.disposables.length = 0;
+		// Disposing the compiler kills whatever child it has in flight, which is
+		// what stops a shutdown leaving a Typst process behind.
+		this.compiler?.dispose();
+		this.compiler = undefined;
+		this.uncancelled.dispose();
+		this.resultEmitter.dispose();
+		this.cache.clear();
+		this.contexts.clear();
+		this.result = undefined;
+	}
+
+	/** One preview, from a position to a published result. */
+	private async run(document: vscode.TextDocument, position: vscode.Position, asked: boolean): Promise<void> {
+		if (this.disposed || (!asked && !this.options.hasSurface())) {
+			return;
+		}
+
+		const version = ++this.requestVersion;
+		// A newer request has started, or the controller has gone, or the document
+		// has. A closed document raised its own event already, so publishing a
+		// result for it here would bring back a preview that was taken away.
+		const stale = (): boolean => this.disposed || version !== this.requestVersion || document.isClosed;
+		/** Say why there is nothing to show, and only to a reader who asked. */
+		const explain = (message: string): void => {
+			logMessage(`Typst preview: ${message}`, "debug");
+			if (asked) {
+				this.options.show(message);
+			}
+		};
+
+		if (!vscode.workspace.isTrusted) {
+			this.reportUnavailable("The Typst preview needs a trusted workspace, because it runs the Typst compiler.");
+			return;
+		}
+
+		const settings = previewSettings(document);
+		// The header applies to a plain block and a raw block. A cell keeps the
+		// colour contract of the filter instead, and drops it.
+		const { header } = themeHeader(
+			themeKindOf(vscode.window.activeColorTheme.kind),
+			settings.foreground,
+			settings.background,
+		);
+		const request = await buildCompileRequest(document, position, header, this.contexts);
+		if (stale()) {
+			return;
+		}
+		if (isUnavailable(request)) {
+			explain(request.unavailable);
+			return;
+		}
+
+		const binary = await this.resolveBinary();
+		if (binary === undefined) {
+			this.reportUnavailable(
+				"The Typst preview needs the Typst binary that ships inside Quarto, and it was not found.",
+			);
+			return;
+		}
+		if (stale()) {
+			return;
+		}
+
+		// The image is decided by the source, the arguments and the binary, and by
+		// nothing else. Two documents that assemble to the same source share the
+		// entry, which is what makes an undone keystroke free.
+		// Joined on a character no argument and no Typst source carries, so two
+		// different triples cannot be spelled the same way.
+		const key = generateHashKey([binary, ...ARGV, request.source].join("\u0000"));
+		const held = this.cache.get(key);
+		if (held !== undefined) {
+			// Re-inserted so the least recently used entry is the first one, which is
+			// what the eviction below removes.
+			this.cache.delete(key);
+			this.cache.set(key, held);
+			this.publish(document, request, held, asked);
+			return;
+		}
+
+		try {
+			const compiled = await this.useCompiler(binary, settings.timeoutMs).compile(
+				request.source,
+				ARGV,
+				this.uncancelled.token,
+			);
+			if (stale()) {
+				return;
+			}
+			this.remember(key, compiled);
+			this.publish(document, request, compiled, asked);
+		} catch (error) {
+			if (stale() || error instanceof vscode.CancellationError) {
+				return;
+			}
+			const message = getErrorMessage(error);
+			logMessage(`Typst preview: ${message}`, "error");
+			this.publish(document, request, { stderr: "" }, asked, message);
+		}
+	}
+
+	/** Publish what one compile means for the surfaces. */
+	private publish(
+		document: vscode.TextDocument,
+		request: CompileRequest,
+		compiled: TypstCompileResult,
+		asked: boolean,
+		failure?: string,
+	): void {
+		const header = headerText(document, request);
+		if (compiled.svg !== undefined) {
+			if (compiled.stderr.length > 0) {
+				logMessage(`Typst preview: the compiler warned:\n${compiled.stderr}`, "debug");
+			}
+			this.result = {
+				uri: document.uri,
+				block: request.block,
+				blockIndex: request.blockIndex,
+				svg: compiled.svg,
+				header,
+				asked,
+			};
+			this.resultEmitter.fire(this.result);
+			return;
+		}
+
+		if (failure === undefined) {
+			logMessage(`Typst preview: the compiler reported:\n${compiled.stderr}`, "debug");
+		}
+		// The last good image of this block stays behind the error, because a parse
+		// error is the normal state of a block halfway through an edit and clearing
+		// the image would make the surface flash empty on almost every keystroke.
+		// The image of another block is not kept: an error of one block over the
+		// image of another says nothing true about either of them.
+		const same =
+			this.result !== undefined &&
+			this.result.uri.toString() === document.uri.toString() &&
+			this.result.blockIndex === request.blockIndex;
+		this.result = {
+			uri: document.uri,
+			block: request.block,
+			blockIndex: request.blockIndex,
+			svg: same ? this.result?.svg : undefined,
+			header,
+			error: failure ?? errorText(compiled.stderr, request),
+			asked,
+		};
+		this.resultEmitter.fire(this.result);
+	}
+
+	/** Remember one compile, and forget the one used longest ago. */
+	private remember(key: string, compiled: TypstCompileResult): void {
+		this.cache.set(key, compiled);
+		if (this.cache.size <= CACHE_LIMIT) {
+			return;
+		}
+		// A `Map` iterates in insertion order and every hit is re-inserted, so the
+		// first key is the one used longest ago.
+		const oldest = this.cache.keys().next();
+		if (!oldest.done) {
+			this.cache.delete(oldest.value);
+		}
+	}
+
+	private resolveBinary(): Promise<string | undefined> {
+		return (this.options.resolveBinary ?? resolveTypstBinary)();
+	}
+
+	/**
+	 * The compiler for one binary and one timeout.
+	 *
+	 * Both are read once at construction, and both can change while the session
+	 * runs, so the compiler is replaced when the values it was built with no
+	 * longer apply. Nothing is lost by replacing it mid-run, because the next
+	 * compile supersedes whatever is running anyway.
+	 */
+	private useCompiler(binary: string, timeoutMs: number): TypstCompilerLike {
+		if (this.compiler === undefined || this.compilerBinary !== binary || this.compilerTimeoutMs !== timeoutMs) {
+			this.compiler?.dispose();
+			this.compiler = this.options.createCompiler?.(binary, timeoutMs) ?? new TypstCompiler(binary, { timeoutMs });
+			this.compilerBinary = binary;
+			this.compilerTimeoutMs = timeoutMs;
+		}
+		return this.compiler;
+	}
+
+	/**
+	 * Say once that the feature cannot run here at all.
+	 *
+	 * The log line is not part of what is said once. The binary probe caches its
+	 * result and logs only on the first attempt, so without this every later
+	 * attempt on an unavailable machine would leave no trace at all, and the log
+	 * would stop being enough to diagnose an inert preview.
+	 */
+	private reportUnavailable(message: string): void {
+		logMessage(`Typst preview: ${message}`, "debug");
+		if (this.reportedUnavailable) {
+			return;
+		}
+		this.reportedUnavailable = true;
+		this.options.show(message);
+	}
+
+	/** Forget the compiler, so the next request builds one from a fresh probe. */
+	private forgetCompiler(): void {
+		this.compiler?.dispose();
+		this.compiler = undefined;
+		this.compilerBinary = undefined;
+		this.compilerTimeoutMs = undefined;
+		this.reportedUnavailable = false;
+	}
+
+	/** Rebuild the preview after an edit, at the delay the settings ask for. */
+	private scheduleDocument(document: vscode.TextDocument): void {
+		const delayMs = previewSettings(document).debounceMs;
+		// The delay is fixed when a debouncer is built and the setting is resource
+		// scoped, so the debouncer is rebuilt when the value it holds no longer
+		// applies. A pending rebuild is not lost: it is asked for again below.
+		if (this.documentDebounce === undefined || this.documentDelayMs !== delayMs) {
+			this.documentDebounce?.cancel();
+			this.documentDelayMs = delayMs;
+			this.documentDebounce = debounce(() => this.refresh(), delayMs);
+		}
+		this.documentDebounce();
+	}
+
+	private wireEvents(): void {
+		this.disposables.push(
+			// The cursor moving is what says which block is being looked at, and it
+			// moves on every keystroke as well, so this is what keeps the block under
+			// an edit current.
+			vscode.window.onDidChangeTextEditorSelection((event) => {
+				if (isRelevantDocument(event.textEditor.document)) {
+					this.selectionDebounce();
+				}
+			}),
+		);
+
+		this.disposables.push(
+			// A new editor usually answers from the cache, so it is not debounced.
+			vscode.window.onDidChangeActiveTextEditor(() => this.refresh()),
+		);
+
+		this.disposables.push(vscode.workspace.onDidChangeTextDocument((event) => this.handleDocumentChange(event)));
+
+		this.disposables.push(
+			// A save is a deliberate act and the reader is waiting for the result, so
+			// the pending rebuild happens now rather than after its delay.
+			vscode.workspace.onDidSaveTextDocument((document) => {
+				if (isContextDocument(document)) {
+					this.contextDebounce.flush();
+					return;
+				}
+				if (isRelevantDocument(document)) {
+					this.selectionDebounce.cancel();
+					this.documentDebounce?.flush();
+				}
+			}),
+		);
+
+		this.disposables.push(
+			vscode.workspace.onDidCloseTextDocument((document) => {
+				this.contexts.forget(document.uri);
+				if (this.result?.uri.toString() === document.uri.toString()) {
+					this.result = undefined;
+					this.resultEmitter.fire(undefined);
+				}
+			}),
+		);
+
+		this.disposables.push(
+			// The injected colour of a plain or raw block and the brand mode of a cell
+			// both follow the theme, so the source changes and the cache decides
+			// whether that is worth a compile: a theme that resolves to the same
+			// source is a hit and spawns nothing. That covers all three kinds without
+			// asking what the theme means for each of them.
+			vscode.window.onDidChangeActiveColorTheme(() => this.recompile()),
+		);
+
+		this.disposables.push(
+			vscode.workspace.onDidChangeConfiguration((event) => {
+				if (event.affectsConfiguration("quartoWizard.typstPreview")) {
+					this.recompile();
+				}
+			}),
+		);
+
+		this.disposables.push(
+			// Installing or removing the Quarto extension changes where the binary is,
+			// or whether there is one at all.
+			vscode.extensions.onDidChange(() => this.forgetCompiler()),
+		);
+
+		this.watch("**/_{quarto,metadata,brand}.{yml,yaml}");
+		this.watch("**/_brand/_brand.{yml,yaml}");
+		this.watch("**/*.typ");
+		// The gate answer is held with the rest of the context, so a project that
+		// installs the extension while the preview is open stops reporting a cell as
+		// unpreviewable without waiting for a cache to expire.
+		this.watch("**/_extensions/**/_extension.{yml,yaml}");
+	}
+
+	/** Rebuild the preview when a file it reads beside the block changes. */
+	private watch(glob: string): void {
+		const watcher = vscode.workspace.createFileSystemWatcher(glob);
+		const changed = (): void => this.contextDebounce();
+		this.disposables.push(watcher.onDidCreate(changed));
+		this.disposables.push(watcher.onDidChange(changed));
+		this.disposables.push(watcher.onDidDelete(changed));
+		this.disposables.push(watcher);
+	}
+
+	private handleDocumentChange(event: vscode.TextDocumentChangeEvent): void {
+		if (isContextDocument(event.document)) {
+			// The chain prefers the copy open in the editor, so an unsaved edit to one
+			// of these files is what the next request would read.
+			this.contextDebounce();
+			return;
+		}
+		if (!isRelevantDocument(event.document) || event.contentChanges.length === 0) {
+			return;
+		}
+		const shown = this.result;
+		if (shown !== undefined && shown.uri.toString() === event.document.uri.toString()) {
+			// A raw block compiles under every raw block above it, so it is sensitive
+			// to a change at any lower offset and not only to one inside it. An edit
+			// that reaches neither compiles to the image already on screen.
+			if (!event.contentChanges.some((change) => invalidatesPreview(shown.block, change))) {
+				return;
+			}
+		}
+		this.scheduleDocument(event.document);
+	}
+}

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -41,6 +41,9 @@ export class TypstPreviewPanel {
 	 */
 	private pendingImage: PreviewMessage | undefined;
 	private pendingError: PreviewMessage | undefined;
+	/** What the page is already showing, so an unchanged image is not sent again. */
+	private shownSvg: string | undefined;
+	private shownHeader: string | undefined;
 	private readonly disposables: vscode.Disposable[] = [];
 	private readonly onDidDisposeEmitter = new vscode.EventEmitter<void>();
 	private closed = false;
@@ -96,6 +99,14 @@ export class TypstPreviewPanel {
 
 	/** Show a compiled image, and describe where it came from. */
 	show(svg: string, header: string): void {
+		// The same image is shown again whenever a failure is reported over it, and
+		// encoding it costs a copy a third larger than the image and a message
+		// across the webview boundary. Neither buys anything when nothing moved.
+		if (svg === this.shownSvg && header === this.shownHeader) {
+			return;
+		}
+		this.shownSvg = svg;
+		this.shownHeader = header;
 		this.post({ type: "image", uri: svgDataUri(svg), header });
 	}
 
@@ -107,6 +118,8 @@ export class TypstPreviewPanel {
 	 * of them.
 	 */
 	clear(): void {
+		this.shownSvg = undefined;
+		this.shownHeader = undefined;
 		this.post({ type: "clear" });
 	}
 

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -44,6 +44,7 @@ export class TypstPreviewPanel {
 	/** What the page is already showing, so an unchanged image is not sent again. */
 	private shownSvg: string | undefined;
 	private shownHeader: string | undefined;
+	private showingError = false;
 	private readonly disposables: vscode.Disposable[] = [];
 	private readonly onDidDisposeEmitter = new vscode.EventEmitter<void>();
 	private closed = false;
@@ -102,11 +103,17 @@ export class TypstPreviewPanel {
 		// The same image is shown again whenever a failure is reported over it, and
 		// encoding it costs a copy a third larger than the image and a message
 		// across the webview boundary. Neither buys anything when nothing moved.
-		if (svg === this.shownSvg && header === this.shownHeader) {
+		//
+		// An error on screen is the exception. The page takes its error away when
+		// an image arrives, so a block that is broken and then restored compiles to
+		// the image already shown, and skipping that message would leave a failure
+		// reported over a block that compiles.
+		if (svg === this.shownSvg && header === this.shownHeader && !this.showingError) {
 			return;
 		}
 		this.shownSvg = svg;
 		this.shownHeader = header;
+		this.showingError = false;
 		this.post({ type: "image", uri: svgDataUri(svg), header });
 	}
 
@@ -120,6 +127,7 @@ export class TypstPreviewPanel {
 	clear(): void {
 		this.shownSvg = undefined;
 		this.shownHeader = undefined;
+		this.showingError = false;
 		this.post({ type: "clear" });
 	}
 
@@ -131,6 +139,7 @@ export class TypstPreviewPanel {
 	 * keystroke.
 	 */
 	showError(message: string): void {
+		this.showingError = true;
 		this.post({ type: "error", message });
 	}
 

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -3,7 +3,8 @@ import { randomBytes } from "node:crypto";
 import { svgDataUri } from "../../utils/typst/typstSvg";
 
 /** What the host sends to the page. */
-type PreviewMessage = { type: "image"; uri: string; header: string } | { type: "error"; message: string };
+type PreviewMessage =
+	{ type: "image"; uri: string; header: string } | { type: "clear" } | { type: "error"; message: string };
 
 /**
  * The webview options, which a restored panel needs set again.
@@ -99,6 +100,17 @@ export class TypstPreviewPanel {
 	}
 
 	/**
+	 * Take the image away, because none describes what is being looked at.
+	 *
+	 * This is the block under the cursor changing, or the document closing. An
+	 * error of one block over the image of another says nothing true about either
+	 * of them.
+	 */
+	clear(): void {
+		this.post({ type: "clear" });
+	}
+
+	/**
 	 * Report a failure, keeping the last image behind it.
 	 *
 	 * A parse error is the normal state of a block halfway through an edit, so
@@ -146,13 +158,14 @@ export class TypstPreviewPanel {
 			return;
 		}
 		if (!this.ready) {
-			if (message.type === "image") {
-				// A compile that succeeded answers the failure before it, so the
-				// queued error is stale and must not replay over the new image.
+			if (message.type === "error") {
+				this.pendingError = message;
+			} else {
+				// A compile that succeeded answers the failure before it, and so does
+				// moving to another block, so the queued error is stale and must not
+				// replay over what replaced it.
 				this.pendingImage = message;
 				this.pendingError = undefined;
-			} else {
-				this.pendingError = message;
 			}
 			return;
 		}
@@ -196,9 +209,19 @@ export class TypstPreviewPanel {
 			window.addEventListener("message", (event) => {
 				const message = event.data;
 				if (message.type === "image") {
-					image.src = message.uri;
+					// Only a different image is assigned. The same one is re-posted
+					// whenever the header changes, and re-assigning it makes the panel
+					// blink through a decode it does not need.
+					if (image.src !== message.uri) {
+						image.src = message.uri;
+					}
 					image.hidden = false;
 					header.textContent = message.header;
+					error.hidden = true;
+				} else if (message.type === "clear") {
+					image.hidden = true;
+					image.removeAttribute("src");
+					header.textContent = "";
 					error.hidden = true;
 				} else if (message.type === "error") {
 					error.textContent = message.message;

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -589,4 +589,45 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.strictEqual(brandColourReader(brand)("light", "background"), undefined);
 		});
 	});
+
+	suite("TypstContextCache", () => {
+		/** One document, as the cache sees it: a URI, a version and its text. */
+		function document(version: number): vscode.TextDocument {
+			return { uri: vscode.Uri.file("/doc.qmd"), version } as vscode.TextDocument;
+		}
+
+		const FRONT_MATTER = "---\ntitle: One\n---\n\n";
+
+		test("Should read the disk again only when the front matter moves", async () => {
+			// The metadata chain reads the front matter and then the disk, so an edit
+			// to a block leaves every answer it gave unchanged. Keying on the document
+			// version instead would walk the whole project on every keystroke.
+			const cache = new TypstContextCache();
+			const first = cache.cellContext(document(1), `${FRONT_MATTER}Body\n`);
+			const again = cache.cellContext(document(2), `${FRONT_MATTER}Body and more\n`);
+			assert.strictEqual(await again, await first, "a body edit reads nothing again");
+
+			const moved = cache.cellContext(document(3), "---\ntitle: Two\n---\n\nBody\n");
+			assert.notStrictEqual(await moved, await first, "a front matter edit reads again");
+		});
+
+		test("Should read the document again when its version moves", async () => {
+			// The blocks are a function of the whole text, so the version is the whole
+			// key, which is the half of the cache the front matter does not decide.
+			const cache = new TypstContextCache();
+			const first = cache.blocksOf(document(1), "```typst\n#circle()\n```\n");
+			assert.strictEqual(cache.blocksOf(document(1), "```typst\n#circle()\n```\n"), first);
+			assert.notStrictEqual(cache.blocksOf(document(2), "```typst\n#square()\n```\n"), first);
+		});
+
+		test("Should forget what a file changing can move, and keep the rest", async () => {
+			const cache = new TypstContextCache();
+			const blocks = cache.blocksOf(document(1), "```typst\n#circle()\n```\n");
+			const context = await cache.cellContext(document(1), `${FRONT_MATTER}Body\n`);
+
+			cache.forgetFiles();
+			assert.strictEqual(cache.blocksOf(document(1), "```typst\n#circle()\n```\n"), blocks);
+			assert.notStrictEqual(await cache.cellContext(document(1), `${FRONT_MATTER}Body\n`), context);
+		});
+	});
 });

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -11,6 +11,7 @@ import {
 	buildCompileRequest,
 	isNewerThanPinned,
 	PINNED_TYPST_RENDER_VERSION,
+	TypstContextCache,
 } from "../../providers/typstPreview/typstContext";
 import { readBrand, readMetadataChain, resolveQuartoPath } from "../../providers/typstPreview/typstMetadata";
 import { invalidateProjectRoots, setProjectRoots } from "../../utils/projectRootsRegistry";
@@ -285,7 +286,7 @@ suite("Typst Preview Context Test Suite", () => {
 			try {
 				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
-				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER);
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, new TypstContextCache());
 				assert.ok(!isUnavailable(request));
 				// The filter's own contract, and not the preview's theme header: the
 				// bindings and the page directive come from the options in force.
@@ -306,7 +307,7 @@ suite("Typst Preview Context Test Suite", () => {
 			try {
 				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
-				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER);
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, new TypstContextCache());
 				assert.ok(!isUnavailable(request));
 			} finally {
 				fs.rmSync(directory, { recursive: true, force: true });
@@ -320,7 +321,7 @@ suite("Typst Preview Context Test Suite", () => {
 			try {
 				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
-				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER);
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, new TypstContextCache());
 				assert.ok(isUnavailable(request));
 				assert.ok(request.unavailable.includes("typst-render"));
 			} finally {
@@ -335,7 +336,7 @@ suite("Typst Preview Context Test Suite", () => {
 			try {
 				fs.writeFileSync(path.join(directory, "doc.qmd"), "```typst\n#circle()\n```\n");
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
-				const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER);
+				const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, new TypstContextCache());
 				assert.ok(!isUnavailable(request));
 				assert.strictEqual(request.source, `${HEADER}\n#circle()\n`);
 			} finally {
@@ -345,14 +346,14 @@ suite("Typst Preview Context Test Suite", () => {
 
 		test("Should say so when the cursor is in no block", async () => {
 			const document = await documentOf("Prose only.\n");
-			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER);
+			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER, new TypstContextCache());
 			assert.ok(isUnavailable(request));
 			assert.ok(request.unavailable.includes("cursor"));
 		});
 
 		test("Should assemble a plain block under the preview's own header", async () => {
 			const document = await documentOf("```typst\n#circle()\n```\n");
-			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER);
+			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, new TypstContextCache());
 			assert.ok(!isUnavailable(request));
 			assert.strictEqual(request.source, `${HEADER}\n#circle()\n`);
 			assert.strictEqual(request.block.kind, "plain");
@@ -365,7 +366,7 @@ suite("Typst Preview Context Test Suite", () => {
 		test("Should assemble a raw block under the raw blocks above it", async () => {
 			const text = "```{=typst}\n#let a = red\n```\n\n```{=typst}\n#text(fill: a)[Hi]\n```\n";
 			const document = await documentOf(text);
-			const request = await buildCompileRequest(document, new vscode.Position(5, 0), HEADER);
+			const request = await buildCompileRequest(document, new vscode.Position(5, 0), HEADER, new TypstContextCache());
 			assert.ok(!isUnavailable(request));
 			assert.strictEqual(request.source, `${HEADER}\n#let a = red\n#text(fill: a)[Hi]\n`);
 			assert.strictEqual(request.injectedLines, 2);

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -1,9 +1,13 @@
 import * as assert from "assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import {
 	TypstPreviewController,
 	type TypstCompilerLike,
 	type TypstPreviewResult,
+	type TypstPreviewUpdate,
 } from "../../providers/typstPreview/typstPreviewController";
 import type { TypstCompileResult } from "../../providers/typstPreview/typstCompiler";
 
@@ -49,12 +53,28 @@ class StubCompiler implements TypstCompilerLike {
 	}
 }
 
+/** The text of a document holding one plain Typst block, which needs nothing from disk. */
+function plainText(body = "#circle()"): string {
+	return `# Title\n\n\`\`\`typst\n${body}\n\`\`\`\n`;
+}
+
 /** A document holding one plain Typst block, which needs nothing from disk. */
 async function plainDocument(body = "#circle()"): Promise<vscode.TextDocument> {
-	return vscode.workspace.openTextDocument({
-		language: "quarto",
-		content: `# Title\n\n\`\`\`typst\n${body}\n\`\`\`\n`,
-	});
+	return vscode.workspace.openTextDocument({ language: "quarto", content: plainText(body) });
+}
+
+/**
+ * The same document, written to disk as a `.qmd`.
+ *
+ * An untitled document is neither named `.qmd` nor given the `quarto` language,
+ * which is contributed by another extension, so the cursor-driven path does not
+ * recognise it as a document this feature previews.
+ */
+async function plainFile(body = "#circle()"): Promise<vscode.TextDocument> {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "typst-preview-"));
+	const file = path.join(directory, "doc.qmd");
+	fs.writeFileSync(file, plainText(body));
+	return vscode.workspace.openTextDocument(vscode.Uri.file(file));
 }
 
 /** The position inside the one block of `plainDocument`. */
@@ -309,6 +329,55 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		assert.strictEqual(result?.blockIndex, 0);
 		assert.strictEqual(compiler.sources.length, 2);
 		assert.ok(compiler.sources[1].includes("##circle()"), `unexpected source: ${compiler.sources[1]}`);
+		controller.dispose();
+	});
+
+	test("Should drop a background result whose surface closed while it compiled", async () => {
+		// A compile runs for up to the timeout and the reader can close the panel
+		// meanwhile. Publishing anyway would have the surface build itself again,
+		// which reopens a panel the reader just closed.
+		const compiler = new StubCompiler();
+		let showing = true;
+		const { controller } = makeController(compiler, { hasSurface: () => showing });
+		const document = await plainFile();
+
+		// Driven through the cursor, which is what a background request follows.
+		await vscode.window.showTextDocument(document, { selection: new vscode.Range(INSIDE_BLOCK, INSIDE_BLOCK) });
+		await settle();
+		controller.refresh();
+		await settle();
+		assert.strictEqual(compiler.sources.length, 1);
+
+		const published: TypstPreviewUpdate[] = [];
+		const subscription = controller.onDidChangeResult((update) => published.push(update));
+		showing = false;
+		compiler.answer(0, { svg: SVG, stderr: "" });
+		await settle();
+
+		assert.deepStrictEqual(published, []);
+		subscription.dispose();
+		controller.dispose();
+	});
+
+	test("Should report a failure to read the context rather than rejecting", async () => {
+		// Every caller starts a request and does not await it, so a throw on the way
+		// to the compiler would be an unhandled rejection: no log line, no message,
+		// and a preview that looks inert.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const messages: string[] = [];
+		const controller = new TypstPreviewController({
+			hasSurface: () => true,
+			show: (message) => messages.push(message),
+			resolveBinary: () => Promise.reject(new Error("the probe failed")),
+			createCompiler: () => compiler,
+		});
+		const document = await plainDocument();
+
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+
+		assert.deepStrictEqual(messages, ["the probe failed"]);
+		assert.strictEqual(compiler.sources.length, 0);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import {
+	CACHE_LIMIT,
 	TypstPreviewController,
 	type TypstCompilerLike,
 	type TypstPreviewResult,
@@ -378,6 +379,30 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 
 		assert.deepStrictEqual(messages, ["the probe failed"]);
 		assert.strictEqual(compiler.sources.length, 0);
+		controller.dispose();
+	});
+
+	test("Should forget the result used longest ago once the cache is full", async () => {
+		// The cache is what makes an undone keystroke free, and it is bounded, so a
+		// long session cannot grow it without end. The first source compiled is the
+		// first one forgotten.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const documents = [];
+		for (let index = 0; index <= CACHE_LIMIT; index++) {
+			documents.push(await plainDocument(`#circle(radius: ${index}pt)`));
+		}
+
+		for (const document of documents) {
+			await nextResultFor(controller, document);
+		}
+		assert.strictEqual(compiler.sources.length, CACHE_LIMIT + 1);
+
+		// The last one asked for is still held, and the first one is not.
+		await nextResultFor(controller, documents[CACHE_LIMIT]);
+		assert.strictEqual(compiler.sources.length, CACHE_LIMIT + 1);
+		await nextResultFor(controller, documents[0]);
+		assert.strictEqual(compiler.sources.length, CACHE_LIMIT + 2);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -82,12 +82,19 @@ function nextResult(controller: TypstPreviewController, timeoutMs = 2000): Promi
 			subscription.dispose();
 			reject(new Error("no result was published"));
 		}, timeoutMs);
-		const subscription = controller.onDidChangeResult((result) => {
+		const subscription = controller.onDidChangeResult((update) => {
 			clearTimeout(timer);
 			subscription.dispose();
-			resolve(result);
+			resolve(update.result);
 		});
 	});
+}
+
+/** Edit the one block of a document, so the next request cannot answer from the cache. */
+async function editBlock(document: vscode.TextDocument, text = "#"): Promise<void> {
+	const edit = new vscode.WorkspaceEdit();
+	edit.insert(document.uri, new vscode.Position(3, 0), text);
+	assert.ok(await vscode.workspace.applyEdit(edit));
 }
 
 /** Let every pending microtask and timer of the current pass run. */
@@ -153,9 +160,9 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 
 		// The superseded compile answers last, and its result is stale.
 		const later: TypstPreviewResult[] = [];
-		const subscription = controller.onDidChangeResult((value) => {
-			if (value) {
-				later.push(value);
+		const subscription = controller.onDidChangeResult((update) => {
+			if (update.result) {
+				later.push(update.result);
 			}
 		});
 		compiler.answer(0, { svg: "<svg id='stale'/>", stderr: "" });
@@ -177,9 +184,7 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		await good;
 
 		// The block is edited, or the second request would answer from the cache.
-		const edit = new vscode.WorkspaceEdit();
-		edit.insert(document.uri, new vscode.Position(3, 0), "#");
-		assert.ok(await vscode.workspace.applyEdit(edit));
+		await editBlock(document);
 
 		const failed = nextResult(controller);
 		controller.request(document, INSIDE_BLOCK);
@@ -294,27 +299,34 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		const document = await plainDocument();
 
 		await nextResultFor(controller, document);
-		controller.clearCache();
+		// Edited, so the block on screen has a source the cache cannot answer, and
+		// there is no active editor at all for `refresh` to have followed.
+		await editBlock(document);
 		const again = nextResult(controller);
 		controller.recompile();
 		const result = await again;
 
 		assert.strictEqual(result?.blockIndex, 0);
-		assert.strictEqual(result?.asked, false);
 		assert.strictEqual(compiler.sources.length, 2);
+		assert.ok(compiler.sources[1].includes("##circle()"), `unexpected source: ${compiler.sources[1]}`);
 		controller.dispose();
 	});
 
-	test("Should compile again for a source the cache no longer holds", async () => {
+	test("Should say nothing is previewed when the document closes", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const { controller } = makeController(compiler);
 		const document = await plainDocument();
 
 		await nextResultFor(controller, document);
-		controller.clearCache();
-		await nextResultFor(controller, document);
+		assert.ok(controller.current());
 
-		assert.strictEqual(compiler.sources.length, 2);
+		const cleared = nextResult(controller);
+		// Closing a document is what the editor reports; the test asks for it by
+		// showing the document and then closing its editor.
+		await vscode.window.showTextDocument(document, { preview: true });
+		await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+		assert.strictEqual(await cleared, undefined);
+		assert.strictEqual(controller.current(), undefined);
 		controller.dispose();
 	});
 });

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -49,6 +49,14 @@ class StubCompiler implements TypstCompilerLike {
 		resolve(result);
 	}
 
+	/** Answer every compile asked for so far. */
+	answerAll(result: TypstCompileResult): void {
+		assert.ok(this.pending.length > 0, "no compile was asked for");
+		for (const resolve of this.pending) {
+			resolve(result);
+		}
+	}
+
 	dispose(): void {
 		this.disposed = true;
 	}
@@ -73,10 +81,14 @@ async function plainDocument(body = "#circle()"): Promise<vscode.TextDocument> {
  */
 async function plainFile(body = "#circle()"): Promise<vscode.TextDocument> {
 	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "typst-preview-"));
+	written.push(directory);
 	const file = path.join(directory, "doc.qmd");
 	fs.writeFileSync(file, plainText(body));
 	return vscode.workspace.openTextDocument(vscode.Uri.file(file));
 }
+
+/** The directories `plainFile` made, removed when the suite is over. */
+const written: string[] = [];
 
 /** The position inside the one block of `plainDocument`. */
 const INSIDE_BLOCK = new vscode.Position(3, 1);
@@ -124,6 +136,13 @@ function settle(delayMs = 50): Promise<void> {
 }
 
 suite("Typst Preview Lifecycle Test Suite", () => {
+	suiteTeardown(() => {
+		for (const directory of written) {
+			fs.rmSync(directory, { recursive: true, force: true });
+		}
+		written.length = 0;
+	});
+
 	test("Should publish the compiled image of the block under the cursor", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const { controller } = makeController(compiler);
@@ -343,16 +362,18 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		const document = await plainFile();
 
 		// Driven through the cursor, which is what a background request follows.
+		// Showing the document is itself an event the controller acts on, so the
+		// count is not pinned: what matters is that something is in flight.
 		await vscode.window.showTextDocument(document, { selection: new vscode.Range(INSIDE_BLOCK, INSIDE_BLOCK) });
 		await settle();
 		controller.refresh();
 		await settle();
-		assert.strictEqual(compiler.sources.length, 1);
+		assert.ok(compiler.sources.length >= 1, "a background compile is in flight");
 
 		const published: TypstPreviewUpdate[] = [];
 		const subscription = controller.onDidChangeResult((update) => published.push(update));
 		showing = false;
-		compiler.answer(0, { svg: SVG, stderr: "" });
+		compiler.answerAll({ svg: SVG, stderr: "" });
 		await settle();
 
 		assert.deepStrictEqual(published, []);
@@ -403,6 +424,36 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		assert.strictEqual(compiler.sources.length, CACHE_LIMIT + 1);
 		await nextResultFor(controller, documents[0]);
 		assert.strictEqual(compiler.sources.length, CACHE_LIMIT + 2);
+		controller.dispose();
+	});
+
+	test("Should keep the cache under its byte budget, and never empty", async () => {
+		// The count alone is not a bound: one compile may produce megabytes, so a
+		// handful of dense pages would hold far more than the count suggests. One
+		// entry is kept whatever its size, or a block larger than the whole budget
+		// would recompile on every request that already has its answer.
+		const big = `<svg>${"x".repeat(600)}</svg>`;
+		const compiler = new StubCompiler({ svg: big, stderr: "" });
+		const messages: string[] = [];
+		const controller = new TypstPreviewController({
+			hasSurface: () => true,
+			show: (message) => messages.push(message),
+			resolveBinary: () => Promise.resolve("/typst"),
+			createCompiler: () => compiler,
+			cacheLimitBytes: 1000,
+		});
+		const first = await plainDocument("#circle()");
+		const second = await plainDocument("#square()");
+
+		await nextResultFor(controller, first);
+		await nextResultFor(controller, second);
+		assert.strictEqual(compiler.sources.length, 2);
+
+		// Two images are over the budget, so the older one went and the newer stayed.
+		await nextResultFor(controller, second);
+		assert.strictEqual(compiler.sources.length, 2, "the newest entry survives the eviction");
+		await nextResultFor(controller, first);
+		assert.strictEqual(compiler.sources.length, 3, "the oldest entry was evicted");
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -1,0 +1,330 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import {
+	TypstPreviewController,
+	type TypstCompilerLike,
+	type TypstPreviewResult,
+} from "../../providers/typstPreview/typstPreviewController";
+import type { TypstCompileResult } from "../../providers/typstPreview/typstCompiler";
+
+/** An image that is never compiled, so nothing here spawns Typst. */
+const SVG = '<svg width="10pt" height="10pt"></svg>';
+
+/**
+ * A compiler whose every answer is given by the test.
+ *
+ * Continuous integration has no Quarto and must never spawn Typst, and the
+ * lifecycle is about which results are published rather than about what Typst
+ * writes, so nothing is lost by answering from a queue.
+ */
+class StubCompiler implements TypstCompilerLike {
+	readonly sources: string[] = [];
+	disposed = false;
+	/** The pending compiles, in the order they were asked for. */
+	private readonly pending: ((result: TypstCompileResult) => void)[] = [];
+	/** What an unanswered compile resolves to, when the test does not answer it. */
+	private readonly automatic: TypstCompileResult | undefined;
+
+	constructor(automatic?: TypstCompileResult) {
+		this.automatic = automatic;
+	}
+
+	compile(source: string): Promise<TypstCompileResult> {
+		this.sources.push(source);
+		if (this.automatic !== undefined) {
+			return Promise.resolve(this.automatic);
+		}
+		return new Promise<TypstCompileResult>((resolve) => this.pending.push(resolve));
+	}
+
+	/** Answer the compile that was asked for at `index`. */
+	answer(index: number, result: TypstCompileResult): void {
+		const resolve = this.pending[index];
+		assert.ok(resolve, `no compile was asked for at index ${index}`);
+		resolve(result);
+	}
+
+	dispose(): void {
+		this.disposed = true;
+	}
+}
+
+/** A document holding one plain Typst block, which needs nothing from disk. */
+async function plainDocument(body = "#circle()"): Promise<vscode.TextDocument> {
+	return vscode.workspace.openTextDocument({
+		language: "quarto",
+		content: `# Title\n\n\`\`\`typst\n${body}\n\`\`\`\n`,
+	});
+}
+
+/** The position inside the one block of `plainDocument`. */
+const INSIDE_BLOCK = new vscode.Position(3, 1);
+
+/** A controller wired to a stub, with no surface unless the test says otherwise. */
+function makeController(
+	compiler: TypstCompilerLike,
+	overrides: { hasSurface?: () => boolean; binary?: string | undefined } = {},
+): { controller: TypstPreviewController; messages: string[] } {
+	const messages: string[] = [];
+	const controller = new TypstPreviewController({
+		hasSurface: overrides.hasSurface ?? (() => true),
+		show: (message) => messages.push(message),
+		resolveBinary: () => Promise.resolve("binary" in overrides ? overrides.binary : "/typst"),
+		createCompiler: () => compiler,
+	});
+	return { controller, messages };
+}
+
+/** The next result the controller publishes, or a rejection when none arrives. */
+function nextResult(controller: TypstPreviewController, timeoutMs = 2000): Promise<TypstPreviewResult | undefined> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			subscription.dispose();
+			reject(new Error("no result was published"));
+		}, timeoutMs);
+		const subscription = controller.onDidChangeResult((result) => {
+			clearTimeout(timer);
+			subscription.dispose();
+			resolve(result);
+		});
+	});
+}
+
+/** Let every pending microtask and timer of the current pass run. */
+function settle(delayMs = 50): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+suite("Typst Preview Lifecycle Test Suite", () => {
+	test("Should publish the compiled image of the block under the cursor", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		const published = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		const result = await published;
+
+		assert.strictEqual(result?.svg, SVG);
+		assert.strictEqual(result?.error, undefined);
+		assert.strictEqual(result?.block.kind, "plain");
+		assert.ok(result?.header.includes("line 3"));
+		assert.strictEqual(controller.current()?.svg, SVG);
+		controller.dispose();
+	});
+
+	test("Should compile once for a source it has already compiled", async () => {
+		// A cache hit is what makes typing a character and undoing it free, and it
+		// is what lets a hover answer without waiting for a compile.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		const first = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await first;
+		const second = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await second;
+
+		assert.strictEqual(compiler.sources.length, 1);
+		controller.dispose();
+	});
+
+	test("Should discard the result of a superseded request", async () => {
+		// The compiler kills its own running child, so the older compile answers
+		// nothing in production. It is answered here anyway, because a result that
+		// arrives out of order must be dropped by the counter and not by luck.
+		const compiler = new StubCompiler();
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+		const other = await plainDocument("#square()");
+
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		controller.request(other, INSIDE_BLOCK);
+		await settle();
+		assert.strictEqual(compiler.sources.length, 2);
+
+		const published = nextResult(controller);
+		compiler.answer(1, { svg: SVG, stderr: "" });
+		const result = await published;
+		assert.ok(result?.svg);
+
+		// The superseded compile answers last, and its result is stale.
+		const later: TypstPreviewResult[] = [];
+		const subscription = controller.onDidChangeResult((value) => {
+			if (value) {
+				later.push(value);
+			}
+		});
+		compiler.answer(0, { svg: "<svg id='stale'/>", stderr: "" });
+		await settle();
+		assert.deepStrictEqual(later, []);
+		subscription.dispose();
+		controller.dispose();
+	});
+
+	test("Should keep the last good image behind a failure of the same block", async () => {
+		const compiler = new StubCompiler();
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		const good = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		compiler.answer(0, { svg: SVG, stderr: "" });
+		await good;
+
+		// The block is edited, or the second request would answer from the cache.
+		const edit = new vscode.WorkspaceEdit();
+		edit.insert(document.uri, new vscode.Position(3, 0), "#");
+		assert.ok(await vscode.workspace.applyEdit(edit));
+
+		const failed = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		compiler.answer(1, { stderr: "error: expected expression\n  ┌─ <stdin>:3:1\n  │\n" });
+		const result = await failed;
+
+		assert.strictEqual(result?.svg, SVG, "the last good image stays on screen");
+		assert.ok(result?.error?.startsWith("error"), `unexpected error text: ${result?.error}`);
+		controller.dispose();
+	});
+
+	test("Should drop the last good image when the block under the cursor changes", async () => {
+		// An error of one block over the image of another says nothing true about
+		// either of them.
+		const compiler = new StubCompiler();
+		const { controller } = makeController(compiler);
+		const document = await vscode.workspace.openTextDocument({
+			language: "quarto",
+			content: "```typst\n#circle()\n```\n\n```typst\n#square()\n```\n",
+		});
+
+		const good = nextResult(controller);
+		controller.request(document, new vscode.Position(1, 1));
+		await settle();
+		compiler.answer(0, { svg: SVG, stderr: "" });
+		await good;
+
+		const failed = nextResult(controller);
+		controller.request(document, new vscode.Position(5, 1));
+		await settle();
+		compiler.answer(1, { stderr: "error: expected expression\n  ┌─ <stdin>:3:1\n  │\n" });
+		const result = await failed;
+
+		assert.strictEqual(result?.svg, undefined);
+		assert.ok(result?.error);
+		controller.dispose();
+	});
+
+	test("Should not compile for a background change when no surface is showing", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler, { hasSurface: () => false });
+		const document = await plainDocument();
+
+		controller.refresh();
+		await settle();
+		assert.strictEqual(compiler.sources.length, 0);
+
+		// The command is not a background change, so it compiles anyway.
+		const published = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await published;
+		assert.strictEqual(compiler.sources.length, 1);
+		controller.dispose();
+	});
+
+	test("Should say once that there is no Typst binary", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller, messages } = makeController(compiler, { binary: undefined });
+		const document = await plainDocument();
+
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+
+		assert.strictEqual(messages.length, 1, `unexpected messages: ${messages.join(" | ")}`);
+		assert.ok(messages[0].includes("Typst binary"));
+		assert.strictEqual(compiler.sources.length, 0);
+		controller.dispose();
+	});
+
+	test("Should say where there is no block, and only when the user asked", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller, messages } = makeController(compiler);
+		const document = await plainDocument();
+
+		controller.request(document, new vscode.Position(0, 0));
+		await settle();
+		assert.strictEqual(messages.length, 1);
+		assert.ok(messages[0].includes("Typst block"));
+		assert.strictEqual(compiler.sources.length, 0);
+		controller.dispose();
+	});
+
+	test("Should leave nothing behind when it is disposed", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		const published = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await published;
+
+		controller.dispose();
+		assert.ok(compiler.disposed, "the compiler is disposed, which kills any live child");
+		assert.strictEqual(controller.current(), undefined);
+
+		// A request after disposal is not a second lifetime.
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		assert.strictEqual(compiler.sources.length, 1);
+	});
+
+	test("Should recompile the block on screen rather than the one under the cursor", async () => {
+		// A theme, a setting or a file the preview reads changing changes the image
+		// of the block being looked at. The cursor may have moved on to a document
+		// with no block in it at all, so following it would leave the surface
+		// showing an image nothing recompiled.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		await nextResultFor(controller, document);
+		controller.clearCache();
+		const again = nextResult(controller);
+		controller.recompile();
+		const result = await again;
+
+		assert.strictEqual(result?.blockIndex, 0);
+		assert.strictEqual(result?.asked, false);
+		assert.strictEqual(compiler.sources.length, 2);
+		controller.dispose();
+	});
+
+	test("Should compile again for a source the cache no longer holds", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		await nextResultFor(controller, document);
+		controller.clearCache();
+		await nextResultFor(controller, document);
+
+		assert.strictEqual(compiler.sources.length, 2);
+		controller.dispose();
+	});
+});
+
+/** Ask for one preview and wait for the result it publishes. */
+async function nextResultFor(
+	controller: TypstPreviewController,
+	document: vscode.TextDocument,
+): Promise<TypstPreviewResult | undefined> {
+	const published = nextResult(controller);
+	controller.request(document, INSIDE_BLOCK);
+	return published;
+}

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -1,6 +1,13 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { errorText, previewColour, previewTimeoutMs, themeKindOf } from "../../providers/typstPreview";
+import {
+	DEFAULT_DEBOUNCE_MS,
+	errorText,
+	previewColour,
+	previewDebounceMs,
+	previewTimeoutMs,
+	themeKindOf,
+} from "../../providers/typstPreview/typstPreviewController";
 import { DEFAULT_TIMEOUT_MS } from "../../providers/typstPreview/typstCompiler";
 
 /** One diagnostic as Typst writes it, on the two lines it uses. */
@@ -104,6 +111,25 @@ suite("Typst Preview Messages Test Suite", () => {
 				// A hand-edited `settings.json` reaches the compiler unchecked, and
 				// `setTimeout` accepts every one of these without complaining.
 				assert.strictEqual(previewTimeoutMs(value), expected);
+			});
+		}
+	});
+
+	suite("previewDebounceMs", () => {
+		const cases: [string, unknown, number][] = [
+			["a value inside the bounds", 500, 500],
+			["zero, which asks for a compile per keystroke", 0, 0],
+			["a negative value", -1, 0],
+			["a value above the upper bound", 999999, 5000],
+			["a value that is not a number at all", "slowly", DEFAULT_DEBOUNCE_MS],
+			["a value that is not finite", Number.NaN, DEFAULT_DEBOUNCE_MS],
+		];
+
+		for (const [description, value, expected] of cases) {
+			test(`Should handle ${description}`, () => {
+				// Zero is a value a reader can mean, unlike the compile timeout, so it
+				// is kept rather than raised to the lower bound.
+				assert.strictEqual(previewDebounceMs(value), expected);
 			});
 		}
 	});

--- a/src/test/suite/typstPreviewPanel.test.ts
+++ b/src/test/suite/typstPreviewPanel.test.ts
@@ -9,7 +9,66 @@ function extensionUri(): vscode.Uri {
 	return extension.extensionUri;
 }
 
+/** A panel whose posted messages the test can read. */
+function fakePanel(): { panel: TypstPreviewPanel; posted: { type: string }[]; ready: () => void } {
+	const posted: { type: string }[] = [];
+	const received = new vscode.EventEmitter<{ type?: string }>();
+	const disposed = new vscode.EventEmitter<void>();
+	const host = {
+		webview: {
+			options: {},
+			html: "",
+			cspSource: "vscode-webview:",
+			asWebviewUri: (uri: vscode.Uri) => uri,
+			onDidReceiveMessage: received.event,
+			postMessage: (message: { type: string }) => {
+				posted.push(message);
+				return Promise.resolve(true);
+			},
+		},
+		onDidDispose: disposed.event,
+		reveal: () => undefined,
+		dispose: () => disposed.fire(),
+	} as unknown as vscode.WebviewPanel;
+	return {
+		panel: new TypstPreviewPanel(host, extensionUri()),
+		posted,
+		ready: () => received.fire({ type: "initialized" }),
+	};
+}
+
 suite("Typst Preview Panel Test Suite", () => {
+	test("Should take the error away when the same image compiles again", () => {
+		// Typing breaks a block and undoing it restores the source, so the image is
+		// the one already on screen and is not sent again. The page hides its error
+		// when an image arrives, so skipping that message would leave a failure
+		// reported over a block that compiles.
+		const { panel, posted, ready } = fakePanel();
+		ready();
+		panel.show("<svg id='a'/>", "doc.qmd · line 3");
+		panel.showError("error at line 1, column 1 of the block: expected expression");
+		panel.show("<svg id='a'/>", "doc.qmd · line 3");
+
+		assert.deepStrictEqual(
+			posted.map((message) => message.type),
+			["image", "error", "image"],
+		);
+		panel.dispose();
+	});
+
+	test("Should not send an image the page is already showing", () => {
+		const { panel, posted, ready } = fakePanel();
+		ready();
+		panel.show("<svg id='a'/>", "doc.qmd · line 3");
+		panel.show("<svg id='a'/>", "doc.qmd · line 3");
+
+		assert.deepStrictEqual(
+			posted.map((message) => message.type),
+			["image"],
+		);
+		panel.dispose();
+	});
+
 	test("Should report that it was closed, once", () => {
 		const panel = TypstPreviewPanel.create(extensionUri());
 		let closed = 0;


### PR DESCRIPTION
The Typst preview only followed the cursor when the command was run, so an edit left a stale image on screen. One object now owns the block being previewed, the debouncing, the compiled image cache and every event subscription, and the panel is a thin renderer of what it publishes. The three surfaces of the next task read the same thing.

A compile runs only when a surface is showing a preview or the user asked for one, so a session that never opens the preview pays for the event subscriptions alone, and the file watchers are not created until a preview is asked for. Results are keyed by the source, the arguments and the binary, so an undone keystroke and a theme change that resolves to the same colour both answer without a process. The cache is bounded by entry count and by bytes.

An edit is followed at `quartoWizard.typstPreview.debounceMs`, contributed here. The cursor moving to another block is followed at 250 milliseconds, and saving compiles at once. A change that reaches neither the block on screen nor, for a raw block, any offset below it does not recompile at all.

Two caches sit behind that. The block scan is keyed on the document version. What a cell reads from disk is keyed on the front matter instead, because that is all the metadata chain reads of the document, so typing inside a cell no longer walks the project on every keystroke. A watcher over the metadata files, the brand, the `.typ` files and the installed extension manifests is what forgets the second one, and an unsaved edit to any of those forgets it as well.

A failure is rendered inside the panel with the last good image of the same block behind it, so the panel does not flash empty mid-edit. The image of a different block is not kept, because an error of one block over the image of another says nothing true about either.