### PR TITLE
feat: finish the Typst preview and document it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- feat: preview a Typst block from a Quarto document. The block under the cursor compiles with the Typst binary that ships inside Quarto, and the image is shown in a panel beside the editor or in a hover.
 - feat: publish the Lua reference validator of the v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/schema.lua`. The vocabulary and the validator carry the same version, and extensions can now resolve the module by URL. (#374)
 - feat: accept `uniqueItems` in a field descriptor. The Lua reference validator already enforced the keyword, and the meta-schema now allows it, so a schema that uses it passes both.
 - docs: add a reference page that describes how an extension loads and calls the Lua reference validator. The page separates the meta-schema, which validates a schema file while you write it, from the module, which validates document metadata during a render. (#383)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- feat: preview a Typst block from a Quarto document. The block under the cursor compiles with the Typst binary that ships inside Quarto, and the image is shown in a panel beside the editor or in a hover.
+- feat: preview a Typst block from a Quarto document. The block under the cursor compiles with the Typst binary that ships inside Quarto, and the image is shown in a panel beside the editor or in a hover. (#395)
 - feat: publish the Lua reference validator of the v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/schema.lua`. The vocabulary and the validator carry the same version, and extensions can now resolve the module by URL. (#374)
 - feat: accept `uniqueItems` in a field descriptor. The Lua reference validator already enforced the keyword, and the meta-schema now allows it, so a schema that uses it passes both.
 - docs: add a reference page that describes how an extension loads and calls the Lua reference validator. The page separates the meta-schema, which validates a schema file while you write it, from the module, which validates document metadata during a render. (#383)

--- a/docs/_sidebar-getting-started.yml
+++ b/docs/_sidebar-getting-started.yml
@@ -12,4 +12,5 @@ website:
             - getting-started/explorer-view.qmd
             - getting-started/using-templates.qmd
             - getting-started/reproducible-docs.qmd
+            - getting-started/typst-preview.qmd
             - getting-started/troubleshooting.qmd

--- a/docs/getting-started/index.qmd
+++ b/docs/getting-started/index.qmd
@@ -51,4 +51,5 @@ fig-alt='{{< meta alt-text.quick-start >}}'
 - [Explorer View](explorer-view.qmd) - Manage installed extensions from the sidebar.
 - [Using Templates](using-templates.qmd) - Quick-start documents with templates.
 - [Reproducible Documents](reproducible-docs.qmd) - Create reproducible examples for R, Python, or Julia.
+- [Typst Preview](typst-preview.qmd) - Compile the Typst block under the cursor and see the image beside the editor.
 - [Troubleshooting](troubleshooting.qmd) - Common issues and solutions.

--- a/docs/getting-started/typst-preview.qmd
+++ b/docs/getting-started/typst-preview.qmd
@@ -1,0 +1,109 @@
+---
+title: "Typst Preview"
+---
+
+Quarto Wizard compiles the Typst block under the cursor and shows the image beside the editor.
+The preview uses the Typst binary that ships inside Quarto, so it needs no other program.
+
+## Where the Preview Appears
+
+`quartoWizard.typstPreview.surface` selects the surface.
+
+- `panel` shows the image in a panel beside the editor.
+  The panel follows the cursor while it is open, and it scrolls, so a tall image is never cut.
+- `hover` shows the image when the pointer rests on a block.
+  A hover cannot scroll, so the image is scaled down to `quartoWizard.typstPreview.maxHeight`.
+- `off` shows no image, and offers no code lens.
+
+There is no preview inside the text of the document.
+The editor gives an extension no way to make a line taller.
+An image drawn after a block covers the lines below it.
+
+**Quarto Wizard: Preview Typst Block** opens the panel whatever the surface is.
+The one exception is `off`, where the command names the setting instead of opening anything.
+
+## The Authoring Loop
+
+1. Put the cursor inside a Typst block.
+2. Run **Quarto Wizard: Preview Typst Block**, or select the code lens above the block.
+3. Edit the block.
+   The preview follows the cursor, and it compiles again after each edit.
+
+`quartoWizard.typstPreview.debounceMs` sets how long an edit waits before the preview follows it.
+A failure is written inside the surface, over the last good image of the same block.
+The preview therefore does not go empty in the middle of an edit.
+The full compiler output goes to the Quarto Wizard log, which **Quarto Wizard: Show Quarto Wizard Log Output** opens.
+
+## The Three Kinds of Block
+
+Three fences are spelled almost the same way and behave differently.
+The code lens above each block says which kind it is.
+
+| Fence           | What Quarto does with it                                                                           | What the preview compiles                                      |
+| --------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| ` ```typst `    | Highlights it, and never executes it.                                                              | The body, under the preview's own page setup and colours.      |
+| ` ```{=typst} ` | Passes it to the Typst output untouched.                                                           | The body, under every raw block above it in the document.      |
+| ` ```{typst} `  | Executes it through the [typst-render](https://github.com/mcanouil/quarto-typst-render) extension. | The body, under the options and the colours of that extension. |
+
+A `{typst}` cell needs `typst-render` installed in the project.
+Without it the preview says so and shows nothing.
+A cell compiled with guessed options shows an image the render does not produce, which is worse than no image at all.
+
+The other two kinds need no extension.
+
+## Colours
+
+A plain block and a raw block take their colours from `quartoWizard.typstPreview.foreground` and `quartoWizard.typstPreview.background`.
+Both accept three forms.
+`auto` follows the editor theme, `none` writes no colour, and a Typst colour expression is written as it stands.
+
+A `{typst}` cell keeps the colour contract of `typst-render` instead, so the image matches the render rather than the editor.
+A cell that resolves a colour from a brand needs a side of the brand, and the preview follows the editor theme.
+The filter itself always takes the light side, so this is a deliberate difference.
+A `brand-mode` in the document wins over the theme.
+**Quarto Wizard: Switch Typst Preview Brand Mode** wins over both, and it holds until you switch back.
+The panel header always names the side in force.
+
+## Commands
+
+| Command                             | What it does                                                                      |
+| ----------------------------------- | --------------------------------------------------------------------------------- |
+| **Preview Typst Block**             | Compiles the block under the cursor and shows it in the panel.                    |
+| **Refresh Typst Preview**           | Compiles the preview again, and forgets every remembered image and metadata file. |
+| **Switch Typst Preview Brand Mode** | Shows the other side of the brand of a `{typst}` cell.                            |
+| **Copy Typst Preview Source**       | Copies the exact source the preview compiled to the clipboard.                    |
+
+**Copy Typst Preview Source** is what makes a failure reportable.
+Paste the source into a file, run `typst compile` on it, and the failure is reproduced outside Visual Studio Code.
+
+## Settings
+
+The [configuration reference](../reference/configuration.qmd) describes every setting.
+All of them are read for each folder, so a multi-root workspace can hold a different answer per folder.
+
+## What the Preview Does Not Do
+
+The preview is an authoring aid, and it is not a render.
+Two differences are known and are stated beside the image when they apply.
+
+- A raw block reaches Typst through the document template during a render.
+  The template contributes imports, show rules and set directives that the preview cannot apply, so a block that depends on them looks different.
+- The preview compiles one block on its own.
+  An import that a render resolves can therefore fail under the narrower root of the preview.
+
+These are out of scope for this version.
+
+- The `typst_define()` payload of the R and Python helpers.
+  It lives in metadata that a Quarto engine produces during a render, which the preview cannot see.
+- `output: asis`, whose cell inherits the page of the document being rendered.
+- `pages`, and any output of more than one page.
+  The preview shows the first page.
+- Native `format: html`.
+  The preview always compiles to SVG, whatever `format` says, and the panel header says so when the format is something else.
+
+## When the Preview Is Not Offered
+
+The preview runs a compiler over the content of the workspace, so it is off in an untrusted workspace.
+It is also off when Quarto is absent, or when the Quarto installation ships no Typst binary.
+In each case the extension says so once and offers no surface.
+The Quarto Wizard log records the path of every attempt.

--- a/docs/getting-started/typst-preview.qmd
+++ b/docs/getting-started/typst-preview.qmd
@@ -61,17 +61,20 @@ A `{typst}` cell keeps the colour contract of `typst-render` instead, so the ima
 A cell that resolves a colour from a brand needs a side of the brand, and the preview follows the editor theme.
 The filter itself always takes the light side, so this is a deliberate difference.
 A `brand-mode` in the document wins over the theme.
-**Quarto Wizard: Switch Typst Preview Brand Mode** wins over both, and it holds until you switch back.
+**Quarto Wizard: Switch Typst Preview Brand Mode** wins over both.
+The side you select holds until you select the other one, or until you refresh the preview.
 The panel header always names the side in force.
 
 ## Commands
 
-| Command                             | What it does                                                                      |
-| ----------------------------------- | --------------------------------------------------------------------------------- |
-| **Preview Typst Block**             | Compiles the block under the cursor and shows it in the panel.                    |
-| **Refresh Typst Preview**           | Compiles the preview again, and forgets every remembered image and metadata file. |
-| **Switch Typst Preview Brand Mode** | Shows the other side of the brand of a `{typst}` cell.                            |
-| **Copy Typst Preview Source**       | Copies the exact source the preview compiled to the clipboard.                    |
+| Command                             | What it does                                                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Preview Typst Block**             | Compiles the block under the cursor and shows it in the panel.                                         |
+| **Refresh Typst Preview**           | Compiles the preview again, and forgets the image, the metadata files and the brand mode you selected. |
+| **Switch Typst Preview Brand Mode** | Shows the other side of the brand of a `{typst}` cell.                                                 |
+| **Copy Typst Preview Source**       | Copies the exact source the preview compiled to the clipboard.                                         |
+
+The [commands reference](../reference/commands.qmd) lists the identifier of each one.
 
 **Copy Typst Preview Source** is what makes a failure reportable.
 Paste the source into a file, run `typst compile` on it, and the failure is reproduced outside Visual Studio Code.

--- a/docs/reference/commands.qmd
+++ b/docs/reference/commands.qmd
@@ -120,7 +120,7 @@ Compile the Typst block under the cursor and show it in a panel.
 
 **Command**: `Quarto Wizard: Refresh Typst Preview`
 
-Compile the Typst preview again, ignoring every remembered image and metadata file.
+Compile the Typst preview again, ignoring the image it holds, the metadata files it read and the brand mode you selected.
 
 ### Switch Typst Preview Brand Mode
 

--- a/docs/reference/commands.qmd
+++ b/docs/reference/commands.qmd
@@ -106,6 +106,34 @@ Authorise Quarto Wizard to use your VSCode GitHub session for private repositori
 
 Remove the manually set GitHub token and revoke Quarto Wizard's use of the VSCode GitHub session.
 
+## Typst Preview Commands
+
+Commands for the Typst block preview, available when a Quarto document is open.
+
+### Preview Typst Block
+
+**Command**: `Quarto Wizard: Preview Typst Block`
+
+Compile the Typst block under the cursor and show it in a panel.
+
+### Refresh Typst Preview
+
+**Command**: `Quarto Wizard: Refresh Typst Preview`
+
+Compile the Typst preview again, ignoring every remembered image and metadata file.
+
+### Switch Typst Preview Brand Mode
+
+**Command**: `Quarto Wizard: Switch Typst Preview Brand Mode`
+
+Show the other side of the brand in the Typst preview of a {typst} cell.
+
+### Copy Typst Preview Source
+
+**Command**: `Quarto Wizard: Copy Typst Preview Source`
+
+Copy the exact source the Typst preview compiled to the clipboard.
+
 ## Explorer View Commands
 
 These commands are available from the Explorer View context menu or toolbar.
@@ -199,6 +227,15 @@ For scripting or keybinding purposes, here are the internal command identifiers:
 | Set GitHub Token (Manual)   | `quartoWizard.setGitHubToken`          |
 | Sign In with GitHub Session | `quartoWizard.signInWithGitHubSession` |
 | Clear GitHub Authentication | `quartoWizard.clearGitHubAuth`         |
+
+### Typst Preview Commands
+
+| Display Name                    | Command ID                            |
+| ------------------------------- | ------------------------------------- |
+| Preview Typst Block             | `quartoWizard.previewTypstBlock`      |
+| Refresh Typst Preview           | `quartoWizard.refreshTypstPreview`    |
+| Switch Typst Preview Brand Mode | `quartoWizard.toggleTypstBrandMode`   |
+| Copy Typst Preview Source       | `quartoWizard.copyTypstPreviewSource` |
 
 ### Explorer View Commands
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 	"capabilities": {
 		"untrustedWorkspaces": {
 			"supported": "limited",
-			"description": "The Typst preview is off in an untrusted workspace, because it runs the Typst compiler over the content of the workspace. Every other feature works.",
+			"description": "The Typst preview is off in an untrusted workspace, because it runs the Typst compiler over the content of the workspace. The registry address and the two install confirmation settings are read from your own settings rather than from the workspace. Every other feature works.",
 			"restrictedConfigurations": [
 				"quartoWizard.registry.url",
 				"quartoWizard.ask.trustAuthors",
@@ -352,7 +352,7 @@
 				"shortTitle": "Refresh Typst",
 				"icon": "$(refresh)",
 				"category": "Quarto Wizard",
-				"description": "Compile the Typst preview again, ignoring every remembered image and metadata file."
+				"description": "Compile the Typst preview again, ignoring the image it holds, the metadata files it read and the brand mode you selected."
 			},
 			{
 				"command": "quartoWizard.toggleTypstBrandMode",

--- a/package.json
+++ b/package.json
@@ -536,18 +536,6 @@
 					"when": "editorLangId == quarto"
 				},
 				{
-					"command": "quartoWizard.refreshTypstPreview",
-					"when": "editorLangId == quarto"
-				},
-				{
-					"command": "quartoWizard.toggleTypstBrandMode",
-					"when": "editorLangId == quarto"
-				},
-				{
-					"command": "quartoWizard.copyTypstPreviewSource",
-					"when": "editorLangId == quarto"
-				},
-				{
 					"command": "quartoWizard.extensionsInstalled.openSource",
 					"when": "false"
 				},

--- a/package.json
+++ b/package.json
@@ -122,6 +122,17 @@
 		"webpack": "^5.109.0",
 		"webpack-cli": "^7.2.1"
 	},
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": "limited",
+			"description": "The Typst preview is off in an untrusted workspace, because it runs the Typst compiler over the content of the workspace. Every other feature works.",
+			"restrictedConfigurations": [
+				"quartoWizard.registry.url",
+				"quartoWizard.ask.trustAuthors",
+				"quartoWizard.ask.confirmInstall"
+			]
+		}
+	},
 	"contributes": {
 		"commands": [
 			{
@@ -334,6 +345,30 @@
 				"icon": "$(preview)",
 				"category": "Quarto Wizard",
 				"description": "Compile the Typst block under the cursor and show it in a panel."
+			},
+			{
+				"command": "quartoWizard.refreshTypstPreview",
+				"title": "Refresh Typst Preview",
+				"shortTitle": "Refresh Typst",
+				"icon": "$(refresh)",
+				"category": "Quarto Wizard",
+				"description": "Compile the Typst preview again, ignoring every remembered image and metadata file."
+			},
+			{
+				"command": "quartoWizard.toggleTypstBrandMode",
+				"title": "Switch Typst Preview Brand Mode",
+				"shortTitle": "Switch Brand Mode",
+				"icon": "$(color-mode)",
+				"category": "Quarto Wizard",
+				"description": "Show the other side of the brand in the Typst preview of a {typst} cell."
+			},
+			{
+				"command": "quartoWizard.copyTypstPreviewSource",
+				"title": "Copy Typst Preview Source",
+				"shortTitle": "Copy Typst Source",
+				"icon": "$(clippy)",
+				"category": "Quarto Wizard",
+				"description": "Copy the exact source the Typst preview compiled to the clipboard."
 			}
 		],
 		"submenus": [
@@ -394,6 +429,11 @@
 				{
 					"command": "quartoWizard.clearCache",
 					"group": "quartoWizard@6"
+				},
+				{
+					"command": "quartoWizard.previewTypstBlock",
+					"when": "editorLangId == quarto",
+					"group": "quartoWizard@7"
 				}
 			],
 			"view/title": [
@@ -493,6 +533,18 @@
 			"commandPalette": [
 				{
 					"command": "quartoWizard.previewTypstBlock",
+					"when": "editorLangId == quarto"
+				},
+				{
+					"command": "quartoWizard.refreshTypstPreview",
+					"when": "editorLangId == quarto"
+				},
+				{
+					"command": "quartoWizard.toggleTypstBrandMode",
+					"when": "editorLangId == quarto"
+				},
+				{
+					"command": "quartoWizard.copyTypstPreviewSource",
 					"when": "editorLangId == quarto"
 				},
 				{

--- a/scripts/docs-config.json
+++ b/scripts/docs-config.json
@@ -87,6 +87,17 @@
 			]
 		},
 		{
+			"id": "typst-preview",
+			"title": "Typst Preview Commands",
+			"description": "Commands for the Typst block preview, available when a Quarto document is open.",
+			"commands": [
+				"quartoWizard.previewTypstBlock",
+				"quartoWizard.refreshTypstPreview",
+				"quartoWizard.toggleTypstBrandMode",
+				"quartoWizard.copyTypstPreviewSource"
+			]
+		},
+		{
 			"id": "explorer",
 			"title": "Explorer View Commands",
 			"description": "These commands are available from the Explorer View context menu or toolbar.",

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { logMessage, showMessageWithLogs } from "../../utils/log";
-import { TypstPreviewController, type TypstPreviewUpdate } from "./typstPreviewController";
+import { TypstPreviewController, type PreviewTarget, type TypstPreviewUpdate } from "./typstPreviewController";
 import { TypstPreviewPanel } from "./typstPreviewPanel";
 import { TypstPreviewCodeLens } from "./typstPreviewCodeLens";
 import { TypstPreviewHover } from "./typstPreviewHover";
@@ -101,10 +101,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 	 * A code lens names the block it sits above, which is not the block the
 	 * cursor is in, so it passes both. Every other caller means the cursor.
 	 */
-	const resolveTarget = (
-		uri?: vscode.Uri,
-		at?: vscode.Position,
-	): { document: vscode.TextDocument; position: vscode.Position } | undefined => {
+	const resolveTarget = (uri?: vscode.Uri, at?: vscode.Position): PreviewTarget | undefined => {
 		if (uri !== undefined && at !== undefined) {
 			const named = vscode.workspace.textDocuments.find((open) => open.uri.toString() === uri.toString());
 			return named === undefined ? undefined : { document: named, position: at };

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -141,7 +141,7 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 			// reader runs this to report the image they are looking at, so a second
 			// assembly of a document that has moved on would answer a question they
 			// did not ask.
-			const shown = controller.current();
+			const shown = controller.shown();
 			if (shown === undefined) {
 				show("Preview a Typst block before copying the source it compiled.");
 				return;

--- a/src/providers/typstPreview/index.ts
+++ b/src/providers/typstPreview/index.ts
@@ -126,6 +126,34 @@ export function registerTypstPreview(context: vscode.ExtensionContext): void {
 		}),
 	);
 
+	context.subscriptions.push(
+		vscode.commands.registerCommand("quartoWizard.refreshTypstPreview", () => {
+			controller.reload();
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("quartoWizard.toggleTypstBrandMode", () => {
+			controller.toggleBrandMode();
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("quartoWizard.copyTypstPreviewSource", async () => {
+			// The source of what is on screen, and never a freshly assembled one. A
+			// reader runs this to report the image they are looking at, so a second
+			// assembly of a document that has moved on would answer a question they
+			// did not ask.
+			const shown = controller.current();
+			if (shown === undefined) {
+				show("Preview a Typst block before copying the source it compiled.");
+				return;
+			}
+			await vscode.env.clipboard.writeText(shown.source);
+			void showMessageWithLogs("The Typst preview source is on the clipboard.", "info");
+		}),
+	);
+
 	const codeLens = new TypstPreviewCodeLens(controller);
 	context.subscriptions.push(codeLens);
 	context.subscriptions.push(vscode.languages.registerCodeLensProvider(SELECTOR, codeLens));

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -271,12 +271,15 @@ export class TypstContextCache {
  *
  * @param cache - What a caller repeating the request remembers. A caller that
  *   asks once builds an empty one, which reads the document and the disk.
+ * @param brandMode - The side of the brand to resolve a cell against. Named by
+ *   the reader through the toggle command, and absent for every other caller.
  */
 export async function buildCompileRequest(
 	document: vscode.TextDocument,
 	position: vscode.Position,
 	header: string,
 	cache: TypstContextCache,
+	brandMode?: TypstBrandMode,
 ): Promise<CompileRequest | Unavailable> {
 	const text = document.getText();
 	// The whole list is kept, because a raw block compiles with the raw blocks
@@ -311,20 +314,22 @@ export async function buildCompileRequest(
 
 	// The one deliberate deviation from the filter. It always defaults to light,
 	// and the preview follows the editor theme instead, so a dark editor shows a
-	// dark image. An explicit `brand-mode:` still wins.
-	const brandMode = documentBrandMode(chain.metadata) ?? themeBrandMode();
+	// dark image. An explicit `brand-mode:` still wins, and a mode the reader
+	// named through the toggle command wins over both: it is a question about
+	// this preview, asked while looking at it.
+	const mode = brandMode ?? documentBrandMode(chain.metadata) ?? themeBrandMode();
 
 	const built = await buildCell(block, {
 		levels: chain.levels,
 		brand,
-		mode: brandMode,
+		mode,
 		readFile: (documentPath) => readTypstFile(documentPath, chain),
 	});
 	if (isUnavailable(built)) {
 		return built;
 	}
 
-	return { block, blockIndex, ...built, brandMode };
+	return { block, blockIndex, ...built, brandMode: mode };
 }
 
 /**

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -39,6 +39,15 @@ export const PINNED_TYPST_RENDER_VERSION = "0.21.0";
 /** The owner the extension is published under, beside its bare name. */
 const TYPST_RENDER_OWNER = "mcanouil";
 
+/**
+ * What a reader is told when there is no block to preview.
+ *
+ * Said from here when the cursor is in a document with no block under it, and
+ * from the controller when a command has no block to work on at all. One
+ * sentence for one situation, so a reword cannot leave half of it behind.
+ */
+export const NO_BLOCK_MESSAGE = "Put the cursor inside a Typst block to preview it.";
+
 /** Everything the compiler and the panel need for one block. */
 export interface CompileRequest {
 	/** The block under the cursor. */
@@ -288,7 +297,7 @@ export async function buildCompileRequest(
 	const blocks = cache.blocksOf(document, () => text);
 	const block = blockAtOffset(blocks, document.offsetAt(position));
 	if (block === undefined) {
-		return { unavailable: "Put the cursor inside a Typst block to preview it." };
+		return { unavailable: NO_BLOCK_MESSAGE };
 	}
 	const blockIndex = blocks.indexOf(block);
 

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { invalidatesPreview, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { blockAtOffset, invalidatesPreview, type TypstBlock } from "../../utils/typst/typstBlocks";
 import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { debounce, type DebouncedFunction } from "../../utils/debounce";
@@ -347,6 +347,20 @@ export class TypstPreviewController implements vscode.Disposable {
 	private requestVersion = 0;
 	private result: TypstPreviewResult | undefined;
 	/**
+	 * The preview the reader is following, which is not always the last compile.
+	 *
+	 * A hover compiles the block under the pointer and publishes it, and the panel
+	 * deliberately ignores that: a pointer rest is not a request to move the panel.
+	 * The panel therefore goes on showing the block it was given, and a command
+	 * that acted on the last compile would act on the block the pointer passed
+	 * over instead of the one on screen.
+	 *
+	 * It is absent until something other than a surface publishes, which is the
+	 * state of a session where the hover is the only surface. `shown()` falls back
+	 * to the last compile there, because that hover is the image the reader saw.
+	 */
+	private tracked: TypstPreviewResult | undefined;
+	/**
 	 * The side of the brand the reader asked to see, when they asked for one.
 	 *
 	 * It outranks both the document and the theme, and it holds until the reader
@@ -372,9 +386,20 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.wireEvents();
 	}
 
-	/** What is being previewed, which is what a surface renders. */
+	/** The last compile, which is what a surface that asked for one renders. */
 	current(): TypstPreviewResult | undefined {
 		return this.result;
+	}
+
+	/**
+	 * The preview the reader is looking at, which is what a command acts on.
+	 *
+	 * Not the same question as `current()`. A hover over another block is the last
+	 * compile without being what is on screen, and the three preview commands mean
+	 * the image the reader can see.
+	 */
+	shown(): TypstPreviewResult | undefined {
+		return this.tracked ?? this.result;
 	}
 
 	/**
@@ -444,7 +469,13 @@ export class TypstPreviewController implements vscode.Disposable {
 	 */
 	reload(): void {
 		const target = this.shownTarget() ?? cursorTarget();
-		if (target === undefined) {
+		// The block is what makes the command mean something, and the cursor can sit
+		// in a document that has none. Asking here rather than leaving it to the
+		// compile is what keeps the promise above true.
+		if (
+			target === undefined ||
+			blockAtOffset(this.blocksOf(target.document), target.document.offsetAt(target.position)) === undefined
+		) {
 			this.options.show(NO_BLOCK_MESSAGE);
 			return;
 		}
@@ -465,7 +496,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * would make this quietly wrong the day another kind gains one.
 	 */
 	toggleBrandMode(): void {
-		const shown = this.result;
+		const shown = this.shown();
 		if (shown?.block.kind !== "cell" || shown.brandMode === undefined) {
 			this.options.show("The brand mode applies to a `{typst}` cell. Preview one to switch the side it resolves.");
 			return;
@@ -500,7 +531,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * offsets it carried, which move under every edit above it.
 	 */
 	private shownTarget(): PreviewTarget | undefined {
-		const shown = this.result;
+		const shown = this.shown();
 		if (shown === undefined) {
 			return undefined;
 		}
@@ -558,6 +589,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.forgetImages();
 		this.contexts.clear();
 		this.result = undefined;
+		this.tracked = undefined;
 	}
 
 	/**
@@ -597,6 +629,7 @@ export class TypstPreviewController implements vscode.Disposable {
 			// tracking the document, so it looks live and is frozen.
 			if (this.result?.uri.toString() === document.uri.toString()) {
 				this.result = undefined;
+				this.tracked = undefined;
 				this.resultEmitter.fire({ reason: "background" });
 			}
 			if (reason === "asked") {
@@ -744,6 +777,11 @@ export class TypstPreviewController implements vscode.Disposable {
 			header: headerText(document, request),
 			error: compiled.svg === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};
+		if (reason !== "surface") {
+			// Every other reason is a block a surface will render, so it is what the
+			// reader ends up looking at.
+			this.tracked = this.result;
+		}
 		this.resultEmitter.fire({ result: this.result, reason });
 		return this.result;
 	}
@@ -895,6 +933,7 @@ export class TypstPreviewController implements vscode.Disposable {
 				this.contexts.forget(document.uri);
 				if (this.result?.uri.toString() === document.uri.toString()) {
 					this.result = undefined;
+					this.tracked = undefined;
 					this.resultEmitter.fire({ reason: "background" });
 				}
 			}),

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -8,9 +8,9 @@ import { debounce, type DebouncedFunction } from "../../utils/debounce";
 import { generateHashKey } from "../../utils/hash";
 import { logMessage } from "../../utils/log";
 import { isQmdFile } from "../../utils/metadataFilesRegistry";
-import type { TypstBrandMode } from "../../utils/typst/typstOptions";
+import { otherBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
 import { EXTENSION_MANIFEST_GLOB } from "../../utils/quartoProjectDiscovery";
-import { buildCompileRequest, TypstContextCache, type CompileRequest } from "./typstContext";
+import { buildCompileRequest, NO_BLOCK_MESSAGE, TypstContextCache, type CompileRequest } from "./typstContext";
 import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary, type TypstCompileResult } from "./typstCompiler";
 import { compileSettings, documentDelayOf, surfaceOf } from "./typstPreviewSettings";
 
@@ -259,7 +259,7 @@ function isRelevantDocument(document: vscode.TextDocument): boolean {
 }
 
 /** One place a preview can be compiled from. */
-interface PreviewTarget {
+export interface PreviewTarget {
 	document: vscode.TextDocument;
 	position: vscode.Position;
 }
@@ -414,11 +414,7 @@ export class TypstPreviewController implements vscode.Disposable {
 
 	/** Preview the block under the cursor again, because something changed. */
 	refresh(): void {
-		const target = cursorTarget();
-		if (target === undefined) {
-			return;
-		}
-		void this.attempt(target.document, target.position, "background");
+		this.compile(cursorTarget(), "background");
 	}
 
 	/**
@@ -428,57 +424,73 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * for. Those change the image of the block being looked at, and the cursor
 	 * may have moved on to a document with no block in it at all, so following the
 	 * cursor here would leave the panel showing an image nothing recompiled.
-	 *
-	 * The block is found again by its place in the document rather than by the
-	 * offsets it carried, which move under every edit above it.
 	 */
 	recompile(): void {
-		const target = this.shownTarget();
-		if (target === undefined) {
-			return;
-		}
-		void this.attempt(target.document, target.position, "background");
+		this.compile(this.shownTarget(), "background");
 	}
 
 	/**
 	 * Compile the preview again, forgetting everything remembered about it.
 	 *
 	 * This is the command a reader runs when the image and the document disagree,
-	 * so it outranks both caches: the images, which would answer an unchanged
-	 * source without compiling, and the metadata files, which are read from disk
-	 * and can be changed by something the watchers do not see, such as a checkout
-	 * or a build step.
+	 * so it outranks everything that would answer without compiling: the image
+	 * held for this source, the metadata files, which are read from disk and can
+	 * be changed by something the watchers do not see, such as a checkout or a
+	 * build step, and the brand mode the reader switched to by hand. It is
+	 * therefore also the way back to a preview that follows the theme again.
+	 *
+	 * Nothing is forgotten until there is something to compile, so a command run
+	 * with the cursor outside every block costs nothing.
 	 */
 	reload(): void {
-		this.contexts.forgetFiles();
-		this.forgetImages();
 		const target = this.shownTarget() ?? cursorTarget();
 		if (target === undefined) {
-			this.options.show("Put the cursor inside a Typst block to preview it.");
+			this.options.show(NO_BLOCK_MESSAGE);
 			return;
 		}
-		void this.attempt(target.document, target.position, "asked");
+		this.brandModeOverride = undefined;
+		this.contexts.forgetFiles();
+		this.compile(target, "asked", true);
 	}
 
 	/**
 	 * Show the other side of the brand of the cell being previewed.
 	 *
-	 * Only a cell has one. A plain block and a raw block carry the preview's own
-	 * theme header, so there is no second image to show and saying so is better
-	 * than a command that silently does nothing.
+	 * Only a cell resolves a colour from a brand. A plain block and a raw block
+	 * carry the preview's own theme header, so there is no second image to show
+	 * and saying so is better than a command that silently does nothing.
+	 *
+	 * The kind is what is asked, and not the presence of a mode: a result carries
+	 * a mode because it is a cell, and reading the answer off the optional field
+	 * would make this quietly wrong the day another kind gains one.
 	 */
 	toggleBrandMode(): void {
 		const shown = this.result;
-		if (shown?.brandMode === undefined) {
+		if (shown?.block.kind !== "cell" || shown.brandMode === undefined) {
 			this.options.show("The brand mode applies to a `{typst}` cell. Preview one to switch the side it resolves.");
 			return;
 		}
-		this.brandModeOverride = shown.brandMode === "dark" ? "light" : "dark";
 		const target = this.shownTarget();
 		if (target === undefined) {
 			return;
 		}
-		void this.attempt(target.document, target.position, "asked");
+		// Written only once the block to recompile is known, or the stored side
+		// would disagree with the image on screen until something else compiled.
+		this.brandModeOverride = otherBrandMode(shown.brandMode);
+		this.compile(target, "asked");
+	}
+
+	/**
+	 * Compile one target, when there is one.
+	 *
+	 * Every entry point differs in which block it means and why, and in nothing
+	 * else, so the tail they share lives here.
+	 */
+	private compile(target: PreviewTarget | undefined, reason: PreviewReason, fresh = false): void {
+		if (target === undefined) {
+			return;
+		}
+		void this.attempt(target.document, target.position, reason, fresh);
 	}
 
 	/**
@@ -513,8 +525,9 @@ export class TypstPreviewController implements vscode.Disposable {
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		reason: PreviewReason,
+		fresh = false,
 	): Promise<TypstPreviewResult | undefined> {
-		return this.run(document, position, reason).catch((error: unknown) => {
+		return this.run(document, position, reason, fresh).catch((error: unknown) => {
 			const message = getErrorMessage(error);
 			logMessage(`Typst preview: ${message}`, "error");
 			if (reason === "asked") {
@@ -554,11 +567,16 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * render it directly. Nothing published means nothing to render: a newer
 	 * request took over, the block cannot be previewed, or the machine cannot
 	 * compile at all.
+	 *
+	 * @param fresh - Compile even when this source has an image already. Only a
+	 *   reader asking for a refresh does, and it costs one process rather than
+	 *   the whole cache.
 	 */
 	private async run(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		reason: PreviewReason,
+		fresh: boolean,
 	): Promise<TypstPreviewResult | undefined> {
 		if (this.disposed || (reason === "background" && !this.options.hasSurface())) {
 			return undefined;
@@ -649,7 +667,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		// Joined on a character no argument and no Typst source carries, so two
 		// different triples cannot be spelled the same way.
 		const key = generateHashKey([binary, ...ARGV, request.source].join("\u0000"));
-		const held = this.cache.get(key);
+		const held = fresh ? undefined : this.cache.get(key);
 		if (held !== undefined) {
 			// Re-inserted so the least recently used entry is the first one, which is
 			// what the eviction below removes.
@@ -732,6 +750,12 @@ export class TypstPreviewController implements vscode.Disposable {
 
 	/** Remember one compile, and forget those used longest ago to make room. */
 	private remember(key: string, compiled: TypstCompileResult): void {
+		// A refresh compiles a source that is held already, so the entry it replaces
+		// is dropped first. Without this the budget would count the same image
+		// twice, and the replacement would keep the insertion place of the entry it
+		// replaced rather than becoming the most recently used one.
+		this.cacheBytes -= this.cache.get(key)?.svg?.length ?? 0;
+		this.cache.delete(key);
 		this.cache.set(key, compiled);
 		this.cacheBytes += compiled.svg?.length ?? 0;
 		// A `Map` iterates in insertion order and every hit is re-inserted, so the

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -627,11 +627,7 @@ export class TypstPreviewController implements vscode.Disposable {
 			// A surface open when the setting changed would otherwise hold the last
 			// image for good: nothing recompiles it, and nothing said it had stopped
 			// tracking the document, so it looks live and is frozen.
-			if (this.result?.uri.toString() === document.uri.toString()) {
-				this.result = undefined;
-				this.tracked = undefined;
-				this.resultEmitter.fire({ reason: "background" });
-			}
+			this.forgetDocument(document.uri);
 			if (reason === "asked") {
 				this.options.show(message);
 			}
@@ -700,7 +696,14 @@ export class TypstPreviewController implements vscode.Disposable {
 		// Joined on a character no argument and no Typst source carries, so two
 		// different triples cannot be spelled the same way.
 		const key = generateHashKey([binary, ...ARGV, request.source].join("\u0000"));
-		const held = fresh ? undefined : this.cache.get(key);
+		if (fresh) {
+			// Dropped now and not merely stepped over. A compile that another request
+			// supersedes never reaches `remember`, so an entry left here would be the
+			// image the reader asked to stop trusting, served again by the next
+			// request that assembles the same source.
+			this.forget(key);
+		}
+		const held = this.cache.get(key);
 		if (held !== undefined) {
 			// Re-inserted so the least recently used entry is the first one, which is
 			// what the eviction below removes.
@@ -764,8 +767,14 @@ export class TypstPreviewController implements vscode.Disposable {
 		// clearing the image would make the surface flash empty on almost every
 		// keystroke. The image of another block is not kept: an error of one block
 		// over the image of another says nothing true about either of them.
+		//
+		// The image kept is the one the reader can see, which is the tracked preview
+		// for everything but a hover. Comparing against the last compile instead
+		// would lose the image of the block on screen as soon as a pointer had
+		// rested on another one.
+		const previous = reason === "surface" ? this.result : this.shown();
 		const sameBlock =
-			this.result?.uri.toString() === document.uri.toString() && this.result?.blockIndex === request.blockIndex;
+			previous?.uri.toString() === document.uri.toString() && previous?.blockIndex === request.blockIndex;
 		this.result = {
 			uri: document.uri,
 			block: request.block,
@@ -773,7 +782,7 @@ export class TypstPreviewController implements vscode.Disposable {
 			version: compiledVersion,
 			source: request.source,
 			brandMode: request.brandMode,
-			svg: compiled.svg ?? (sameBlock ? this.result?.svg : undefined),
+			svg: compiled.svg ?? (sameBlock ? previous?.svg : undefined),
 			header: headerText(document, request),
 			error: compiled.svg === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};
@@ -786,14 +795,19 @@ export class TypstPreviewController implements vscode.Disposable {
 		return this.result;
 	}
 
-	/** Remember one compile, and forget those used longest ago to make room. */
-	private remember(key: string, compiled: TypstCompileResult): void {
-		// A refresh compiles a source that is held already, so the entry it replaces
-		// is dropped first. Without this the budget would count the same image
-		// twice, and the replacement would keep the insertion place of the entry it
-		// replaced rather than becoming the most recently used one.
+	/** Forget one compiled image, and the bytes it was counted for. */
+	private forget(key: string): void {
 		this.cacheBytes -= this.cache.get(key)?.svg?.length ?? 0;
 		this.cache.delete(key);
+	}
+
+	/** Remember one compile, and forget those used longest ago to make room. */
+	private remember(key: string, compiled: TypstCompileResult): void {
+		// Anything held for this source is dropped first. Without this the budget
+		// would count the same image twice, and the replacement would keep the
+		// insertion place of the entry it replaced rather than becoming the most
+		// recently used one.
+		this.forget(key);
 		this.cache.set(key, compiled);
 		this.cacheBytes += compiled.svg?.length ?? 0;
 		// A `Map` iterates in insertion order and every hit is re-inserted, so the
@@ -809,6 +823,29 @@ export class TypstPreviewController implements vscode.Disposable {
 			this.cacheBytes -= this.cache.get(oldest.value)?.svg?.length ?? 0;
 			this.cache.delete(oldest.value);
 		}
+	}
+
+	/**
+	 * Stop describing one document, and say so when something changed.
+	 *
+	 * The two held previews are asked separately. A hover moves the last compile
+	 * without moving the tracked one, so a document can be the subject of one and
+	 * not of the other, and testing only one of them would leave a surface showing
+	 * a document that is gone while looking live.
+	 */
+	private forgetDocument(uri: vscode.Uri): void {
+		const key = uri.toString();
+		const forgotten = this.result?.uri.toString() === key || this.tracked?.uri.toString() === key;
+		if (!forgotten) {
+			return;
+		}
+		if (this.result?.uri.toString() === key) {
+			this.result = undefined;
+		}
+		if (this.tracked?.uri.toString() === key) {
+			this.tracked = undefined;
+		}
+		this.resultEmitter.fire({ result: this.shown(), reason: "background" });
 	}
 
 	/** Forget every compiled image, so the next request compiles again. */
@@ -931,11 +968,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.disposables.push(
 			vscode.workspace.onDidCloseTextDocument((document) => {
 				this.contexts.forget(document.uri);
-				if (this.result?.uri.toString() === document.uri.toString()) {
-					this.result = undefined;
-					this.tracked = undefined;
-					this.resultEmitter.fire({ reason: "background" });
-				}
+				this.forgetDocument(document.uri);
 			}),
 		);
 

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -686,10 +686,6 @@ export class TypstPreviewController implements vscode.Disposable {
 			);
 			return undefined;
 		}
-		if (stale()) {
-			return undefined;
-		}
-
 		// The image is decided by the source, the arguments and the binary, and by
 		// nothing else. Two documents that assemble to the same source share the
 		// entry, which is what makes an undone keystroke free.
@@ -697,12 +693,17 @@ export class TypstPreviewController implements vscode.Disposable {
 		// different triples cannot be spelled the same way.
 		const key = generateHashKey([binary, ...ARGV, request.source].join("\u0000"));
 		if (fresh) {
-			// Dropped now and not merely stepped over. A compile that another request
+			// Dropped now and not merely stepped over, and before this request is
+			// asked whether it is still wanted. A compile that another request
 			// supersedes never reaches `remember`, so an entry left here would be the
-			// image the reader asked to stop trusting, served again by the next
-			// request that assembles the same source.
+			// image the reader asked to stop trusting, served back to them by the
+			// request that superseded the refresh.
 			this.forget(key);
 		}
+		if (stale()) {
+			return undefined;
+		}
+
 		const held = this.cache.get(key);
 		if (held !== undefined) {
 			// Re-inserted so the least recently used entry is the first one, which is
@@ -845,7 +846,10 @@ export class TypstPreviewController implements vscode.Disposable {
 		if (this.tracked?.uri.toString() === key) {
 			this.tracked = undefined;
 		}
-		this.resultEmitter.fire({ result: this.shown(), reason: "background" });
+		// The tracked preview and nothing else. Falling back to the last compile
+		// here would hand a surface the block a pointer rested on, which is how the
+		// panel would move to a document the reader never asked it to show.
+		this.resultEmitter.fire({ result: this.tracked, reason: "background" });
 	}
 
 	/** Forget every compiled image, so the next request compiles again. */
@@ -1042,7 +1046,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * block moves its end by what was typed, and the cursor moves with it.
 	 */
 	private movedBlock(event: vscode.TextEditorSelectionChangeEvent): boolean {
-		const shown = this.result;
+		const shown = this.shown();
 		if (shown === undefined || shown.uri.toString() !== event.textEditor.document.uri.toString()) {
 			return true;
 		}
@@ -1069,7 +1073,10 @@ export class TypstPreviewController implements vscode.Disposable {
 		if (!isRelevantDocument(event.document) || event.contentChanges.length === 0) {
 			return;
 		}
-		const shown = this.result;
+		// The block on screen, and not the last compile: a hover moves the last
+		// compile to another block, and asking about that one would read an edit
+		// inside the block the reader is looking at as an edit that changes nothing.
+		const shown = this.shown();
 		if (shown !== undefined && shown.uri.toString() === event.document.uri.toString()) {
 			// A raw block compiles under every raw block above it, so it is sensitive
 			// to a change at any lower offset and not only to one inside it. An edit

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -8,6 +8,7 @@ import { debounce, type DebouncedFunction } from "../../utils/debounce";
 import { generateHashKey } from "../../utils/hash";
 import { logMessage } from "../../utils/log";
 import { isQmdFile } from "../../utils/metadataFilesRegistry";
+import type { TypstBrandMode } from "../../utils/typst/typstOptions";
 import { EXTENSION_MANIFEST_GLOB } from "../../utils/quartoProjectDiscovery";
 import { buildCompileRequest, TypstContextCache, type CompileRequest } from "./typstContext";
 import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary, type TypstCompileResult } from "./typstCompiler";
@@ -100,6 +101,16 @@ export interface TypstPreviewResult {
 	 * and the place of the block alone cannot say that.
 	 */
 	version: number;
+	/**
+	 * The whole source that was sent to the compiler.
+	 *
+	 * Carried so that the copy command can hand a reader the exact text Typst
+	 * read, which is what turns a preview failure into something reproducible
+	 * outside the editor.
+	 */
+	source: string;
+	/** The side of the brand a cell resolved with, absent for the other two kinds. */
+	brandMode?: TypstBrandMode;
 	/** The image on screen, which is the last one this block compiled to. */
 	svg?: string;
 	/** What the surface says about the block beside the image. */
@@ -247,6 +258,21 @@ function isRelevantDocument(document: vscode.TextDocument): boolean {
 	return document.languageId === "quarto" || isQmdFile(document.fileName);
 }
 
+/** One place a preview can be compiled from. */
+interface PreviewTarget {
+	document: vscode.TextDocument;
+	position: vscode.Position;
+}
+
+/** Where the cursor is, when it is in a document this feature previews. */
+function cursorTarget(): PreviewTarget | undefined {
+	const editor = vscode.window.activeTextEditor;
+	if (editor === undefined || !isRelevantDocument(editor.document)) {
+		return undefined;
+	}
+	return { document: editor.document, position: editor.selection.active };
+}
+
 /**
  * The metadata files a preview reads beside the block.
  *
@@ -320,6 +346,16 @@ export class TypstPreviewController implements vscode.Disposable {
 	/** Rises with every request, so a result that arrives out of order is dropped. */
 	private requestVersion = 0;
 	private result: TypstPreviewResult | undefined;
+	/**
+	 * The side of the brand the reader asked to see, when they asked for one.
+	 *
+	 * It outranks both the document and the theme, and it holds until the reader
+	 * asks for the other side, so moving between the cells of a document keeps
+	 * showing the side they are reading. Nothing else writes it, and the header
+	 * names the side in force, so the preview never differs from the render
+	 * without saying so.
+	 */
+	private brandModeOverride: TypstBrandMode | undefined;
 	/** Said once per session, because an unavailable machine stays unavailable. */
 	private reportedUnavailable = false;
 	private disposed = false;
@@ -378,11 +414,11 @@ export class TypstPreviewController implements vscode.Disposable {
 
 	/** Preview the block under the cursor again, because something changed. */
 	refresh(): void {
-		const editor = vscode.window.activeTextEditor;
-		if (editor === undefined || !isRelevantDocument(editor.document)) {
+		const target = cursorTarget();
+		if (target === undefined) {
 			return;
 		}
-		void this.attempt(editor.document, editor.selection.active, "background");
+		void this.attempt(target.document, target.position, "background");
 	}
 
 	/**
@@ -397,19 +433,71 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * offsets it carried, which move under every edit above it.
 	 */
 	recompile(): void {
+		const target = this.shownTarget();
+		if (target === undefined) {
+			return;
+		}
+		void this.attempt(target.document, target.position, "background");
+	}
+
+	/**
+	 * Compile the preview again, forgetting everything remembered about it.
+	 *
+	 * This is the command a reader runs when the image and the document disagree,
+	 * so it outranks both caches: the images, which would answer an unchanged
+	 * source without compiling, and the metadata files, which are read from disk
+	 * and can be changed by something the watchers do not see, such as a checkout
+	 * or a build step.
+	 */
+	reload(): void {
+		this.contexts.forgetFiles();
+		this.forgetImages();
+		const target = this.shownTarget() ?? cursorTarget();
+		if (target === undefined) {
+			this.options.show("Put the cursor inside a Typst block to preview it.");
+			return;
+		}
+		void this.attempt(target.document, target.position, "asked");
+	}
+
+	/**
+	 * Show the other side of the brand of the cell being previewed.
+	 *
+	 * Only a cell has one. A plain block and a raw block carry the preview's own
+	 * theme header, so there is no second image to show and saying so is better
+	 * than a command that silently does nothing.
+	 */
+	toggleBrandMode(): void {
+		const shown = this.result;
+		if (shown?.brandMode === undefined) {
+			this.options.show("The brand mode applies to a `{typst}` cell. Preview one to switch the side it resolves.");
+			return;
+		}
+		this.brandModeOverride = shown.brandMode === "dark" ? "light" : "dark";
+		const target = this.shownTarget();
+		if (target === undefined) {
+			return;
+		}
+		void this.attempt(target.document, target.position, "asked");
+	}
+
+	/**
+	 * The block on screen, as a position in the document holding it.
+	 *
+	 * The block is found again by its place in the document rather than by the
+	 * offsets it carried, which move under every edit above it.
+	 */
+	private shownTarget(): PreviewTarget | undefined {
 		const shown = this.result;
 		if (shown === undefined) {
-			return;
+			return undefined;
 		}
 		const document = vscode.workspace.textDocuments.find((open) => open.uri.toString() === shown.uri.toString());
 		if (document === undefined) {
-			return;
+			return undefined;
 		}
 		const block = this.blocksOf(document)[shown.blockIndex];
-		if (block === undefined) {
-			return;
-		}
-		void this.attempt(document, document.positionAt(block.fenceStart), "background");
+		return block === undefined ? undefined : { document, position: document.positionAt(block.fenceStart) };
 	}
 
 	/**
@@ -529,7 +617,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		// so an edit landing during a compile would stamp the new version onto the
 		// old image, and a surface trusting the stamp would serve it as current.
 		const compiledVersion = document.version;
-		const request = await buildCompileRequest(document, position, header, this.contexts);
+		const request = await buildCompileRequest(document, position, header, this.contexts, this.brandModeOverride);
 		if (stale()) {
 			return undefined;
 		}
@@ -632,6 +720,8 @@ export class TypstPreviewController implements vscode.Disposable {
 			block: request.block,
 			blockIndex: request.blockIndex,
 			version: compiledVersion,
+			source: request.source,
+			brandMode: request.brandMode,
 			svg: compiled.svg ?? (sameBlock ? this.result?.svg : undefined),
 			header: headerText(document, request),
 			error: compiled.svg === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -302,6 +302,45 @@ suite("Typst Preview Context Test Suite", () => {
 			}
 		});
 
+		test("Should resolve a cell against the brand mode the caller names", async () => {
+			// The toggle command is how a reader sees the other side of a brand, so the
+			// mode it names wins over the theme the preview would follow by itself.
+			const directory = project(true);
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), CELL);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const cache = new TypstContextCache();
+				const light = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, cache, "light");
+				const dark = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, cache, "dark");
+				assert.ok(!isUnavailable(light));
+				assert.ok(!isUnavailable(dark));
+				assert.strictEqual(light.brandMode, "light");
+				assert.strictEqual(dark.brandMode, "dark");
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should let the named brand mode win over the one the document sets", async () => {
+			// A document that names a mode still gets the other side on request. The
+			// toggle would otherwise do nothing at all in exactly the documents whose
+			// author thought about the brand.
+			const directory = project(true);
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), `---\nbrand-mode: light\n---\n\n${CELL}`);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const cache = new TypstContextCache();
+				const followed = await buildCompileRequest(document, new vscode.Position(6, 0), HEADER, cache);
+				const named = await buildCompileRequest(document, new vscode.Position(6, 0), HEADER, cache, "dark");
+				assert.ok(!isUnavailable(followed));
+				assert.ok(!isUnavailable(named));
+				assert.strictEqual(followed.brandMode, "light");
+				assert.strictEqual(named.brandMode, "dark");
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
 		test("Should assemble a cell when typst-render is installed with no owner", async () => {
 			const directory = project("ownerless");
 			try {

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -441,6 +441,28 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should keep every other remembered image when the preview is reloaded", async () => {
+		// The reader asked for one block. Emptying the cache would make every other
+		// block previewed in the session spawn Typst again on the next hover.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const first = await plainDocument("#circle()");
+		const second = await plainDocument("#square()");
+
+		await nextResultFor(controller, first);
+		await nextResultFor(controller, second);
+		assert.strictEqual(compiler.sources.length, 2);
+
+		const reloaded = nextResult(controller);
+		controller.reload();
+		await reloaded;
+		assert.strictEqual(compiler.sources.length, 3, "the block on screen compiled again");
+
+		await nextResultFor(controller, first);
+		assert.strictEqual(compiler.sources.length, 3, "the other block answered from the cache");
+		controller.dispose();
+	});
+
 	test("Should say what to do when a reload has nothing to compile", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const { controller, messages } = makeController(compiler);

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -407,6 +407,70 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should carry the source it compiled, so a reader can reproduce it", async () => {
+		// This is what makes the feature supportable: the exact source pasted into
+		// `typst compile` reproduces the failure outside the editor.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		const result = await nextResultFor(controller, document);
+
+		assert.strictEqual(result?.source, compiler.sources[0]);
+		assert.ok(result?.source.includes("#circle()"));
+		controller.dispose();
+	});
+
+	test("Should compile again from nothing when the preview is reloaded", async () => {
+		// A reload is what a reader runs when the image and the document disagree,
+		// so it has to outrank the cache. Answering the same block from the cache
+		// would make the command look as though it did nothing.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument();
+
+		await nextResultFor(controller, document);
+		assert.strictEqual(compiler.sources.length, 1);
+
+		const again = nextResult(controller);
+		controller.reload();
+		const result = await again;
+
+		assert.strictEqual(result?.blockIndex, 0);
+		assert.strictEqual(compiler.sources.length, 2);
+		controller.dispose();
+	});
+
+	test("Should say what to do when a reload has nothing to compile", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller, messages } = makeController(compiler);
+
+		controller.reload();
+		await settle();
+
+		assert.strictEqual(compiler.sources.length, 0);
+		assert.strictEqual(messages.length, 1);
+		assert.ok(messages[0].includes("Typst block"), `unexpected message: ${messages[0]}`);
+		controller.dispose();
+	});
+
+	test("Should refuse to switch the brand mode of a block that has none", async () => {
+		// Only a cell resolves colours against a brand. A plain block carries the
+		// preview's own header, so there is no other side to show.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller, messages } = makeController(compiler);
+		const document = await plainDocument();
+
+		await nextResultFor(controller, document);
+		controller.toggleBrandMode();
+		await settle();
+
+		assert.strictEqual(compiler.sources.length, 1);
+		assert.strictEqual(messages.length, 1);
+		assert.ok(messages[0].includes("cell"), `unexpected message: ${messages[0]}`);
+		controller.dispose();
+	});
+
 	test("Should drop a background result whose surface closed while it compiled", async () => {
 		// A compile runs for up to the timeout and the reader can close the panel
 		// meanwhile. Publishing anyway would have the surface build itself again,

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -373,6 +373,33 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		}
 	});
 
+	test("Should take away a tracked preview a hover has moved off", async () => {
+		// The tracked preview and the last compile can be two documents, because a
+		// hover compiles a block the panel does not follow. Asking only about the
+		// last compile would leave the panel holding an image of a document that
+		// stopped being previewed: live-looking and frozen, with nothing said.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await plainDocument("#circle()");
+		const hovered = await plainDocument("#square()");
+		const config = vscode.workspace.getConfiguration("quartoWizard.typstPreview");
+
+		await nextResultFor(controller, document);
+		await controller.preview(hovered, INSIDE_BLOCK);
+		assert.strictEqual(controller.current()?.uri.toString(), hovered.uri.toString());
+		assert.strictEqual(controller.shown()?.uri.toString(), document.uri.toString());
+
+		const cleared = nextResult(controller);
+		await config.update("surface", "off", vscode.ConfigurationTarget.Global);
+		try {
+			await cleared;
+			assert.notStrictEqual(controller.shown()?.uri.toString(), document.uri.toString());
+		} finally {
+			await config.update("surface", undefined, vscode.ConfigurationTarget.Global);
+			controller.dispose();
+		}
+	});
+
 	test("Should say once that there is no Typst binary", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const { controller, messages } = makeController(compiler, { binary: undefined });
@@ -497,6 +524,67 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 
 		await nextResultFor(controller, first);
 		assert.strictEqual(compiler.sources.length, 3, "the other block answered from the cache");
+		controller.dispose();
+	});
+
+	test("Should not answer from an image a reload asked it to stop trusting", async () => {
+		// A reload compiles again, and another request can supersede that compile
+		// before it is remembered. The entry the reader distrusted would otherwise
+		// still be there for the next request that assembles the same source.
+		const compiler = new StubCompiler();
+		const { controller } = makeController(compiler);
+		const document = await plainDocument("#circle()");
+		const other = await plainDocument("#square()");
+
+		const first = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		compiler.answer(0, { svg: SVG, stderr: "" });
+		await first;
+
+		controller.reload();
+		await settle();
+		controller.request(other, INSIDE_BLOCK);
+		await settle();
+		assert.strictEqual(compiler.sources.length, 3);
+		compiler.answerAll({ svg: SVG, stderr: "" });
+		await settle();
+
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		assert.strictEqual(compiler.sources.length, 4, "the superseded entry was not left behind");
+		controller.dispose();
+	});
+
+	test("Should keep the image of the tracked block when a hover compiled another", async () => {
+		// A hover moves the last compile without moving what the panel shows. A
+		// failure of the block on screen has to keep that block's own last image,
+		// or the panel flashes empty on almost every keystroke after a pointer rest.
+		const compiler = new StubCompiler();
+		const { controller } = makeController(compiler);
+		const document = await plainDocument("#circle()");
+		const other = await plainDocument("#square()");
+
+		const shown = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		compiler.answer(0, { svg: SVG, stderr: "" });
+		await shown;
+
+		const hovered = controller.preview(other, INSIDE_BLOCK);
+		await settle();
+		compiler.answer(1, { svg: '<svg width="20pt" height="20pt"></svg>', stderr: "" });
+		await hovered;
+
+		await editBlock(document);
+		const failed = nextResult(controller);
+		controller.request(document, INSIDE_BLOCK);
+		await settle();
+		compiler.answer(2, { stderr: "error: <stdin>:2:0: unexpected" });
+		const result = await failed;
+
+		assert.strictEqual(result?.svg, SVG);
+		assert.ok(result?.error);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -11,6 +11,9 @@ import {
 	type TypstPreviewUpdate,
 } from "../../providers/typstPreview/typstPreviewController";
 import type { TypstCompileResult } from "../../providers/typstPreview/typstCompiler";
+import { invalidateProjectRoots, setProjectRoots } from "../../utils/projectRootsRegistry";
+import { invalidateInstalledExtensionsCache } from "../../utils/installedExtensionsCache";
+import { makeFolder, makeRoot } from "./projectFixtures";
 
 /** An image that is never compiled, so nothing here spawns Typst. */
 const SVG = '<svg width="10pt" height="10pt"></svg>';
@@ -90,8 +93,34 @@ async function plainFile(body = "#circle()"): Promise<vscode.TextDocument> {
 /** The directories `plainFile` made, removed when the suite is over. */
 const written: string[] = [];
 
+/**
+ * A document holding one `{typst}` cell, in a project that has `typst-render`.
+ *
+ * A cell is the only kind that resolves a colour from a brand, so it is the only
+ * kind the brand mode command works on, and the install gate refuses a cell in a
+ * project without the extension.
+ */
+async function cellDocument(): Promise<vscode.TextDocument> {
+	const directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-preview-cell-")));
+	written.push(directory);
+	fs.writeFileSync(path.join(directory, "_quarto.yml"), "project:\n  type: default\n");
+	const manifest = path.join(directory, "_extensions", "mcanouil", "typst-render");
+	fs.mkdirSync(manifest, { recursive: true });
+	fs.writeFileSync(
+		path.join(manifest, "_extension.yml"),
+		"title: Typst Render\nauthor: Mickael Canouil\nversion: 0.21.0\ncontributes:\n  filters:\n    - typst-render.lua\n",
+	);
+	const file = path.join(directory, "doc.qmd");
+	fs.writeFileSync(file, "```{typst}\n//| margin: 2mm\n#circle()\n```\n");
+	setProjectRoots([makeRoot(makeFolder("typst-preview-cell", directory))]);
+	return vscode.workspace.openTextDocument(vscode.Uri.file(file));
+}
+
 /** The position inside the one block of `plainDocument`. */
 const INSIDE_BLOCK = new vscode.Position(3, 1);
+
+/** The position inside the one cell of `cellDocument`. */
+const INSIDE_CELL = new vscode.Position(2, 0);
 
 /** A controller wired to a stub, with a surface showing unless the test says otherwise. */
 function makeController(
@@ -137,6 +166,14 @@ function settle(delayMs = 50): Promise<void> {
 }
 
 suite("Typst Preview Lifecycle Test Suite", () => {
+	teardown(() => {
+		// `cellDocument` names a project root and reads the extensions installed in
+		// it, and both are held for the session, so a later test would read the
+		// project of an earlier one.
+		invalidateProjectRoots();
+		invalidateInstalledExtensionsCache();
+	});
+
 	suiteTeardown(() => {
 		for (const directory of written) {
 			fs.rmSync(directory, { recursive: true, force: true });
@@ -476,6 +513,28 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should switch a cell to the other side of the brand, and back on a reload", async () => {
+		// The command exists so that a reader can see the side the editor theme is
+		// not showing. The side has to reach the compiled source, and a refresh has
+		// to be the way back to following the theme.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await cellDocument();
+
+		const first = await nextResultFor(controller, document, INSIDE_CELL);
+		const mode = first?.brandMode;
+		assert.ok(mode === "light" || mode === "dark", `unexpected mode: ${String(mode)}`);
+
+		const switched = nextResult(controller);
+		controller.toggleBrandMode();
+		assert.strictEqual((await switched)?.brandMode, mode === "dark" ? "light" : "dark");
+
+		const reloaded = nextResult(controller);
+		controller.reload();
+		assert.strictEqual((await reloaded)?.brandMode, mode, "a reload follows the theme again");
+		controller.dispose();
+	});
+
 	test("Should refuse to switch the brand mode of a block that has none", async () => {
 		// Only a cell resolves colours against a brand. A plain block carries the
 		// preview's own header, so there is no other side to show.
@@ -620,8 +679,9 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 async function nextResultFor(
 	controller: TypstPreviewController,
 	document: vscode.TextDocument,
+	position: vscode.Position = INSIDE_BLOCK,
 ): Promise<TypstPreviewResult | undefined> {
 	const published = nextResult(controller);
-	controller.request(document, INSIDE_BLOCK);
+	controller.request(document, position);
 	return published;
 }

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -122,6 +122,23 @@ const INSIDE_BLOCK = new vscode.Position(3, 1);
 /** The position inside the one cell of `cellDocument`. */
 const INSIDE_CELL = new vscode.Position(2, 0);
 
+/** The position inside the second block of `twoBlockFile`. */
+const SECOND_BLOCK = new vscode.Position(7, 1);
+
+/**
+ * A `.qmd` on disk holding two plain blocks.
+ *
+ * Written to disk and not left untitled, because the cursor-driven path only
+ * follows a document the editor calls a Quarto one.
+ */
+async function twoBlockFile(): Promise<vscode.TextDocument> {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), "typst-preview-two-"));
+	written.push(directory);
+	const file = path.join(directory, "doc.qmd");
+	fs.writeFileSync(file, "# Title\n\n```typst\n#circle()\n```\n\n```typst\n#square()\n```\n");
+	return vscode.workspace.openTextDocument(vscode.Uri.file(file));
+}
+
 /** A controller wired to a stub, with a surface showing unless the test says otherwise. */
 function makeController(
 	compiler: TypstCompilerLike,
@@ -166,12 +183,15 @@ function settle(delayMs = 50): Promise<void> {
 }
 
 suite("Typst Preview Lifecycle Test Suite", () => {
-	teardown(() => {
+	teardown(async () => {
 		// `cellDocument` names a project root and reads the extensions installed in
 		// it, and both are held for the session, so a later test would read the
 		// project of an earlier one.
 		invalidateProjectRoots();
 		invalidateInstalledExtensionsCache();
+		// An editor left open is a cursor the next test did not put anywhere, and
+		// the cursor is what several of these paths follow.
+		await vscode.commands.executeCommand("workbench.action.closeAllEditors");
 	});
 
 	suiteTeardown(() => {
@@ -392,12 +412,35 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		const cleared = nextResult(controller);
 		await config.update("surface", "off", vscode.ConfigurationTarget.Global);
 		try {
-			await cleared;
+			// Nothing, and not the block the pointer rested on: a surface given that
+			// would move to a document the reader never asked it to show.
+			assert.strictEqual(await cleared, undefined);
 			assert.notStrictEqual(controller.shown()?.uri.toString(), document.uri.toString());
 		} finally {
 			await config.update("surface", undefined, vscode.ConfigurationTarget.Global);
 			controller.dispose();
 		}
+	});
+
+	test("Should follow an edit of the block on screen after a hover over another", async () => {
+		// The edit gate asks whether the change reaches the block being previewed.
+		// Asking about the last compile instead reads an edit inside the block on
+		// screen as an edit of a block that is nowhere, and leaves the panel stale.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await twoBlockFile();
+
+		await vscode.window.showTextDocument(document, { selection: new vscode.Range(INSIDE_BLOCK, INSIDE_BLOCK) });
+		await settle(500);
+		// A pointer rest on the second block, which the panel does not follow.
+		await controller.preview(document, SECOND_BLOCK);
+		const before = compiler.sources.length;
+
+		await editBlock(document);
+		await settle(700);
+
+		assert.ok(compiler.sources.length > before, "the edited block compiled again");
+		controller.dispose();
 	});
 
 	test("Should say once that there is no Typst binary", async () => {

--- a/src/utils/typst/typstBrand.ts
+++ b/src/utils/typst/typstBrand.ts
@@ -14,7 +14,7 @@
  * defaults are not read, because no colour option needs them.
  */
 
-import { mapping } from "./typstOptions";
+import { mapping, otherBrandMode } from "./typstOptions";
 import type { BrandColourReader, TypstBrandMode } from "./typstOptions";
 
 /**
@@ -362,7 +362,7 @@ export function brandDictionary(brand: Brand, mode: TypstBrandMode): string {
 		const value = read(side, role);
 		return value === undefined || value === "" ? undefined : hexOnly(value);
 	};
-	const other = mode === "light" ? "dark" : "light";
+	const other = otherBrandMode(mode);
 	const colours: Record<string, string> = {};
 	for (const role of BRAND_COLOUR_ROLES) {
 		const hex = hexAt(mode, role) ?? hexAt(other, role);

--- a/src/utils/typst/typstOptions.ts
+++ b/src/utils/typst/typstOptions.ts
@@ -18,6 +18,17 @@ import type { TypstBlock } from "./typstBlocks";
 export type TypstBrandMode = "light" | "dark";
 
 /**
+ * The other side of a light and dark pair.
+ *
+ * A pair has two sides, so falling back and switching are the same question,
+ * and the answer lives beside the type rather than being spelled out at each
+ * place that asks it.
+ */
+export function otherBrandMode(mode: TypstBrandMode): TypstBrandMode {
+	return mode === "light" ? "dark" : "light";
+}
+
+/**
  * A colour option after the global pass.
  *
  * A string is one colour for both modes. The pair form comes from a `light:`
@@ -177,8 +188,7 @@ export function resolveColourValue(config: TypstColour | undefined, mode: TypstB
 	if (config === undefined) {
 		return undefined;
 	}
-	const other = mode === "light" ? "dark" : "light";
-	return config[mode] ?? config[other];
+	return config[mode] ?? config[otherBrandMode(mode)];
 }
 
 /**

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -222,8 +222,8 @@ function cellBody(body: string): string {
  * One part is deliberately not emitted. `build_define_preamble` at `:946-949`
  * writes the `typst_define()` payload of the R and Python helpers, which the
  * preview cannot see: it lives in metadata Quarto's engine produces during a
- * render. A cell that reads it is out of scope for the first version and the
- * panel says so.
+ * render. A cell that reads it is out of scope for the first version, which
+ * `docs/getting-started/typst-preview.qmd` states.
  */
 function buildCellSource(block: TypstBlock, options: CellSourceOptions): AssembledSource {
 	const above = [


### PR DESCRIPTION
This completes the Typst block preview and gives it a user-facing page.

Three commands join **Preview Typst Block**. **Refresh Typst Preview** compiles the block on screen again, ignoring the image held for that source, the metadata files read from disk and any brand mode the reader selected, so it is also the way back to a preview that follows the editor theme. **Switch Typst Preview Brand Mode** shows the other side of the brand of a `{typst}` cell, which the panel header names. **Copy Typst Preview Source** puts the exact source the preview compiled on the clipboard, which is what makes a failure reproducible outside the editor.

`capabilities.untrustedWorkspaces` states what the extension does in a workspace the user has not trusted. The preview is off there, because it runs the Typst compiler over the content of the workspace, and the registry address and the two install confirmation settings are read from the user's own settings rather than from the workspace.

`docs/getting-started/typst-preview.qmd` covers the authoring loop, the difference between the three fence kinds, the colour and brand rules, and the limits: the preview always compiles to SVG, a raw block is compiled without the document template, and the `typst_define()` payload, `output: asis`, `pages` and native `format: html` are out of scope for this version. The commands reference page is regenerated from the contributions.

The controller now keeps the preview the reader is looking at apart from the last compile. A hover compiles the block under the pointer and the panel deliberately does not follow it, so every command, the edit gate and the last good image kept behind a failure read the block on screen instead.

The feature gets one changelog entry, which is the first one it has: the earlier pull requests of this work added none.