### PR TITLE
fix: reject a document with no front matter body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
 - fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 15 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
 - fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`. (#385)
+- fix: find a Typst block written between two `---` lines that open no front matter. A document whose second line is blank or is itself `---` has no front matter, which is the rule Pandoc applies. (#397)
 
 ## 3.2.0 (2026-08-02)
 

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -145,6 +145,17 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(found[0].body, "#a\n");
 		});
 
+		test("Should find a block above a delimiter that opens no front matter", () => {
+			// A blank second line means the document has no front matter, so the two
+			// `---` lines are thematic breaks. Reading them as delimiters started the
+			// scan below the second one and hid the block between them.
+			const text = "---\n\n```typst\n#a\n```\n\n---\n";
+			const found = findTypstBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].kind, "plain");
+			assert.strictEqual(found[0].body, "#a\n");
+		});
+
 		test("Should report offsets and line numbers past the front matter", () => {
 			const text = "---\ntitle: t\n---\n\n```typst\n#a\n```\n";
 			const found = findTypstBlocks(text);

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -756,11 +756,19 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
 		});
 
-		test("should handle empty front matter", () => {
+		test("should return undefined when the second line closes the block", () => {
 			const text = "---\n---\nbody\n";
-			const range = getYamlFrontMatterRange(text);
-			assert.ok(range);
-			assert.strictEqual(text.slice(range!.start, range!.end), "---\n---");
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
+		});
+
+		test("should return undefined when the second line is blank", () => {
+			const text = "---\n\n---\nbody\n";
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
+		});
+
+		test("should return undefined for a two line document", () => {
+			const text = "---\ntitle: Test";
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
 		});
 
 		test("should return undefined for empty text", () => {

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -71,6 +71,12 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.strictEqual(isInYamlRegion(lines, 1, "quarto"), false);
 		});
 
+		test("Should return false when a CRLF second line is blank", () => {
+			// Lines split on "\n" keep their carriage return, which `trim` removes.
+			const lines = ["---\r", "\r", "---\r", "Body text\r"];
+			assert.strictEqual(isInYamlRegion(lines, 1, "quarto"), false);
+		});
+
 		test("Should return false when no delimiters exist at all", () => {
 			const lines = ["Some text", "More text"];
 			assert.strictEqual(isInYamlRegion(lines, 0, "quarto"), false);
@@ -775,6 +781,18 @@ suite("YAML Position Utils Test Suite", () => {
 
 		test("should return undefined for a two line document", () => {
 			const text = "---\ntitle: Test";
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
+		});
+
+		test("should return undefined when a CRLF second line is blank", () => {
+			// The guard reads the second line through `trim`, which removes the
+			// carriage return, so a CRLF document follows the same rule.
+			const text = "---\r\n\r\n---\r\nbody\r\n";
+			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
+		});
+
+		test("should return undefined when a CRLF second line closes the block", () => {
+			const text = "---\r\n---\r\nbody\r\n";
 			assert.strictEqual(getYamlFrontMatterRange(text), undefined);
 		});
 

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -64,6 +64,13 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.strictEqual(isInYamlRegion(lines, 1, "quarto"), false);
 		});
 
+		test("Should return false when the second line is blank", () => {
+			// The two `---` lines are thematic breaks, so the blank line between
+			// them is body text and not front matter.
+			const lines = ["---", "", "---", "Body text"];
+			assert.strictEqual(isInYamlRegion(lines, 1, "quarto"), false);
+		});
+
 		test("Should return false when no delimiters exist at all", () => {
 			const lines = ["Some text", "More text"];
 			assert.strictEqual(isInYamlRegion(lines, 0, "quarto"), false);

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -487,6 +487,11 @@ export function isInCodeBlockRange(ranges: TextRange[], offset: number): boolean
  * delimiter line (the trailing newline is excluded), so that any `{...}`
  * content within is fully enclosed.
  *
+ * A document of fewer than three lines has no front matter, and neither has one
+ * whose second line is blank or is itself a delimiter.  Pandoc reads the two
+ * `---` lines of `---\n\n---` as thematic breaks, so a range there would hide
+ * every block a reader writes between them.
+ *
  * @param text - The full document text.
  * @returns The front-matter range, or `undefined` when no closed front
  *   matter is present.
@@ -499,6 +504,18 @@ export function getYamlFrontMatterRange(text: string): TextRange | undefined {
 
 	const firstLineEnd = firstNewline > 0 && text[firstNewline - 1] === "\r" ? firstNewline - 1 : firstNewline;
 	if (text.slice(0, firstLineEnd).trim() !== "---") {
+		return undefined;
+	}
+
+	const secondLineStart = firstNewline + 1;
+	const secondNewline = text.indexOf("\n", secondLineStart);
+	if (secondNewline === -1) {
+		return undefined;
+	}
+	const secondLineEnd =
+		secondNewline > secondLineStart && text[secondNewline - 1] === "\r" ? secondNewline - 1 : secondNewline;
+	const secondLine = text.slice(secondLineStart, secondLineEnd).trim();
+	if (secondLine.length === 0 || secondLine === "---") {
 		return undefined;
 	}
 

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -479,6 +479,23 @@ export function isInCodeBlockRange(ranges: TextRange[], offset: number): boolean
 }
 
 /**
+ * Whether the second line of a document lets front matter open.
+ *
+ * Pandoc reads `---` followed by a blank line, or by a second delimiter, as two
+ * thematic breaks rather than as front matter.  `getYamlFrontMatterRange` and
+ * `isInYamlRegion` both apply this rule, so one document never gets two answers
+ * about where its front matter is.
+ *
+ * @param secondLine - The second line of the document, with or without its
+ *   carriage return.
+ * @returns True when front matter can open on the line above.
+ */
+function opensFrontMatter(secondLine: string): boolean {
+	const content = secondLine.trim();
+	return content.length > 0 && content !== "---";
+}
+
+/**
  * Find the YAML front-matter range in a Quarto document.
  *
  * The front matter must open with `---` on line 0 and close with another
@@ -502,29 +519,27 @@ export function getYamlFrontMatterRange(text: string): TextRange | undefined {
 		return undefined;
 	}
 
-	const firstLineEnd = firstNewline > 0 && text[firstNewline - 1] === "\r" ? firstNewline - 1 : firstNewline;
-	if (text.slice(0, firstLineEnd).trim() !== "---") {
+	// `trim` removes a trailing carriage return, so a CRLF document needs no
+	// line ending of its own here or in the closing scan below.
+	if (text.slice(0, firstNewline).trim() !== "---") {
 		return undefined;
 	}
 
-	const secondLineStart = firstNewline + 1;
-	const secondNewline = text.indexOf("\n", secondLineStart);
+	const secondNewline = text.indexOf("\n", firstNewline + 1);
 	if (secondNewline === -1) {
 		return undefined;
 	}
-	const secondLineEnd =
-		secondNewline > secondLineStart && text[secondNewline - 1] === "\r" ? secondNewline - 1 : secondNewline;
-	const secondLine = text.slice(secondLineStart, secondLineEnd).trim();
-	if (secondLine.length === 0 || secondLine === "---") {
+	if (!opensFrontMatter(text.slice(firstNewline + 1, secondNewline))) {
 		return undefined;
 	}
 
-	let lineStart = firstNewline + 1;
+	// The second line is neither blank nor a delimiter, so the closing scan
+	// starts below it rather than reading that line a second time.
+	let lineStart = secondNewline + 1;
 	while (lineStart <= text.length) {
 		const nextNewline = text.indexOf("\n", lineStart);
 		const lineEnd = nextNewline === -1 ? text.length : nextNewline;
-		const trimmedEnd = lineEnd > lineStart && text[lineEnd - 1] === "\r" ? lineEnd - 1 : lineEnd;
-		if (text.slice(lineStart, trimmedEnd).trim() === "---") {
+		if (text.slice(lineStart, lineEnd).trim() === "---") {
 			return { start: 0, end: lineEnd };
 		}
 		if (nextNewline === -1) {
@@ -594,7 +609,11 @@ export function isInYamlRegion(lines: string[], lineIndex: number, languageId: s
 	}
 
 	// For quarto / qmd files the YAML front matter must start with --- on line 0.
-	if (lines.length === 0 || lines[0].trim() !== "---") {
+	if (lines.length < 3 || lines[0].trim() !== "---") {
+		return false;
+	}
+
+	if (!opensFrontMatter(lines[1])) {
 		return false;
 	}
 


### PR DESCRIPTION
`getYamlFrontMatterRange` accepted any document that opened with `---` and carried a later `---` line, so `---\n\n---` reported a range for a document that has none. Pandoc reads those two lines as thematic breaks. `findTypstBlocks` starts its scan below the reported range, so the spurious range hid every Typst block written between the two lines, with no message that said why.

The rule now matches `partitionYamlFrontMatter` in `quarto-core`: a document of fewer than three lines has no front matter, and neither has one whose second line is blank or is itself a delimiter.

`isInYamlRegion` scanned for the delimiters on its own and would have kept the old answer, so completion and hover would have offered YAML keys on a line that the block scanner reads as body text. Both readers now call `opensFrontMatter`, so one document gets one answer.

Two smaller changes came with that. The closing scan starts below the second line rather than reading it a second time, and the carriage return handling is dropped from all three line reads, because `trim` already removes one. The tests cover a CRLF document on both entry points, so nothing rests on that silently.