### PR TITLE
ci: report a verdict when no cell uploads a summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,6 +300,13 @@ jobs:
       - name: Generate consolidated summary
         shell: bash
         run: |
+          # `download-artifact` creates no directory when it matches nothing,
+          # and this step runs under `-e -o pipefail`, so a `find` over a
+          # missing directory ends the step before it prints anything. A
+          # pull request that changes no build input uploads no artifact,
+          # which is the case this job exists to report on.
+          mkdir -p job-summaries
+
           echo "# 🚀 Quarto Wizard Build & Test Results" >> ${GITHUB_STEP_SUMMARY}
           echo "" >> ${GITHUB_STEP_SUMMARY}
 


### PR DESCRIPTION
The `summary` job is the required check, and it failed on the first pull request that changed no build input, which is #398. `build` and `lua` skipped as #386 intended, and then `summary` reported a failure, so the pull request was blocked.

`actions/download-artifact` logs `Total of 0 artifact(s) downloaded` and creates no directory when its pattern matches nothing. The step runs under `-e` with `pipefail`, so the first `find` over the missing directory exits 1 and ends the step before it prints a single line. A skipped build matrix uploads no artifact, so this is the exact case the job was widened to report on.

The directory is now created first. The table then reports no cells, the Lua row falls back to the job result, and the verdict comes from the job results, which the loop below already reads and which already treat a skipped job as not a failure.

The failure and the fix were both reproduced locally under `bash -e -o pipefail`. `actionlint` reports the same 25 findings before and after this change, so it adds none.

One of those 25 is worth a separate look: the step interpolates `github.event.pull_request.title` straight into the script, which actionlint flags as a script injection risk. That is untouched here.