### PR TITLE
fix: compile a Typst preview under the root a render uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 15 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
 - fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`. (#385)
 - fix: find a Typst block written between two `---` lines that open no front matter. A document whose second line is blank or is itself `---` has no front matter, which is the rule Pandoc applies. (#397)
+- fix: compile a Typst preview under the root a render uses, so a block that reads a file beside its own document no longer fails. A `{typst}` cell also compiles with the `root`, `font-path`, `package-path` and `input` values of the `typst-render` extension. (#401)
 
 ## 3.2.0 (2026-08-02)
 

--- a/docs/getting-started/typst-preview.qmd
+++ b/docs/getting-started/typst-preview.qmd
@@ -65,6 +65,21 @@ A `brand-mode` in the document wins over the theme.
 The side you select holds until you select the other one, or until you refresh the preview.
 The panel header always names the side in force.
 
+## Paths
+
+The preview sends the block to Typst through standard input.
+A path inside the block therefore resolves against the compile root, and not against the file that holds the block.
+
+The preview uses the root that a render uses.
+For a `{typst}` cell, the root is the `root` value under `extensions.typst-render`.
+Its default is the directory of the document.
+A value that starts with `/` resolves from the project root.
+A plain block and a raw block always use the directory of the document.
+
+A `{typst}` cell also compiles with the `font-path`, the `package-path` and the `input` values of the extension.
+A font path or a package path that starts with `/` resolves from the project root.
+Every other value stays relative, and the compile runs from the project root.
+
 ## Commands
 
 | Command                             | What it does                                                                                           |
@@ -92,7 +107,7 @@ Two differences are known and are stated beside the image when they apply.
 - A raw block reaches Typst through the document template during a render.
   The template contributes imports, show rules and set directives that the preview cannot apply, so a block that depends on them looks different.
 - The preview compiles one block on its own.
-  An import that a render resolves can therefore fail under the narrower root of the preview.
+  A plain block that uses a value from another block therefore fails.
 
 These are out of scope for this version.
 

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -3,6 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getQuartoVersionInfo } from "../../services/quartoVersion";
+import type { TypstCommand } from "../../utils/typst/typstCli";
 import { logMessage } from "../../utils/log";
 
 /**
@@ -186,11 +187,11 @@ export class TypstCompiler {
 	 * because a failed compile is a result the caller renders. Rejects when the
 	 * run was cancelled, superseded, timed out, oversized, or never started.
 	 *
-	 * @param cwd - The directory to run from. It is what a relative `--font-path`
-	 *   resolves against, the way one under a render resolves against the
-	 *   directory Quarto runs Typst from.
+	 * The command carries the directory to run from beside its arguments. That is
+	 * what a relative `--font-path` resolves against, the way one under a render
+	 * resolves against the directory Quarto runs Typst from.
 	 */
-	compile(source: string, argv: string[], token: vscode.CancellationToken, cwd?: string): Promise<TypstCompileResult> {
+	compile(source: string, command: TypstCommand, token: vscode.CancellationToken): Promise<TypstCompileResult> {
 		if (this.disposed) {
 			return Promise.reject(new TypstCompileFailure("The Typst compiler is disposed."));
 		}
@@ -200,7 +201,7 @@ export class TypstCompiler {
 		const maxOutputBytes = this.options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
 
 		return new Promise<TypstCompileResult>((resolve, reject) => {
-			const child = spawn(this.binary, argv, { shell: false, windowsHide: true, cwd });
+			const child = spawn(this.binary, command.argv, { shell: false, windowsHide: true, cwd: command.cwd });
 
 			const output: Buffer[] = [];
 			let outputBytes = 0;

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -185,8 +185,12 @@ export class TypstCompiler {
 	 * Resolves for any run Typst finished, whether or not it produced an image,
 	 * because a failed compile is a result the caller renders. Rejects when the
 	 * run was cancelled, superseded, timed out, oversized, or never started.
+	 *
+	 * @param cwd - The directory to run from. It is what a relative `--font-path`
+	 *   resolves against, the way one under a render resolves against the
+	 *   directory Quarto runs Typst from.
 	 */
-	compile(source: string, argv: string[], token: vscode.CancellationToken): Promise<TypstCompileResult> {
+	compile(source: string, argv: string[], token: vscode.CancellationToken, cwd?: string): Promise<TypstCompileResult> {
 		if (this.disposed) {
 			return Promise.reject(new TypstCompileFailure("The Typst compiler is disposed."));
 		}
@@ -196,7 +200,7 @@ export class TypstCompiler {
 		const maxOutputBytes = this.options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
 
 		return new Promise<TypstCompileResult>((resolve, reject) => {
-			const child = spawn(this.binary, argv, { shell: false, windowsHide: true });
+			const child = spawn(this.binary, argv, { shell: false, windowsHide: true, cwd });
 
 			const output: Buffer[] = [];
 			let outputBytes = 0;

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,4 +1,3 @@
-import * as path from "node:path";
 import * as vscode from "vscode";
 import * as semver from "semver";
 import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
@@ -10,13 +9,14 @@ import {
 	type Unavailable,
 } from "../../utils/typst/typstSource";
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
-import { buildBlockArgv, compileCwd, type TypstPaths } from "../../utils/typst/typstCli";
+import { buildTypstCommand, type TypstCommand } from "../../utils/typst/typstCli";
 import { EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
 import { getInstalledExtensionsCached } from "../../utils/installedExtensionsCache";
 import { getYamlFrontMatterRange } from "../../utils/yamlPosition";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
 import { logMessage } from "../../utils/log";
-import { readBrand, readMetadataChain, readSourceText, resolveQuartoPath, type MetadataChain } from "./typstMetadata";
+import { documentDirectoryOf, readBrand, readMetadataChain, readSourceText, type MetadataChain } from "./typstMetadata";
+import { resolveQuartoPath } from "../../utils/typst/typstPaths";
 
 /**
  * One document and one position turned into a compile.
@@ -71,15 +71,13 @@ export interface CompileRequest {
 	/** The whole source to send to the compiler. */
 	source: string;
 	/**
-	 * The command line the block compiles under.
+	 * The command the block compiles under.
 	 *
 	 * Per document rather than one constant, because the compile root is what
 	 * every relative path the block reads resolves against, and it is a property
 	 * of where the document sits.
 	 */
-	argv: string[];
-	/** The directory the compile runs from, absent when there is none to name. */
-	cwd?: string;
+	command: TypstCommand;
 	/** How many lines sit above the block body, for mapping a diagnostic back. */
 	injectedLines: number;
 	/** The brand mode a cell resolved with, absent for the other two kinds. */
@@ -319,19 +317,11 @@ export async function buildCompileRequest(
 		// imports, show rules and set directives the preview cannot apply. Saying so
 		// beside the image is what stops a divergence being read as a defect.
 		const notes = block.kind === "raw" ? ["the document template is not applied to a raw passthrough"] : [];
-		// Neither kind reaches the filter, so neither reads a project of it. The
+		// Neither kind reaches the filter, so neither carries an option of it. The
 		// directory of the document is the whole answer, and finding it costs no
 		// read, which is what keeps these two off the disk entirely.
-		const directory = documentDirectoryOf(document);
-		return {
-			block,
-			blockIndex,
-			...assembled,
-			argv: buildBlockArgv(directory),
-			cwd: directory,
-			notes,
-			bodyLineOffset: 0,
-		};
+		const command = buildTypstCommand({ paths: { documentDirectory: documentDirectoryOf(document) } });
+		return { block, blockIndex, ...assembled, command, notes, bodyLineOffset: 0 };
 	}
 
 	const { installed, chain, brand } = await cache.cellContext(document, text);
@@ -352,30 +342,20 @@ export async function buildCompileRequest(
 	// this preview, asked while looking at it.
 	const mode = brandMode ?? documentBrandMode(chain.metadata) ?? themeBrandMode();
 
-	// The chain answers where the document sits, and the document itself answers
-	// again for a document the chain found no project for.
-	const paths: TypstPaths = {
-		projectRoot: chain.projectRoot,
-		documentDirectory: chain.documentDirectory ?? documentDirectoryOf(document),
-	};
-
 	const built = await buildCell(block, {
 		levels: chain.levels,
 		brand,
 		mode,
-		paths,
+		// The chain is itself where the document sits, so the two halves of one
+		// document cannot be paired with the halves of another.
+		paths: chain,
 		readFile: (documentPath) => readTypstFile(documentPath, chain),
 	});
 	if (isUnavailable(built)) {
 		return built;
 	}
 
-	return { block, blockIndex, ...built, cwd: compileCwd(paths), brandMode: mode };
-}
-
-/** The directory holding a document, or undefined when it is not a file on disk. */
-function documentDirectoryOf(document: vscode.TextDocument): string | undefined {
-	return document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
+	return { block, blockIndex, ...built, brandMode: mode };
 }
 
 /**

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import * as vscode from "vscode";
 import * as semver from "semver";
 import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
@@ -9,6 +10,7 @@ import {
 	type Unavailable,
 } from "../../utils/typst/typstSource";
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
+import { buildBlockArgv, compileCwd, type TypstPaths } from "../../utils/typst/typstCli";
 import { EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
 import { getInstalledExtensionsCached } from "../../utils/installedExtensionsCache";
 import { getYamlFrontMatterRange } from "../../utils/yamlPosition";
@@ -68,6 +70,16 @@ export interface CompileRequest {
 	blockIndex: number;
 	/** The whole source to send to the compiler. */
 	source: string;
+	/**
+	 * The command line the block compiles under.
+	 *
+	 * Per document rather than one constant, because the compile root is what
+	 * every relative path the block reads resolves against, and it is a property
+	 * of where the document sits.
+	 */
+	argv: string[];
+	/** The directory the compile runs from, absent when there is none to name. */
+	cwd?: string;
 	/** How many lines sit above the block body, for mapping a diagnostic back. */
 	injectedLines: number;
 	/** The brand mode a cell resolved with, absent for the other two kinds. */
@@ -307,7 +319,19 @@ export async function buildCompileRequest(
 		// imports, show rules and set directives the preview cannot apply. Saying so
 		// beside the image is what stops a divergence being read as a defect.
 		const notes = block.kind === "raw" ? ["the document template is not applied to a raw passthrough"] : [];
-		return { block, blockIndex, ...assembled, notes, bodyLineOffset: 0 };
+		// Neither kind reaches the filter, so neither reads a project of it. The
+		// directory of the document is the whole answer, and finding it costs no
+		// read, which is what keeps these two off the disk entirely.
+		const directory = documentDirectoryOf(document);
+		return {
+			block,
+			blockIndex,
+			...assembled,
+			argv: buildBlockArgv(directory),
+			cwd: directory,
+			notes,
+			bodyLineOffset: 0,
+		};
 	}
 
 	const { installed, chain, brand } = await cache.cellContext(document, text);
@@ -328,17 +352,30 @@ export async function buildCompileRequest(
 	// this preview, asked while looking at it.
 	const mode = brandMode ?? documentBrandMode(chain.metadata) ?? themeBrandMode();
 
+	// The chain answers where the document sits, and the document itself answers
+	// again for a document the chain found no project for.
+	const paths: TypstPaths = {
+		projectRoot: chain.projectRoot,
+		documentDirectory: chain.documentDirectory ?? documentDirectoryOf(document),
+	};
+
 	const built = await buildCell(block, {
 		levels: chain.levels,
 		brand,
 		mode,
+		paths,
 		readFile: (documentPath) => readTypstFile(documentPath, chain),
 	});
 	if (isUnavailable(built)) {
 		return built;
 	}
 
-	return { block, blockIndex, ...built, brandMode: mode };
+	return { block, blockIndex, ...built, cwd: compileCwd(paths), brandMode: mode };
+}
+
+/** The directory holding a document, or undefined when it is not a file on disk. */
+function documentDirectoryOf(document: vscode.TextDocument): string | undefined {
+	return document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
 }
 
 /**

--- a/src/providers/typstPreview/typstMetadata.ts
+++ b/src/providers/typstPreview/typstMetadata.ts
@@ -12,6 +12,7 @@ import {
 	type Brand,
 } from "../../utils/typst/typstBrand";
 import { extensionLevel, mapping, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
+import { resolveQuartoPath, type TypstPaths } from "../../utils/typst/typstPaths";
 
 /**
  * The Quarto metadata chain of one document, read from disk.
@@ -21,16 +22,18 @@ import { extensionLevel, mapping, type TypstGlobalLevel } from "../../utils/typs
  * a workspace.
  */
 
-/** The metadata one document compiles under. */
-export interface MetadataChain {
+/**
+ * The metadata one document compiles under.
+ *
+ * It extends `TypstPaths`, so a chain is itself the answer to where the document
+ * sits and a caller resolving a path against it cannot pair the two halves of
+ * one document with the halves of another.
+ */
+export interface MetadataChain extends TypstPaths {
 	/** The `typst-render` mapping of each level, lowest first. */
 	levels: TypstGlobalLevel[];
 	/** Every level's own metadata, merged shallowly, lowest first. */
 	metadata: Record<string, unknown>;
-	/** The project root that owns the document, when one does. */
-	projectRoot?: string;
-	/** The directory holding the document, when it is a file on disk. */
-	documentDirectory?: string;
 	/**
 	 * The directory a relative `brand:` path resolves from.
 	 *
@@ -89,22 +92,9 @@ async function readFirst(directory: string, names: readonly string[]): Promise<u
 	return documents.find((document) => document !== undefined);
 }
 
-/**
- * A path Quarto resolves against a document or a project,
- * `_modules/paths.lua:34-48` and `src/project/project-shared.ts:574-584`.
- *
- * A leading `/` means the project root, and every other path is relative to the
- * directory passed in. Undefined when there is no directory to resolve against,
- * which is a document that lives outside every project root.
- */
-export function resolveQuartoPath(
-	quartoPath: string,
-	from: string | undefined,
-	projectRoot: string | undefined,
-): string | undefined {
-	const fromProjectRoot = quartoPath.startsWith("/");
-	const base = fromProjectRoot ? projectRoot : from;
-	return base === undefined ? undefined : path.join(base, fromProjectRoot ? quartoPath.slice(1) : quartoPath);
+/** The directory holding a document, or undefined when it is not a file on disk. */
+export function documentDirectoryOf(document: vscode.TextDocument): string | undefined {
+	return document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
 }
 
 /**
@@ -192,7 +182,7 @@ export async function readMetadataChain(
 	projectRoot?: string,
 ): Promise<MetadataChain> {
 	const owningRoot = projectRoot ?? (await findOwningProjectRoot(document.uri));
-	const documentDirectory = document.uri.scheme === "file" ? path.dirname(document.uri.fsPath) : undefined;
+	const documentDirectory = documentDirectoryOf(document);
 
 	// The project configuration is its own case for `brand:`, so each level says
 	// which directory a relative path it names would resolve from. Every level

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -9,6 +9,7 @@ import { generateHashKey } from "../../utils/hash";
 import { logMessage } from "../../utils/log";
 import { isQmdFile } from "../../utils/metadataFilesRegistry";
 import { otherBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
+import { commandKey, type TypstCommand } from "../../utils/typst/typstCli";
 import { EXTENSION_MANIFEST_GLOB } from "../../utils/quartoProjectDiscovery";
 import { buildCompileRequest, NO_BLOCK_MESSAGE, TypstContextCache, type CompileRequest } from "./typstContext";
 import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary, type TypstCompileResult } from "./typstCompiler";
@@ -118,7 +119,7 @@ export interface TypstPreviewResult {
 
 /** What the controller needs of a compiler, which is what makes it stubbable. */
 export interface TypstCompilerLike {
-	compile(source: string, argv: string[], token: vscode.CancellationToken, cwd?: string): Promise<TypstCompileResult>;
+	compile(source: string, command: TypstCommand, token: vscode.CancellationToken): Promise<TypstCompileResult>;
 	dispose(): void;
 }
 
@@ -683,13 +684,12 @@ export class TypstPreviewController implements vscode.Disposable {
 			);
 			return undefined;
 		}
-		// The image is decided by the source, the command line, the directory the
-		// compile runs from and the binary, and by nothing else. Two documents that
-		// assemble to the same source under the same command line share the entry,
-		// which is what makes an undone keystroke free.
-		// Joined on a character no argument and no Typst source carries, so two
-		// different requests cannot be spelled the same way.
-		const key = generateHashKey([binary, request.cwd ?? "", ...request.argv, request.source].join("\u0000"));
+		// The image is decided by the source, the command and the binary, and by
+		// nothing else. Two documents that assemble to the same source under the
+		// same command share the entry, which is what makes an undone keystroke
+		// free. Joined on a character no Typst source carries, so two different
+		// requests cannot be spelled the same way.
+		const key = generateHashKey([binary, commandKey(request.command), request.source].join("\u0000"));
 		if (fresh) {
 			// Dropped now and not merely stepped over, and before this request is
 			// asked whether it is still wanted. A compile that another request
@@ -714,9 +714,8 @@ export class TypstPreviewController implements vscode.Disposable {
 		try {
 			const compiled = await this.useCompiler(binary, settings.timeoutMs).compile(
 				request.source,
-				request.argv,
+				request.command,
 				this.uncancelled.token,
-				request.cwd,
 			);
 			if (stale()) {
 				return undefined;

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -22,9 +22,6 @@ import { compileSettings, documentDelayOf, surfaceOf } from "./typstPreviewSetti
  * that decides when a compile is worth running.
  */
 
-/** Read the source from stdin, write the image to stdout. */
-const ARGV = ["compile", "--format", "svg", "-", "-"];
-
 /**
  * How long after the cursor moves the preview follows it.
  *
@@ -121,7 +118,7 @@ export interface TypstPreviewResult {
 
 /** What the controller needs of a compiler, which is what makes it stubbable. */
 export interface TypstCompilerLike {
-	compile(source: string, argv: string[], token: vscode.CancellationToken): Promise<TypstCompileResult>;
+	compile(source: string, argv: string[], token: vscode.CancellationToken, cwd?: string): Promise<TypstCompileResult>;
 	dispose(): void;
 }
 
@@ -686,12 +683,13 @@ export class TypstPreviewController implements vscode.Disposable {
 			);
 			return undefined;
 		}
-		// The image is decided by the source, the arguments and the binary, and by
-		// nothing else. Two documents that assemble to the same source share the
-		// entry, which is what makes an undone keystroke free.
+		// The image is decided by the source, the command line, the directory the
+		// compile runs from and the binary, and by nothing else. Two documents that
+		// assemble to the same source under the same command line share the entry,
+		// which is what makes an undone keystroke free.
 		// Joined on a character no argument and no Typst source carries, so two
-		// different triples cannot be spelled the same way.
-		const key = generateHashKey([binary, ...ARGV, request.source].join("\u0000"));
+		// different requests cannot be spelled the same way.
+		const key = generateHashKey([binary, request.cwd ?? "", ...request.argv, request.source].join("\u0000"));
 		if (fresh) {
 			// Dropped now and not merely stepped over, and before this request is
 			// asked whether it is still wanted. A compile that another request
@@ -716,8 +714,9 @@ export class TypstPreviewController implements vscode.Disposable {
 		try {
 			const compiled = await this.useCompiler(binary, settings.timeoutMs).compile(
 				request.source,
-				ARGV,
+				request.argv,
 				this.uncancelled.token,
+				request.cwd,
 			);
 			if (stale()) {
 				return undefined;

--- a/src/test/suite/typstCli.test.ts
+++ b/src/test/suite/typstCli.test.ts
@@ -149,5 +149,18 @@ suite("Typst CLI Test Suite", () => {
 			const command = buildTypstCommand({ paths: PATHS });
 			assert.strictEqual(commandKey(command), commandKey(buildTypstCommand({ paths: PATHS })));
 		});
+
+		test("Should tell a directory that is absent from one that is empty", () => {
+			assert.notStrictEqual(commandKey({ argv: [] }), commandKey({ argv: [], cwd: "" }));
+		});
+
+		test("Should let no character of an argument spell a boundary", () => {
+			// A YAML double-quoted `input:` value can hold any character, the NUL of a
+			// `"\0"` escape included, so no separator is safe to rely on. Such a
+			// command never spawns, and aliasing one onto a command that does spawn
+			// would serve its image for the wrong document.
+			const nul = String.fromCharCode(0);
+			assert.notStrictEqual(commandKey({ argv: [`a${nul}b`] }), commandKey({ argv: ["a", "b"] }));
+		});
 	});
 });

--- a/src/test/suite/typstCli.test.ts
+++ b/src/test/suite/typstCli.test.ts
@@ -1,16 +1,13 @@
 import * as assert from "assert";
 import * as path from "node:path";
 import {
-	buildBlockArgv,
-	buildCellArgv,
-	compileCwd,
+	buildTypstCommand,
+	commandKey,
 	mergeInputs,
 	parseInputString,
-	resolveCompileRoot,
-	resolveProjectPath,
 	typstColourHex,
-	type TypstPaths,
 } from "../../utils/typst/typstCli";
+import type { TypstPaths } from "../../utils/typst/typstPaths";
 
 const PROJECT = path.join("/home", "site");
 const DOCUMENT = path.join(PROJECT, "posts", "2026");
@@ -30,58 +27,6 @@ function flags(argv: readonly string[], name: string): string[] {
 }
 
 suite("Typst CLI Test Suite", () => {
-	suite("resolveProjectPath", () => {
-		test("Should resolve a leading slash against the project root", () => {
-			assert.strictEqual(resolveProjectPath("/assets/fonts", PROJECT), path.join(PROJECT, "assets", "fonts"));
-		});
-
-		test("Should leave a relative path alone, which the filter does as well", () => {
-			// `paths.lua:44` returns the path unchanged, so it resolves against the
-			// working directory of the compile and not against the project.
-			assert.strictEqual(resolveProjectPath("fonts", PROJECT), "fonts");
-		});
-
-		test("Should strip the leading slash when there is no project root", () => {
-			assert.strictEqual(resolveProjectPath("/assets/fonts", undefined), path.join("assets", "fonts"));
-		});
-
-		test("Should leave an empty path alone", () => {
-			assert.strictEqual(resolveProjectPath("", PROJECT), "");
-		});
-	});
-
-	suite("resolveCompileRoot", () => {
-		test("Should default to the document directory", () => {
-			assert.strictEqual(resolveCompileRoot(undefined, PATHS), DOCUMENT);
-		});
-
-		test("Should resolve a relative root against the document directory", () => {
-			assert.strictEqual(resolveCompileRoot("..", PATHS), path.join(PROJECT, "posts"));
-		});
-
-		test("Should resolve a leading slash against the project root", () => {
-			assert.strictEqual(resolveCompileRoot("/assets", PATHS), path.join(PROJECT, "assets"));
-		});
-
-		test("Should read a bare slash as the project root itself", () => {
-			assert.strictEqual(resolveCompileRoot("/", PATHS), PROJECT);
-		});
-
-		test("Should fall back to the project root for a document with no directory", () => {
-			assert.strictEqual(resolveCompileRoot(undefined, { projectRoot: PROJECT }), PROJECT);
-		});
-
-		test("Should resolve nothing when there is no directory and no project", () => {
-			assert.strictEqual(resolveCompileRoot("..", {}), undefined);
-		});
-
-		test("Should resolve a leading slash to nothing when there is no project", () => {
-			// The root is what confines every read, so a guess would either widen it
-			// past the document or point it somewhere the document never names.
-			assert.strictEqual(resolveCompileRoot("/assets", { documentDirectory: DOCUMENT }), undefined);
-		});
-	});
-
 	suite("parseInputString", () => {
 		test("Should read comma-separated pairs and trim around them", () => {
 			assert.deepStrictEqual(parseInputString(" a = 1 , b=2 "), { a: "1", b: "2" });
@@ -105,11 +50,11 @@ suite("Typst CLI Test Suite", () => {
 			assert.deepStrictEqual(mergeInputs({ a: "1", b: "2" }, "b=3"), { a: "1", b: "3" });
 		});
 
-		test("Should carry the global map alone when the block writes none", () => {
+		test("Should carry the global mapping alone when the block writes none", () => {
 			assert.deepStrictEqual(mergeInputs({ a: "1" }, undefined), { a: "1" });
 		});
 
-		test("Should carry the block string alone when there is no global map", () => {
+		test("Should carry the block string alone when there is no global mapping", () => {
 			assert.deepStrictEqual(mergeInputs(undefined, "a=1"), { a: "1" });
 		});
 	});
@@ -129,89 +74,80 @@ suite("Typst CLI Test Suite", () => {
 		});
 	});
 
-	suite("compileCwd", () => {
-		test("Should run from the project root, which a relative font path needs", () => {
-			assert.strictEqual(compileCwd(PATHS), PROJECT);
-		});
-
-		test("Should fall back to the document directory outside every project", () => {
-			assert.strictEqual(compileCwd({ documentDirectory: DOCUMENT }), DOCUMENT);
-		});
-
-		test("Should run from nowhere in particular for a document with neither", () => {
-			assert.strictEqual(compileCwd({}), undefined);
-		});
-	});
-
-	suite("buildBlockArgv", () => {
-		test("Should compile from stdin to stdout as SVG, rooted at the document", () => {
-			assert.deepStrictEqual(buildBlockArgv(DOCUMENT), ["compile", "--format", "svg", "--root", DOCUMENT, "-", "-"]);
+	suite("buildTypstCommand", () => {
+		test("Should root a block at its document directory by default", () => {
+			const command = buildTypstCommand({ paths: PATHS });
+			assert.deepStrictEqual(command.argv, ["compile", "--format", "svg", "--root", DOCUMENT, "-", "-"]);
+			assert.strictEqual(command.cwd, PROJECT);
 		});
 
 		test("Should carry no root for a document that is not a file on disk", () => {
-			assert.deepStrictEqual(buildBlockArgv(undefined), ["compile", "--format", "svg", "-", "-"]);
-		});
-	});
-
-	suite("buildCellArgv", () => {
-		test("Should root a cell at its document directory by default", () => {
-			const argv = buildCellArgv({ options: {}, paths: PATHS });
-			assert.deepStrictEqual(argv, ["compile", "--format", "svg", "--root", DOCUMENT, "-", "-"]);
+			const command = buildTypstCommand({ paths: {} });
+			assert.deepStrictEqual(command.argv, ["compile", "--format", "svg", "-", "-"]);
+			assert.strictEqual(command.cwd, undefined);
 		});
 
-		test("Should root a cell at the root the configuration names", () => {
-			const argv = buildCellArgv({ options: { root: "/" }, paths: PATHS });
-			assert.strictEqual(flag(argv, "--root"), PROJECT);
+		test("Should root a block at the root the configuration names", () => {
+			const command = buildTypstCommand({ global: { root: "/" }, paths: PATHS });
+			assert.strictEqual(flag(command.argv, "--root"), PROJECT);
 		});
 
 		test("Should pass one font path per entry", () => {
-			const argv = buildCellArgv({
-				options: { "font-path": ["/assets/fonts", "fonts"] },
-				paths: PATHS,
-			});
-			assert.deepStrictEqual(flags(argv, "--font-path"), [path.join(PROJECT, "assets", "fonts"), "fonts"]);
+			const command = buildTypstCommand({ global: { "font-path": ["/assets/fonts", "fonts"] }, paths: PATHS });
+			assert.deepStrictEqual(flags(command.argv, "--font-path"), [path.join(PROJECT, "assets", "fonts"), "fonts"]);
 		});
 
 		test("Should pass the package path the configuration names", () => {
-			const argv = buildCellArgv({ options: { "package-path": "/packages" }, paths: PATHS });
-			assert.strictEqual(flag(argv, "--package-path"), path.join(PROJECT, "packages"));
+			const command = buildTypstCommand({ global: { "package-path": "/packages" }, paths: PATHS });
+			assert.strictEqual(flag(command.argv, "--package-path"), path.join(PROJECT, "packages"));
 		});
 
-		test("Should pass every input, sorted, with the block string over the map", () => {
-			const argv = buildCellArgv({
-				options: { input: { theme: "light", scale: "1" } },
+		test("Should pass every input, sorted, with the block string over the mapping", () => {
+			const command = buildTypstCommand({
+				global: { input: { theme: "light", scale: "1" } },
 				blockInput: "theme=dark",
 				paths: PATHS,
 			});
-			assert.deepStrictEqual(flags(argv, "--input"), ["scale=1", "theme=dark"]);
+			assert.deepStrictEqual(flags(command.argv, "--input"), ["scale=1", "theme=dark"]);
 		});
 
 		test("Should pass the resolved colours as the inputs the filter passes", () => {
-			const argv = buildCellArgv({
-				options: {},
+			const command = buildTypstCommand({
 				background: 'rgb("#0d1626")',
 				foreground: 'rgb("#e7ecf4")',
 				paths: PATHS,
 			});
-			assert.deepStrictEqual(flags(argv, "--input"), [
+			assert.deepStrictEqual(flags(command.argv, "--input"), [
 				"typst-render-foreground=#e7ecf4",
 				"typst-render-background=#0d1626",
 			]);
 		});
 
 		test("Should pass no colour input for a colour no flag can carry", () => {
-			const argv = buildCellArgv({ options: {}, background: "none", paths: PATHS });
-			assert.deepStrictEqual(flags(argv, "--input"), []);
+			const command = buildTypstCommand({ background: "none", paths: PATHS });
+			assert.deepStrictEqual(flags(command.argv, "--input"), []);
 		});
 
 		test("Should end with the two arguments that read stdin and write stdout", () => {
-			const argv = buildCellArgv({
-				options: { "font-path": ["fonts"], input: { a: "1" } },
+			const command = buildTypstCommand({
+				global: { "font-path": ["fonts"], input: { a: "1" } },
 				background: 'rgb("#ffffff")',
 				paths: PATHS,
 			});
-			assert.deepStrictEqual(argv.slice(-2), ["-", "-"]);
-			assert.deepStrictEqual(argv.slice(0, 3), ["compile", "--format", "svg"]);
+			assert.deepStrictEqual(command.argv.slice(-2), ["-", "-"]);
+			assert.deepStrictEqual(command.argv.slice(0, 3), ["compile", "--format", "svg"]);
+		});
+	});
+
+	suite("commandKey", () => {
+		test("Should tell two commands apart by their directory alone", () => {
+			const argv = ["compile", "-", "-"];
+			assert.notStrictEqual(commandKey({ argv, cwd: "/a" }), commandKey({ argv, cwd: "/b" }));
+		});
+
+		test("Should give one command one key", () => {
+			const command = buildTypstCommand({ paths: PATHS });
+			assert.strictEqual(commandKey(command), commandKey(buildTypstCommand({ paths: PATHS })));
 		});
 	});
 });

--- a/src/test/suite/typstCli.test.ts
+++ b/src/test/suite/typstCli.test.ts
@@ -1,0 +1,217 @@
+import * as assert from "assert";
+import * as path from "node:path";
+import {
+	buildBlockArgv,
+	buildCellArgv,
+	compileCwd,
+	mergeInputs,
+	parseInputString,
+	resolveCompileRoot,
+	resolveProjectPath,
+	typstColourHex,
+	type TypstPaths,
+} from "../../utils/typst/typstCli";
+
+const PROJECT = path.join("/home", "site");
+const DOCUMENT = path.join(PROJECT, "posts", "2026");
+
+/** A project with a document below it, which is the ordinary case. */
+const PATHS: TypstPaths = { projectRoot: PROJECT, documentDirectory: DOCUMENT };
+
+/** The value of one flag, or undefined when the argv carries none. */
+function flag(argv: readonly string[], name: string): string | undefined {
+	const at = argv.indexOf(name);
+	return at === -1 ? undefined : argv[at + 1];
+}
+
+/** Every value of a flag the argv may repeat. */
+function flags(argv: readonly string[], name: string): string[] {
+	return argv.flatMap((value, at) => (value === name ? [argv[at + 1]] : []));
+}
+
+suite("Typst CLI Test Suite", () => {
+	suite("resolveProjectPath", () => {
+		test("Should resolve a leading slash against the project root", () => {
+			assert.strictEqual(resolveProjectPath("/assets/fonts", PROJECT), path.join(PROJECT, "assets", "fonts"));
+		});
+
+		test("Should leave a relative path alone, which the filter does as well", () => {
+			// `paths.lua:44` returns the path unchanged, so it resolves against the
+			// working directory of the compile and not against the project.
+			assert.strictEqual(resolveProjectPath("fonts", PROJECT), "fonts");
+		});
+
+		test("Should strip the leading slash when there is no project root", () => {
+			assert.strictEqual(resolveProjectPath("/assets/fonts", undefined), path.join("assets", "fonts"));
+		});
+
+		test("Should leave an empty path alone", () => {
+			assert.strictEqual(resolveProjectPath("", PROJECT), "");
+		});
+	});
+
+	suite("resolveCompileRoot", () => {
+		test("Should default to the document directory", () => {
+			assert.strictEqual(resolveCompileRoot(undefined, PATHS), DOCUMENT);
+		});
+
+		test("Should resolve a relative root against the document directory", () => {
+			assert.strictEqual(resolveCompileRoot("..", PATHS), path.join(PROJECT, "posts"));
+		});
+
+		test("Should resolve a leading slash against the project root", () => {
+			assert.strictEqual(resolveCompileRoot("/assets", PATHS), path.join(PROJECT, "assets"));
+		});
+
+		test("Should read a bare slash as the project root itself", () => {
+			assert.strictEqual(resolveCompileRoot("/", PATHS), PROJECT);
+		});
+
+		test("Should fall back to the project root for a document with no directory", () => {
+			assert.strictEqual(resolveCompileRoot(undefined, { projectRoot: PROJECT }), PROJECT);
+		});
+
+		test("Should resolve nothing when there is no directory and no project", () => {
+			assert.strictEqual(resolveCompileRoot("..", {}), undefined);
+		});
+
+		test("Should resolve a leading slash to nothing when there is no project", () => {
+			// The root is what confines every read, so a guess would either widen it
+			// past the document or point it somewhere the document never names.
+			assert.strictEqual(resolveCompileRoot("/assets", { documentDirectory: DOCUMENT }), undefined);
+		});
+	});
+
+	suite("parseInputString", () => {
+		test("Should read comma-separated pairs and trim around them", () => {
+			assert.deepStrictEqual(parseInputString(" a = 1 , b=2 "), { a: "1", b: "2" });
+		});
+
+		test("Should keep a key whose value is empty", () => {
+			assert.deepStrictEqual(parseInputString("a="), { a: "" });
+		});
+
+		test("Should drop an entry with no equals sign and one with no key", () => {
+			assert.deepStrictEqual(parseInputString("a,=2,b=3"), { b: "3" });
+		});
+
+		test("Should read an empty string as no input at all", () => {
+			assert.deepStrictEqual(parseInputString(""), {});
+		});
+	});
+
+	suite("mergeInputs", () => {
+		test("Should let a block value win over a global one", () => {
+			assert.deepStrictEqual(mergeInputs({ a: "1", b: "2" }, "b=3"), { a: "1", b: "3" });
+		});
+
+		test("Should carry the global map alone when the block writes none", () => {
+			assert.deepStrictEqual(mergeInputs({ a: "1" }, undefined), { a: "1" });
+		});
+
+		test("Should carry the block string alone when there is no global map", () => {
+			assert.deepStrictEqual(mergeInputs(undefined, "a=1"), { a: "1" });
+		});
+	});
+
+	suite("typstColourHex", () => {
+		test("Should read the hex out of a wrapped colour", () => {
+			assert.strictEqual(typstColourHex('rgb("#faf6ee")'), "#faf6ee");
+		});
+
+		test("Should read nothing out of an expression that is not a wrapped hex", () => {
+			// `typst_colour_to_hex` at `typst-render.lua:748-751` matches that one
+			// shape, because it is the only one a `--input` can carry.
+			assert.strictEqual(typstColourHex("oklch(60% 0.2 30deg)"), undefined);
+			assert.strictEqual(typstColourHex("none"), undefined);
+			assert.strictEqual(typstColourHex('rgb("60%, 20%, 30%")'), undefined);
+			assert.strictEqual(typstColourHex(undefined), undefined);
+		});
+	});
+
+	suite("compileCwd", () => {
+		test("Should run from the project root, which a relative font path needs", () => {
+			assert.strictEqual(compileCwd(PATHS), PROJECT);
+		});
+
+		test("Should fall back to the document directory outside every project", () => {
+			assert.strictEqual(compileCwd({ documentDirectory: DOCUMENT }), DOCUMENT);
+		});
+
+		test("Should run from nowhere in particular for a document with neither", () => {
+			assert.strictEqual(compileCwd({}), undefined);
+		});
+	});
+
+	suite("buildBlockArgv", () => {
+		test("Should compile from stdin to stdout as SVG, rooted at the document", () => {
+			assert.deepStrictEqual(buildBlockArgv(DOCUMENT), ["compile", "--format", "svg", "--root", DOCUMENT, "-", "-"]);
+		});
+
+		test("Should carry no root for a document that is not a file on disk", () => {
+			assert.deepStrictEqual(buildBlockArgv(undefined), ["compile", "--format", "svg", "-", "-"]);
+		});
+	});
+
+	suite("buildCellArgv", () => {
+		test("Should root a cell at its document directory by default", () => {
+			const argv = buildCellArgv({ options: {}, paths: PATHS });
+			assert.deepStrictEqual(argv, ["compile", "--format", "svg", "--root", DOCUMENT, "-", "-"]);
+		});
+
+		test("Should root a cell at the root the configuration names", () => {
+			const argv = buildCellArgv({ options: { root: "/" }, paths: PATHS });
+			assert.strictEqual(flag(argv, "--root"), PROJECT);
+		});
+
+		test("Should pass one font path per entry", () => {
+			const argv = buildCellArgv({
+				options: { "font-path": ["/assets/fonts", "fonts"] },
+				paths: PATHS,
+			});
+			assert.deepStrictEqual(flags(argv, "--font-path"), [path.join(PROJECT, "assets", "fonts"), "fonts"]);
+		});
+
+		test("Should pass the package path the configuration names", () => {
+			const argv = buildCellArgv({ options: { "package-path": "/packages" }, paths: PATHS });
+			assert.strictEqual(flag(argv, "--package-path"), path.join(PROJECT, "packages"));
+		});
+
+		test("Should pass every input, sorted, with the block string over the map", () => {
+			const argv = buildCellArgv({
+				options: { input: { theme: "light", scale: "1" } },
+				blockInput: "theme=dark",
+				paths: PATHS,
+			});
+			assert.deepStrictEqual(flags(argv, "--input"), ["scale=1", "theme=dark"]);
+		});
+
+		test("Should pass the resolved colours as the inputs the filter passes", () => {
+			const argv = buildCellArgv({
+				options: {},
+				background: 'rgb("#0d1626")',
+				foreground: 'rgb("#e7ecf4")',
+				paths: PATHS,
+			});
+			assert.deepStrictEqual(flags(argv, "--input"), [
+				"typst-render-foreground=#e7ecf4",
+				"typst-render-background=#0d1626",
+			]);
+		});
+
+		test("Should pass no colour input for a colour no flag can carry", () => {
+			const argv = buildCellArgv({ options: {}, background: "none", paths: PATHS });
+			assert.deepStrictEqual(flags(argv, "--input"), []);
+		});
+
+		test("Should end with the two arguments that read stdin and write stdout", () => {
+			const argv = buildCellArgv({
+				options: { "font-path": ["fonts"], input: { a: "1" } },
+				background: 'rgb("#ffffff")',
+				paths: PATHS,
+			});
+			assert.deepStrictEqual(argv.slice(-2), ["-", "-"]);
+			assert.deepStrictEqual(argv.slice(0, 3), ["compile", "--format", "svg"]);
+		});
+	});
+});

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import {
 	typstBinaryCandidate,
@@ -132,6 +134,20 @@ suite("Typst Compiler Test Suite", () => {
 					never,
 				);
 				assert.strictEqual(result.svg, "the source");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should run from the directory the caller names", async () => {
+			// A relative `--font-path` is left relative by the filter, so it resolves
+			// against the directory the compile runs from. The preview has to run from
+			// the same place a render does, or it reads the fonts of nowhere.
+			const directory = fs.realpathSync(os.tmpdir());
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				const result = await compiler.compile("", run("process.stdout.write(process.cwd())"), never, directory);
+				assert.strictEqual(result.svg, directory);
 			} finally {
 				compiler.dispose();
 			}

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -10,6 +10,7 @@ import {
 	TypstCompileFailure,
 	type TypstProbe,
 } from "../../providers/typstPreview/typstCompiler";
+import type { TypstCommand } from "../../utils/typst/typstCli";
 
 const BIN = path.join("/opt", "quarto", "bin");
 
@@ -23,9 +24,9 @@ const BIN = path.join("/opt", "quarto", "bin");
  */
 const RUNTIME = process.execPath;
 
-/** Arguments that run one expression in a child process. */
-function run(source: string): string[] {
-	return ["-e", source];
+/** A command that runs one expression in a child process. */
+function run(source: string): TypstCommand {
+	return { argv: ["-e", source] };
 }
 
 /** A token that is already cancelled. */
@@ -146,7 +147,8 @@ suite("Typst Compiler Test Suite", () => {
 			const directory = fs.realpathSync(os.tmpdir());
 			const compiler = new TypstCompiler(RUNTIME);
 			try {
-				const result = await compiler.compile("", run("process.stdout.write(process.cwd())"), never, directory);
+				const command = { ...run("process.stdout.write(process.cwd())"), cwd: directory };
+				const result = await compiler.compile("", command, never);
 				assert.strictEqual(result.svg, directory);
 			} finally {
 				compiler.dispose();
@@ -245,7 +247,7 @@ suite("Typst Compiler Test Suite", () => {
 			const compiler = new TypstCompiler(path.join(BIN, "tools", "aarch64", "typst"));
 			try {
 				await assert.rejects(
-					compiler.compile("", [], never),
+					compiler.compile("", { argv: [] }, never),
 					(error: unknown) => error instanceof TypstCompileFailure && /Failed to start Typst/.test(String(error)),
 				);
 			} finally {

--- a/src/test/suite/typstFixtures.test.ts
+++ b/src/test/suite/typstFixtures.test.ts
@@ -113,6 +113,9 @@ suite("Typst Fixtures Test Suite", () => {
 				// document whose colours differ between the two is rendered twice, and
 				// each side is one fixture.
 				mode: meta.brandMode,
+				// A fixture compares the source and not the command line, and it names
+				// no place on disk to resolve one against.
+				paths: {},
 				readFile: async (documentPath) => {
 					const file = path.join(directory, documentPath);
 					return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : undefined;

--- a/src/test/suite/typstPaths.test.ts
+++ b/src/test/suite/typstPaths.test.ts
@@ -1,0 +1,73 @@
+import * as assert from "assert";
+import * as path from "node:path";
+import { compileCwd, resolveCompileRoot, resolveProjectPath, type TypstPaths } from "../../utils/typst/typstPaths";
+
+const PROJECT = path.join("/home", "site");
+const DOCUMENT = path.join(PROJECT, "posts", "2026");
+
+/** A project with a document below it, which is the ordinary case. */
+const PATHS: TypstPaths = { projectRoot: PROJECT, documentDirectory: DOCUMENT };
+
+suite("Typst Paths Test Suite", () => {
+	suite("resolveProjectPath", () => {
+		test("Should resolve a leading slash against the project root", () => {
+			assert.strictEqual(resolveProjectPath("/assets/fonts", PROJECT), path.join(PROJECT, "assets", "fonts"));
+		});
+
+		test("Should leave a relative path alone, which the filter does as well", () => {
+			// `paths.lua:44` returns the path unchanged, so it resolves against the
+			// working directory of the compile and not against the project.
+			assert.strictEqual(resolveProjectPath("fonts", PROJECT), "fonts");
+		});
+
+		test("Should strip the leading slash when there is no project root", () => {
+			assert.strictEqual(resolveProjectPath("/assets/fonts", undefined), path.join("assets", "fonts"));
+		});
+	});
+
+	suite("resolveCompileRoot", () => {
+		test("Should default to the document directory", () => {
+			assert.strictEqual(resolveCompileRoot(undefined, PATHS), DOCUMENT);
+		});
+
+		test("Should resolve a relative root against the document directory", () => {
+			assert.strictEqual(resolveCompileRoot("..", PATHS), path.join(PROJECT, "posts"));
+		});
+
+		test("Should resolve a leading slash against the project root", () => {
+			assert.strictEqual(resolveCompileRoot("/assets", PATHS), path.join(PROJECT, "assets"));
+		});
+
+		test("Should read a bare slash as the project root itself", () => {
+			assert.strictEqual(resolveCompileRoot("/", PATHS), PROJECT);
+		});
+
+		test("Should fall back to the project root for a document with no directory", () => {
+			assert.strictEqual(resolveCompileRoot(undefined, { projectRoot: PROJECT }), PROJECT);
+		});
+
+		test("Should resolve nothing when there is no directory and no project", () => {
+			assert.strictEqual(resolveCompileRoot("..", {}), undefined);
+		});
+
+		test("Should resolve a leading slash to nothing when there is no project", () => {
+			// The root is what confines every read, so a guess would either widen it
+			// past the document or point it somewhere the document never names.
+			assert.strictEqual(resolveCompileRoot("/assets", { documentDirectory: DOCUMENT }), undefined);
+		});
+	});
+
+	suite("compileCwd", () => {
+		test("Should run from the project root, which a relative font path needs", () => {
+			assert.strictEqual(compileCwd(PATHS), PROJECT);
+		});
+
+		test("Should fall back to the document directory outside every project", () => {
+			assert.strictEqual(compileCwd({ documentDirectory: DOCUMENT }), DOCUMENT);
+		});
+
+		test("Should run from nowhere in particular for a document with neither", () => {
+			assert.strictEqual(compileCwd({}), undefined);
+		});
+	});
+});

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -13,7 +13,8 @@ import {
 	PINNED_TYPST_RENDER_VERSION,
 	TypstContextCache,
 } from "../../providers/typstPreview/typstContext";
-import { readBrand, readMetadataChain, resolveQuartoPath } from "../../providers/typstPreview/typstMetadata";
+import { readBrand, readMetadataChain } from "../../providers/typstPreview/typstMetadata";
+import { resolveQuartoPath } from "../../utils/typst/typstPaths";
 import { invalidateProjectRoots, setProjectRoots } from "../../utils/projectRootsRegistry";
 import { invalidateInstalledExtensionsCache } from "../../utils/installedExtensionsCache";
 import { parseFrontMatter } from "../../utils/yamlPosition";
@@ -63,6 +64,9 @@ suite("Typst Preview Context Test Suite", () => {
 			levels: [],
 			brand: EMPTY_BRAND,
 			mode: "light" as const,
+			// A fixture drives the assembly from strings alone, so it names no place
+			// on disk, and the command it builds carries no root.
+			paths: {},
 			readFile: reader({}),
 		};
 
@@ -396,8 +400,8 @@ suite("Typst Preview Context Test Suite", () => {
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(posts, "doc.qmd")));
 				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, new TypstContextCache());
 				assert.ok(!isUnavailable(request));
-				assert.deepStrictEqual(request.argv, ["compile", "--format", "svg", "--root", posts, "-", "-"]);
-				assert.strictEqual(request.cwd, directory);
+				assert.deepStrictEqual(request.command.argv, ["compile", "--format", "svg", "--root", posts, "-", "-"]);
+				assert.strictEqual(request.command.cwd, directory);
 			} finally {
 				fs.rmSync(directory, { recursive: true, force: true });
 			}
@@ -420,7 +424,7 @@ suite("Typst Preview Context Test Suite", () => {
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
 				const request = await buildCompileRequest(document, new vscode.Position(9, 0), HEADER, new TypstContextCache());
 				assert.ok(!isUnavailable(request));
-				assert.deepStrictEqual(request.argv, [
+				assert.deepStrictEqual(request.command.argv, [
 					"compile",
 					"--format",
 					"svg",
@@ -445,8 +449,8 @@ suite("Typst Preview Context Test Suite", () => {
 				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
 				const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, new TypstContextCache());
 				assert.ok(!isUnavailable(request));
-				assert.deepStrictEqual(request.argv, ["compile", "--format", "svg", "--root", directory, "-", "-"]);
-				assert.strictEqual(request.cwd, directory);
+				assert.deepStrictEqual(request.command.argv, ["compile", "--format", "svg", "--root", directory, "-", "-"]);
+				assert.strictEqual(request.command.cwd, directory);
 			} finally {
 				fs.rmSync(directory, { recursive: true, force: true });
 			}
@@ -456,8 +460,8 @@ suite("Typst Preview Context Test Suite", () => {
 			const document = await documentOf("```typst\n#circle()\n```\n");
 			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, new TypstContextCache());
 			assert.ok(!isUnavailable(request));
-			assert.deepStrictEqual(request.argv, ["compile", "--format", "svg", "-", "-"]);
-			assert.strictEqual(request.cwd, undefined);
+			assert.deepStrictEqual(request.command.argv, ["compile", "--format", "svg", "-", "-"]);
+			assert.strictEqual(request.command.cwd, undefined);
 		});
 
 		test("Should say so when the cursor is in no block", async () => {

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -137,11 +137,27 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(built.source.includes("#set page(width: 6cm, height: auto, margin: 1cm, fill: none)"));
 		});
 
-		test("Should ignore a block-level root, which is a global-only option", async () => {
-			// `root` never reaches the source, so a block writing it changes nothing.
-			const plain = await buildCell(cell([]), context);
-			const rooted = await buildCell(cell(["root: ../assets"]), context);
-			assert.ok(!isUnavailable(plain) && !isUnavailable(rooted));
+		test("Should ignore a block-level root and font path, which are global-only", async () => {
+			// `typst-render.lua:1284-1293` reads these from the global configuration
+			// alone, so a block writing one changes neither the source nor the command.
+			// The document sits somewhere on disk here, or every command would carry
+			// no root and the comparison would hold for the wrong reason.
+			const placed = { ...context, paths: { projectRoot: "/p", documentDirectory: path.join("/p", "posts") } };
+			const plain = await buildCell(cell([]), placed);
+			const rooted = await buildCell(cell(["root: ../assets"]), placed);
+			const fonted = await buildCell(cell(["font-path: /other"]), placed);
+			assert.ok(!isUnavailable(plain) && !isUnavailable(rooted) && !isUnavailable(fonted));
+			assert.deepStrictEqual(plain.command.argv, [
+				"compile",
+				"--format",
+				"svg",
+				"--root",
+				path.join("/p", "posts"),
+				"-",
+				"-",
+			]);
+			assert.deepStrictEqual(rooted.command, plain.command);
+			assert.deepStrictEqual(fonted.command, plain.command);
 			assert.strictEqual(rooted.source, plain.source);
 		});
 	});

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -383,6 +383,83 @@ suite("Typst Preview Context Test Suite", () => {
 			}
 		});
 
+		test("Should root a cell at its own directory and run from the project", async () => {
+			// The source reaches Typst on stdin, so the root is what every relative
+			// path the cell reads resolves against. Without it a cell reading a file
+			// beside its document searches the working directory of the extension
+			// host, which is where this whole slice went wrong.
+			const directory = project(true);
+			try {
+				const posts = path.join(directory, "posts");
+				fs.mkdirSync(posts);
+				fs.writeFileSync(path.join(posts, "doc.qmd"), CELL);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(posts, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(2, 0), HEADER, new TypstContextCache());
+				assert.ok(!isUnavailable(request));
+				assert.deepStrictEqual(request.argv, ["compile", "--format", "svg", "--root", posts, "-", "-"]);
+				assert.strictEqual(request.cwd, directory);
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should carry the root and the font path the configuration names", async () => {
+			const directory = project(true);
+			try {
+				const text = [
+					"---",
+					"extensions:",
+					"  typst-render:",
+					"    root: /",
+					"    font-path: /assets/fonts",
+					"---",
+					"",
+					CELL,
+				].join("\n");
+				fs.writeFileSync(path.join(directory, "doc.qmd"), text);
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(9, 0), HEADER, new TypstContextCache());
+				assert.ok(!isUnavailable(request));
+				assert.deepStrictEqual(request.argv, [
+					"compile",
+					"--format",
+					"svg",
+					"--root",
+					directory,
+					"--font-path",
+					path.join(directory, "assets", "fonts"),
+					"-",
+					"-",
+				]);
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should root a plain block at the directory of its document", async () => {
+			// A plain block never reaches the filter, so it reads no option of it. The
+			// directory of the document is the whole answer, and it costs no read.
+			const directory = project(false);
+			try {
+				fs.writeFileSync(path.join(directory, "doc.qmd"), "```typst\n#circle()\n```\n");
+				const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.join(directory, "doc.qmd")));
+				const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, new TypstContextCache());
+				assert.ok(!isUnavailable(request));
+				assert.deepStrictEqual(request.argv, ["compile", "--format", "svg", "--root", directory, "-", "-"]);
+				assert.strictEqual(request.cwd, directory);
+			} finally {
+				fs.rmSync(directory, { recursive: true, force: true });
+			}
+		});
+
+		test("Should carry no root for a document that is not a file on disk", async () => {
+			const document = await documentOf("```typst\n#circle()\n```\n");
+			const request = await buildCompileRequest(document, new vscode.Position(1, 0), HEADER, new TypstContextCache());
+			assert.ok(!isUnavailable(request));
+			assert.deepStrictEqual(request.argv, ["compile", "--format", "svg", "-", "-"]);
+			assert.strictEqual(request.cwd, undefined);
+		});
+
 		test("Should say so when the cursor is in no block", async () => {
 			const document = await documentOf("Prose only.\n");
 			const request = await buildCompileRequest(document, new vscode.Position(0, 0), HEADER, new TypstContextCache());

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -173,8 +173,10 @@ export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
  * What makes two compiles the same compile.
  *
  * Beside the builder, so that what identifies an invocation cannot drift from
- * what one is. Joined on a character no argument carries, so two different
- * commands cannot be spelled the same way.
+ * what one is. The parts are joined on a NUL, which every path and every option
+ * this builds from a YAML document is free of. It is a cache key and not a
+ * signature: a caller that hand-built an argument holding a NUL could spell two
+ * commands the same way, and Typst would refuse to start on either of them.
  */
 export function commandKey(command: TypstCommand): string {
 	return [command.cwd ?? "", ...command.argv].join("\u0000");

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -1,5 +1,5 @@
 /**
- * The command line one compile runs under, ported from the `typst-render` filter.
+ * The command one compile runs, ported from the `typst-render` filter.
  *
  * The source reaches Typst on stdin, so Typst has no file directory to anchor a
  * relative path on and resolves every read against the compile root instead.
@@ -14,15 +14,20 @@
  * not would show an image the render does not produce.
  */
 
-import * as path from "node:path";
 import { mapping, type ResolvedTypstOptions, type TypstOptionValue } from "./typstOptions";
+import { compileCwd, resolveCompileRoot, resolveProjectPath, type TypstPaths } from "./typstPaths";
 
-/** Where one document sits, which is what every path here resolves against. */
-export interface TypstPaths {
-	/** The project root that owns the document, when one does. */
-	projectRoot?: string;
-	/** The directory holding the document, when it is a file on disk. */
-	documentDirectory?: string;
+/**
+ * One whole invocation of the compiler.
+ *
+ * The arguments and the directory travel together, because a relative
+ * `--font-path` means nothing without the directory it resolves against, and
+ * pairing an argv with the wrong one reads the fonts of another project.
+ */
+export interface TypstCommand {
+	argv: string[];
+	/** The directory to run from, absent when the document names none. */
+	cwd?: string;
 }
 
 /** The arguments that read the source from stdin and write the image to stdout. */
@@ -30,58 +35,6 @@ const STDIO: readonly string[] = ["-", "-"];
 
 /** The image format every surface can show, whatever the cell asks to render as. */
 const FORMAT: readonly string[] = ["compile", "--format", "svg"];
-
-/**
- * A `font-path` or `package-path` as the filter resolves it,
- * `_modules/paths.lua:34-48`.
- *
- * A leading `/` means the project root, and every other path is returned
- * unchanged: the filter leaves it relative, so it resolves against the working
- * directory of the compile. `compileCwd` is what makes that the same directory
- * here as it is under a render.
- *
- * This is not the rule `root`, `preamble` and `file` follow, which resolve a
- * relative path against the document instead.
- */
-export function resolveProjectPath(quartoPath: string, projectRoot: string | undefined): string {
-	if (quartoPath === "" || !quartoPath.startsWith("/")) {
-		return quartoPath;
-	}
-	const relative = quartoPath.slice(1);
-	return projectRoot === undefined ? path.normalize(relative) : path.join(projectRoot, relative);
-}
-
-/**
- * The compile root, `typst-render.lua:1195` and `:931-953`.
- *
- * A leading `/` means the project root, and every other value is relative to the
- * document directory. The default is `.`, which is the document directory
- * itself, and a document at the project root resolves the two to the same place.
- *
- * Undefined when the value names a place this cannot find: a document outside
- * every project has no root for a leading `/` to mean, and one that is not a
- * file on disk has no directory for a relative value to sit under. The root
- * confines every read a compile makes, so a guess would either widen it past the
- * document or point it somewhere the document never names.
- */
-export function resolveCompileRoot(root: string | undefined, paths: TypstPaths): string | undefined {
-	const value = root === undefined || root === "" ? "." : root;
-	if (value.startsWith("/")) {
-		return paths.projectRoot === undefined ? undefined : path.join(paths.projectRoot, value.slice(1));
-	}
-	const base = paths.documentDirectory ?? paths.projectRoot;
-	return base === undefined ? undefined : path.normalize(path.join(base, value));
-}
-
-/**
- * The directory a compile runs from.
- *
- * The project root, because that is where Quarto runs Typst from under a render
- * and because a relative `font-path` is left relative and resolves against it.
- */
-export function compileCwd(paths: TypstPaths): string | undefined {
-	return paths.projectRoot ?? paths.documentDirectory;
-}
 
 /**
  * A per-block `input:` string, `typst-render.lua:612-624`.
@@ -93,7 +46,7 @@ export function compileCwd(paths: TypstPaths): string | undefined {
  */
 export function parseInputString(value: string | undefined): Record<string, string> {
 	const parsed: Record<string, string> = {};
-	if (value === undefined || value === "") {
+	if (value === undefined) {
 		return parsed;
 	}
 	for (const pair of value.split(",")) {
@@ -108,15 +61,20 @@ export function parseInputString(value: string | undefined): Record<string, stri
 /**
  * The inputs one cell compiles with, `typst-render.lua:630-643`.
  *
- * The global mapping is what `input:` writes at a metadata level, and the block
- * string is what its own `//| input:` writes. A block value wins, which is the
+ * The mapping is what `input:` writes at a metadata level, and the string is
+ * what the cell's own `//| input:` writes. A block value wins, which is the
  * precedence every other option follows.
  */
 export function mergeInputs(
-	global: Record<string, string> | undefined,
+	global: TypstOptionValue | undefined,
 	blockInput: string | undefined,
 ): Record<string, string> {
-	return { ...global, ...parseInputString(blockInput) };
+	const map = mapping(global) ?? {};
+	const inputs: Record<string, string> = {};
+	for (const [key, value] of Object.entries(map)) {
+		inputs[key] = String(value);
+	}
+	return { ...inputs, ...parseInputString(blockInput) };
 }
 
 /**
@@ -134,20 +92,7 @@ export function typstColourHex(expression: string | undefined): string | undefin
 	return found === null ? undefined : found[1];
 }
 
-/** The `input:` mapping of the merged options, when it holds one. */
-function inputMapping(value: TypstOptionValue | undefined): Record<string, string> | undefined {
-	const map = mapping(value);
-	if (map === undefined) {
-		return undefined;
-	}
-	const inputs: Record<string, string> = {};
-	for (const [key, held] of Object.entries(map)) {
-		inputs[key] = String(held);
-	}
-	return inputs;
-}
-
-/** The `font-path:` of the merged options as a list, whichever shape it holds. */
+/** The `font-path:` of a configuration as a list, whichever shape it holds. */
 function fontPaths(value: TypstOptionValue | undefined): string[] {
 	if (value === undefined) {
 		return [];
@@ -155,10 +100,18 @@ function fontPaths(value: TypstOptionValue | undefined): string[] {
 	return Array.isArray(value) ? value.map(String) : [String(value)];
 }
 
-/** Everything one cell's command line is decided by. */
-export interface CellArgvRequest {
-	/** The merged options of the cell. */
-	options: ResolvedTypstOptions;
+/** Everything one command line is decided by. */
+export interface TypstCommandRequest {
+	/**
+	 * The global configuration of the document, merged lowest level first.
+	 *
+	 * The global configuration and not the merged options of the cell.
+	 * `typst-render.lua:1284-1293` reads `root`, `font-path` and `package-path`
+	 * from it alone, so a cell writing one of the three has no effect.
+	 *
+	 * A plain block and a raw block reach no filter and pass none of this.
+	 */
+	global?: ResolvedTypstOptions;
 	/** The cell's own `input:` string, which the merged options drop. */
 	blockInput?: string;
 	/** The page fill of the mode in force, as a Typst expression. */
@@ -169,8 +122,7 @@ export interface CellArgvRequest {
 }
 
 /**
- * The command line of one ```` ```{typst} ```` cell,
- * `typst-render.lua:1242-1262`.
+ * The command one block compiles under, `typst-render.lua:1242-1262`.
  *
  * The order is the filter's own, and the colour inputs come last on purpose: an
  * author who writes `typst-render-background` in their own `input:` mapping has
@@ -179,54 +131,51 @@ export interface CellArgvRequest {
  * `--ppi` is not emitted, because the preview compiles to SVG and the flag reads
  * on a raster format alone.
  */
-export function buildCellArgv(request: CellArgvRequest): string[] {
-	const { options, paths } = request;
+export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
+	const { global = {}, paths } = request;
 	const argv = [...FORMAT];
 
-	const root = resolveCompileRoot(options.root === undefined ? undefined : String(options.root), paths);
+	const root = resolveCompileRoot(global.root === undefined ? undefined : String(global.root), paths);
 	if (root !== undefined) {
 		argv.push("--root", root);
 	}
 
-	for (const fontPath of fontPaths(options["font-path"])) {
+	for (const fontPath of fontPaths(global["font-path"])) {
 		argv.push("--font-path", resolveProjectPath(fontPath, paths.projectRoot));
 	}
 
-	const packagePath = options["package-path"];
+	const packagePath = global["package-path"];
 	if (packagePath !== undefined) {
 		argv.push("--package-path", resolveProjectPath(String(packagePath), paths.projectRoot));
 	}
 
-	const inputs = mergeInputs(inputMapping(options.input), request.blockInput);
-	// Sorted, so two compiles of the same cell spell the same command line and
-	// share one cache entry.
+	// Sorted, so one cell spells one command line however the YAML was written.
+	const inputs = mergeInputs(global.input, request.blockInput);
 	for (const key of Object.keys(inputs).sort()) {
 		argv.push("--input", `${key}=${inputs[key]}`);
 	}
 
-	const foreground = typstColourHex(request.foreground);
-	if (foreground !== undefined) {
-		argv.push("--input", `typst-render-foreground=${foreground}`);
-	}
-	const background = typstColourHex(request.background);
-	if (background !== undefined) {
-		argv.push("--input", `typst-render-background=${background}`);
+	for (const [name, expression] of [
+		["typst-render-foreground", request.foreground],
+		["typst-render-background", request.background],
+	] as const) {
+		const hex = typstColourHex(expression);
+		if (hex !== undefined) {
+			argv.push("--input", `${name}=${hex}`);
+		}
 	}
 
-	return [...argv, ...STDIO];
+	argv.push(...STDIO);
+	return { argv, cwd: compileCwd(paths) };
 }
 
 /**
- * The command line of a plain block and of a raw block.
+ * What makes two compiles the same compile.
  *
- * Neither reaches the filter, so neither reads an option of it. The root is the
- * document directory alone, which is what makes a relative path in the block
- * resolve the way it reads: beside the document it is written in.
+ * Beside the builder, so that what identifies an invocation cannot drift from
+ * what one is. Joined on a character no argument carries, so two different
+ * commands cannot be spelled the same way.
  */
-export function buildBlockArgv(documentDirectory: string | undefined): string[] {
-	const argv = [...FORMAT];
-	if (documentDirectory !== undefined) {
-		argv.push("--root", documentDirectory);
-	}
-	return [...argv, ...STDIO];
+export function commandKey(command: TypstCommand): string {
+	return [command.cwd ?? "", ...command.argv].join("\u0000");
 }

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -1,0 +1,232 @@
+/**
+ * The command line one compile runs under, ported from the `typst-render` filter.
+ *
+ * The source reaches Typst on stdin, so Typst has no file directory to anchor a
+ * relative path on and resolves every read against the compile root instead.
+ * That makes `--root` the flag the whole feature depends on: without it the root
+ * is the working directory of the extension host, and a block reading a file
+ * beside its own document fails.
+ *
+ * Every rule here comes from `_extensions/typst-render/typst-render.lua` of
+ * `mcanouil/quarto-typst-render`, at the version pinned in
+ * `src/test/fixtures/typstPreview/README.md`. The port is bug-compatible, the
+ * same way `typstOptions.ts` is: a preview that resolved a path the filter does
+ * not would show an image the render does not produce.
+ */
+
+import * as path from "node:path";
+import { mapping, type ResolvedTypstOptions, type TypstOptionValue } from "./typstOptions";
+
+/** Where one document sits, which is what every path here resolves against. */
+export interface TypstPaths {
+	/** The project root that owns the document, when one does. */
+	projectRoot?: string;
+	/** The directory holding the document, when it is a file on disk. */
+	documentDirectory?: string;
+}
+
+/** The arguments that read the source from stdin and write the image to stdout. */
+const STDIO: readonly string[] = ["-", "-"];
+
+/** The image format every surface can show, whatever the cell asks to render as. */
+const FORMAT: readonly string[] = ["compile", "--format", "svg"];
+
+/**
+ * A `font-path` or `package-path` as the filter resolves it,
+ * `_modules/paths.lua:34-48`.
+ *
+ * A leading `/` means the project root, and every other path is returned
+ * unchanged: the filter leaves it relative, so it resolves against the working
+ * directory of the compile. `compileCwd` is what makes that the same directory
+ * here as it is under a render.
+ *
+ * This is not the rule `root`, `preamble` and `file` follow, which resolve a
+ * relative path against the document instead.
+ */
+export function resolveProjectPath(quartoPath: string, projectRoot: string | undefined): string {
+	if (quartoPath === "" || !quartoPath.startsWith("/")) {
+		return quartoPath;
+	}
+	const relative = quartoPath.slice(1);
+	return projectRoot === undefined ? path.normalize(relative) : path.join(projectRoot, relative);
+}
+
+/**
+ * The compile root, `typst-render.lua:1195` and `:931-953`.
+ *
+ * A leading `/` means the project root, and every other value is relative to the
+ * document directory. The default is `.`, which is the document directory
+ * itself, and a document at the project root resolves the two to the same place.
+ *
+ * Undefined when the value names a place this cannot find: a document outside
+ * every project has no root for a leading `/` to mean, and one that is not a
+ * file on disk has no directory for a relative value to sit under. The root
+ * confines every read a compile makes, so a guess would either widen it past the
+ * document or point it somewhere the document never names.
+ */
+export function resolveCompileRoot(root: string | undefined, paths: TypstPaths): string | undefined {
+	const value = root === undefined || root === "" ? "." : root;
+	if (value.startsWith("/")) {
+		return paths.projectRoot === undefined ? undefined : path.join(paths.projectRoot, value.slice(1));
+	}
+	const base = paths.documentDirectory ?? paths.projectRoot;
+	return base === undefined ? undefined : path.normalize(path.join(base, value));
+}
+
+/**
+ * The directory a compile runs from.
+ *
+ * The project root, because that is where Quarto runs Typst from under a render
+ * and because a relative `font-path` is left relative and resolves against it.
+ */
+export function compileCwd(paths: TypstPaths): string | undefined {
+	return paths.projectRoot ?? paths.documentDirectory;
+}
+
+/**
+ * A per-block `input:` string, `typst-render.lua:612-624`.
+ *
+ * Comma-separated `key=value` pairs, trimmed around both halves. An entry with
+ * no `=` and one with an empty key are dropped, and an entry whose value is
+ * empty is kept, because clearing an inherited input is a thing an author can
+ * mean.
+ */
+export function parseInputString(value: string | undefined): Record<string, string> {
+	const parsed: Record<string, string> = {};
+	if (value === undefined || value === "") {
+		return parsed;
+	}
+	for (const pair of value.split(",")) {
+		const found = /^\s*(.*?)\s*=\s*(.*?)\s*$/.exec(pair);
+		if (found !== null && found[1] !== "") {
+			parsed[found[1]] = found[2];
+		}
+	}
+	return parsed;
+}
+
+/**
+ * The inputs one cell compiles with, `typst-render.lua:630-643`.
+ *
+ * The global mapping is what `input:` writes at a metadata level, and the block
+ * string is what its own `//| input:` writes. A block value wins, which is the
+ * precedence every other option follows.
+ */
+export function mergeInputs(
+	global: Record<string, string> | undefined,
+	blockInput: string | undefined,
+): Record<string, string> {
+	return { ...global, ...parseInputString(blockInput) };
+}
+
+/**
+ * The hex a colour expression carries, `typst-render.lua:748-751`.
+ *
+ * A flag can carry a hex and nothing else, so every other expression resolves to
+ * no input at all. The `#let` bindings the source already carries are what a
+ * block reads those from.
+ */
+export function typstColourHex(expression: string | undefined): string | undefined {
+	if (expression === undefined) {
+		return undefined;
+	}
+	const found = /^rgb\("(#[0-9a-fA-F]+)"\)$/.exec(expression);
+	return found === null ? undefined : found[1];
+}
+
+/** The `input:` mapping of the merged options, when it holds one. */
+function inputMapping(value: TypstOptionValue | undefined): Record<string, string> | undefined {
+	const map = mapping(value);
+	if (map === undefined) {
+		return undefined;
+	}
+	const inputs: Record<string, string> = {};
+	for (const [key, held] of Object.entries(map)) {
+		inputs[key] = String(held);
+	}
+	return inputs;
+}
+
+/** The `font-path:` of the merged options as a list, whichever shape it holds. */
+function fontPaths(value: TypstOptionValue | undefined): string[] {
+	if (value === undefined) {
+		return [];
+	}
+	return Array.isArray(value) ? value.map(String) : [String(value)];
+}
+
+/** Everything one cell's command line is decided by. */
+export interface CellArgvRequest {
+	/** The merged options of the cell. */
+	options: ResolvedTypstOptions;
+	/** The cell's own `input:` string, which the merged options drop. */
+	blockInput?: string;
+	/** The page fill of the mode in force, as a Typst expression. */
+	background?: string;
+	/** The text fill of the mode in force, absent when the cell sets none. */
+	foreground?: string;
+	paths: TypstPaths;
+}
+
+/**
+ * The command line of one ```` ```{typst} ```` cell,
+ * `typst-render.lua:1242-1262`.
+ *
+ * The order is the filter's own, and the colour inputs come last on purpose: an
+ * author who writes `typst-render-background` in their own `input:` mapping has
+ * it overridden by the resolved colour, the same way a render does.
+ *
+ * `--ppi` is not emitted, because the preview compiles to SVG and the flag reads
+ * on a raster format alone.
+ */
+export function buildCellArgv(request: CellArgvRequest): string[] {
+	const { options, paths } = request;
+	const argv = [...FORMAT];
+
+	const root = resolveCompileRoot(options.root === undefined ? undefined : String(options.root), paths);
+	if (root !== undefined) {
+		argv.push("--root", root);
+	}
+
+	for (const fontPath of fontPaths(options["font-path"])) {
+		argv.push("--font-path", resolveProjectPath(fontPath, paths.projectRoot));
+	}
+
+	const packagePath = options["package-path"];
+	if (packagePath !== undefined) {
+		argv.push("--package-path", resolveProjectPath(String(packagePath), paths.projectRoot));
+	}
+
+	const inputs = mergeInputs(inputMapping(options.input), request.blockInput);
+	// Sorted, so two compiles of the same cell spell the same command line and
+	// share one cache entry.
+	for (const key of Object.keys(inputs).sort()) {
+		argv.push("--input", `${key}=${inputs[key]}`);
+	}
+
+	const foreground = typstColourHex(request.foreground);
+	if (foreground !== undefined) {
+		argv.push("--input", `typst-render-foreground=${foreground}`);
+	}
+	const background = typstColourHex(request.background);
+	if (background !== undefined) {
+		argv.push("--input", `typst-render-background=${background}`);
+	}
+
+	return [...argv, ...STDIO];
+}
+
+/**
+ * The command line of a plain block and of a raw block.
+ *
+ * Neither reaches the filter, so neither reads an option of it. The root is the
+ * document directory alone, which is what makes a relative path in the block
+ * resolve the way it reads: beside the document it is written in.
+ */
+export function buildBlockArgv(documentDirectory: string | undefined): string[] {
+	const argv = [...FORMAT];
+	if (documentDirectory !== undefined) {
+		argv.push("--root", documentDirectory);
+	}
+	return [...argv, ...STDIO];
+}

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -173,14 +173,18 @@ export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
  * What makes two compiles the same compile.
  *
  * Beside the builder, so that what identifies an invocation cannot drift from
- * what one is. The parts are joined on a NUL, which every path and every option
- * this builds from a YAML document is free of. It is a cache key and not a
- * signature: a caller that hand-built an argument holding a NUL could spell two
- * commands the same way, and Typst would refuse to start on either of them.
+ * what one is.
  *
- * An absent directory is written as an empty one, which `compileCwd` never
- * answers: it returns a directory or nothing at all, so the two cannot collide.
+ * Each part carries its own length rather than a separator between parts. An
+ * `input:` value is a YAML string and can hold any character at all, a NUL
+ * included, so there is no character a separator could rely on. A command whose
+ * argument holds one never spawns, and giving it the key of a command that does
+ * spawn would serve that command's image for the wrong document.
+ *
+ * An absent directory is marked apart from an empty one, so the two cannot be
+ * read as one command.
  */
 export function commandKey(command: TypstCommand): string {
-	return [command.cwd ?? "", ...command.argv].join("\u0000");
+	const parts = command.cwd === undefined ? command.argv : [command.cwd, ...command.argv];
+	return parts.reduce((key, part) => `${key}${part.length}:${part}`, command.cwd === undefined ? "-" : "+");
 }

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -177,6 +177,9 @@ export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
  * this builds from a YAML document is free of. It is a cache key and not a
  * signature: a caller that hand-built an argument holding a NUL could spell two
  * commands the same way, and Typst would refuse to start on either of them.
+ *
+ * An absent directory is written as an empty one, which `compileCwd` never
+ * answers: it returns a directory or nothing at all, so the two cannot collide.
  */
 export function commandKey(command: TypstCommand): string {
 	return [command.cwd ?? "", ...command.argv].join("\u0000");

--- a/src/utils/typst/typstOptions.ts
+++ b/src/utils/typst/typstOptions.ts
@@ -123,8 +123,10 @@ export const TYPST_DEFAULTS: ResolvedTypstOptions = Object.freeze({
  *
  * `root`, `font-path` and `package-path` run the other way: they are read from
  * the global configuration alone (`typst-render.lua:1284-1293` and `:1332`) and
- * never from the merged table, so a block writing `root:` has no effect. Nothing
- * here has to enforce that, because none of the three reaches the source.
+ * never from the merged table, so a block writing `root:` has no effect. None of
+ * the three reaches the source, and all three reach the command line, so the
+ * rule is enforced where the command is built: `buildCell` hands
+ * `buildTypstCommand` the global configuration and not the merged options.
  */
 const GLOBAL_KEYS: readonly string[] = [
 	"format",

--- a/src/utils/typst/typstPaths.ts
+++ b/src/utils/typst/typstPaths.ts
@@ -1,0 +1,83 @@
+/**
+ * The two path rules Quarto and the `typst-render` filter resolve against.
+ *
+ * They are separate rules and they are easy to conflate. `preamble`, `file` and
+ * `brand` resolve a relative path against the document, and `font-path` and
+ * `package-path` leave one relative for the working directory of the compile to
+ * decide. Conflating the two reads a file from the wrong directory in every
+ * project whose documents are not at its root.
+ *
+ * No `vscode` here, the way nothing under `src/utils/typst/` imports it, so both
+ * the metadata reader and the command line builder can use the same rule.
+ */
+
+import * as path from "node:path";
+
+/** Where one document sits, which is what every path here resolves against. */
+export interface TypstPaths {
+	/** The project root that owns the document, when one does. */
+	projectRoot?: string;
+	/** The directory holding the document, when it is a file on disk. */
+	documentDirectory?: string;
+}
+
+/**
+ * A path Quarto resolves against a document or a project,
+ * `_modules/paths.lua:34-48` and `src/project/project-shared.ts:574-584`.
+ *
+ * A leading `/` means the project root, and every other path is relative to the
+ * directory passed in. Undefined when there is no directory to resolve against,
+ * which is a document that lives outside every project root.
+ */
+export function resolveQuartoPath(
+	quartoPath: string,
+	from: string | undefined,
+	projectRoot: string | undefined,
+): string | undefined {
+	const fromProjectRoot = quartoPath.startsWith("/");
+	const base = fromProjectRoot ? projectRoot : from;
+	return base === undefined ? undefined : path.join(base, fromProjectRoot ? quartoPath.slice(1) : quartoPath);
+}
+
+/**
+ * A `font-path` or `package-path` as the filter resolves it,
+ * `_modules/paths.lua:34-48`.
+ *
+ * A leading `/` means the project root, and every other path is returned
+ * unchanged: the filter leaves it relative, so it resolves against the working
+ * directory of the compile. `compileCwd` is what makes that the same directory
+ * here as it is under a render.
+ */
+export function resolveProjectPath(quartoPath: string, projectRoot: string | undefined): string {
+	if (!quartoPath.startsWith("/")) {
+		return quartoPath;
+	}
+	return path.join(projectRoot ?? "", quartoPath.slice(1));
+}
+
+/**
+ * The compile root, `typst-render.lua:1195` and `:931-953`.
+ *
+ * The `root` option, resolved the way `preamble` and `file` are: a leading `/`
+ * means the project root, and every other value is relative to the document
+ * directory. The default is `.`, which is the document directory itself.
+ *
+ * Undefined when the value names a place this cannot find, which is a document
+ * that is neither in a project nor a file on disk. The root confines every read
+ * a compile makes, so a guess would either widen it past the document or point
+ * it somewhere the document never names.
+ */
+export function resolveCompileRoot(root: string | undefined, paths: TypstPaths): string | undefined {
+	const value = root === undefined || root === "" ? "." : root;
+	return resolveQuartoPath(value, paths.documentDirectory ?? paths.projectRoot, paths.projectRoot);
+}
+
+/**
+ * The directory a compile runs from.
+ *
+ * The project root, because that is where Quarto runs Typst from under a render
+ * and because a relative `font-path` is left relative and resolves against it.
+ */
+export function compileCwd(paths: TypstPaths): string | undefined {
+	return paths.projectRoot ?? paths.documentDirectory;
+}

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -1,6 +1,7 @@
 import { precedingRawBlocks, type TypstBlock } from "./typstBlocks";
 import { brandColourReader, brandDictionary, type Brand } from "./typstBrand";
-import { buildCellArgv, type TypstPaths } from "./typstCli";
+import { buildTypstCommand, type TypstCommand } from "./typstCli";
+import type { TypstPaths } from "./typstPaths";
 import {
 	TYPST_DEFAULTS,
 	mergeGlobalConfigs,
@@ -298,13 +299,13 @@ export interface CellContext {
 	/** Which side of the brand the compile reads. */
 	mode: TypstBrandMode;
 	/**
-	 * Where the document sits, which is what the command line resolves against.
+	 * Where the document sits, which is what the command resolves against.
 	 *
 	 * Two plain strings, so this module still imports no `vscode` and a fixture
-	 * still drives the whole pipeline without a workspace. A caller with neither
-	 * passes neither, and the compile then carries no root.
+	 * still drives the whole pipeline without a workspace. A document with
+	 * neither passes an empty pair, and the compile then carries no root.
 	 */
-	paths?: TypstPaths;
+	paths: TypstPaths;
 	readFile: ReadFile;
 }
 
@@ -320,8 +321,8 @@ export function isUnavailable<T extends object>(result: T | Unavailable): result
 
 /** One cell assembled, with what the preview does not reproduce about it. */
 export interface AssembledCell extends AssembledSource {
-	/** The command line the cell compiles under. */
-	argv: string[];
+	/** The command the cell compiles under. */
+	command: TypstCommand;
 	/** What the panel should say about the block beside the image. */
 	notes: string[];
 	/**
@@ -423,15 +424,16 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	// the read and compiles the body, and reporting it as the external file would
 	// print a position "of " with no name and drop the option run correction.
 	const externalFile = code === undefined ? undefined : options.file;
-	// The block's own `input:` is read from the block and not from the merged
-	// options, because the merge drops it: it is a string per block and a mapping
-	// globally, and the two cannot live under one key.
-	const argv = buildCellArgv({
-		options,
+	// The global configuration and not the merged options, because the filter
+	// reads `root`, `font-path` and `package-path` from it alone. The block's own
+	// `input:` is read from the block, because the merge drops it: it is a string
+	// per block and a mapping globally, and the two cannot live under one key.
+	const command = buildTypstCommand({
+		global,
 		blockInput: typeof block.options.input === "string" ? block.options.input : undefined,
 		background,
 		foreground,
-		paths: context.paths ?? {},
+		paths: context.paths,
 	});
-	return { ...assembled, argv, notes: cellNotes(options), bodyLineOffset, externalFile };
+	return { ...assembled, command, notes: cellNotes(options), bodyLineOffset, externalFile };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -1,5 +1,6 @@
 import { precedingRawBlocks, type TypstBlock } from "./typstBlocks";
 import { brandColourReader, brandDictionary, type Brand } from "./typstBrand";
+import { buildCellArgv, type TypstPaths } from "./typstCli";
 import {
 	TYPST_DEFAULTS,
 	mergeGlobalConfigs,
@@ -296,6 +297,14 @@ export interface CellContext {
 	brand: Brand;
 	/** Which side of the brand the compile reads. */
 	mode: TypstBrandMode;
+	/**
+	 * Where the document sits, which is what the command line resolves against.
+	 *
+	 * Two plain strings, so this module still imports no `vscode` and a fixture
+	 * still drives the whole pipeline without a workspace. A caller with neither
+	 * passes neither, and the compile then carries no root.
+	 */
+	paths?: TypstPaths;
 	readFile: ReadFile;
 }
 
@@ -311,6 +320,8 @@ export function isUnavailable<T extends object>(result: T | Unavailable): result
 
 /** One cell assembled, with what the preview does not reproduce about it. */
 export interface AssembledCell extends AssembledSource {
+	/** The command line the cell compiles under. */
+	argv: string[];
 	/** What the panel should say about the block beside the image. */
 	notes: string[];
 	/**
@@ -392,12 +403,15 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	const bodyLineOffset =
 		code === undefined ? block.body.slice(0, block.body.length - block.code.length).split("\n").length - 1 : 0;
 
+	// The fallback is `DEFAULTS.background`, which `resolve_opts_colours` applies
+	// at `typst-render.lua:884`. Only the background has one: a cell with no
+	// foreground writes no text fill line at all.
+	const background = resolveColourValue(options.background, context.mode) ?? String(TYPST_DEFAULTS.background);
+	const foreground = resolveColourValue(options.foreground, context.mode);
+
 	const assembled = buildCellSource(block, {
-		// The fallback is `DEFAULTS.background`, which `resolve_opts_colours` applies
-		// at `typst-render.lua:884`. Only the background has one: a cell with no
-		// foreground writes no text fill line at all.
-		background: resolveColourValue(options.background, context.mode) ?? String(TYPST_DEFAULTS.background),
-		foreground: resolveColourValue(options.foreground, context.mode),
+		background,
+		foreground,
 		width: String(options.width),
 		height: String(options.height),
 		margin: String(options.margin),
@@ -409,5 +423,15 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	// the read and compiles the body, and reporting it as the external file would
 	// print a position "of " with no name and drop the option run correction.
 	const externalFile = code === undefined ? undefined : options.file;
-	return { ...assembled, notes: cellNotes(options), bodyLineOffset, externalFile };
+	// The block's own `input:` is read from the block and not from the merged
+	// options, because the merge drops it: it is a string per block and a mapping
+	// globally, and the two cannot live under one key.
+	const argv = buildCellArgv({
+		options,
+		blockInput: typeof block.options.input === "string" ? block.options.input : undefined,
+		background,
+		foreground,
+		paths: context.paths ?? {},
+	});
+	return { ...assembled, argv, notes: cellNotes(options), bodyLineOffset, externalFile };
 }


### PR DESCRIPTION
The Typst preview sends the source to the compiler on standard input, and it passed no `--root` and no working directory.
Typst then resolved every relative path from the working directory of the extension host, so a block that read a file beside its own document failed with `file not found (searched at /data/...)`.

The command line is now built for each document, from the same rules the `typst-render` filter follows.

- A `{typst}` cell carries the `root`, `font-path`, `package-path` and `input` values of the extension, and the two colour inputs the filter passes, read from the global configuration alone.
- A plain block and a raw block are rooted at the directory of their document.
- A compile runs from the project directory, which is what a relative `font-path` resolves against.

The arguments and that directory travel as one `TypstCommand`, so no site can pair one with the wrong other, and the result cache keys on it.
The two Quarto path rules move into `src/utils/typst/typstPaths.ts`, shared by the metadata reader and the command builder.

`docs/getting-started/typst-preview.qmd` gains a section on how a path resolves, and it no longer claims the preview compiles under a narrower root than a render.