### PR TITLE
feat: link the file a Typst option names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 
 - feat: preview a Typst block from a Quarto document. The block under the cursor compiles with the Typst binary that ships inside Quarto, and the image is shown in a panel beside the editor or in a hover. (#395)
-- feat: open the file that a `file:` or a `preamble:` option names. The value is a link in a `{typst}` cell, in the front matter of a document, and in a configuration file, and a path that leads to no file carries a warning.
+- feat: open the file that a `file:` or a `preamble:` option names. The value is a link in a `{typst}` cell, in the front matter of a document, and in a configuration file, and a path that leads to no file carries a warning. (#402)
 - feat: publish the Lua reference validator of the v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/schema.lua`. The vocabulary and the validator carry the same version, and extensions can now resolve the module by URL. (#374)
 - feat: accept `uniqueItems` in a field descriptor. The Lua reference validator already enforced the keyword, and the meta-schema now allows it, so a schema that uses it passes both. (#378)
 - docs: add a reference page that describes how an extension loads and calls the Lua reference validator. The page separates the meta-schema, which validates a schema file while you write it, from the module, which validates document metadata during a render. (#383)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - feat: preview a Typst block from a Quarto document. The block under the cursor compiles with the Typst binary that ships inside Quarto, and the image is shown in a panel beside the editor or in a hover. (#395)
+- feat: open the file that a `file:` or a `preamble:` option names. The value is a link in a `{typst}` cell, in the front matter of a document, and in a configuration file, and a path that leads to no file carries a warning.
 - feat: publish the Lua reference validator of the v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/schema.lua`. The vocabulary and the validator carry the same version, and extensions can now resolve the module by URL. (#374)
 - feat: accept `uniqueItems` in a field descriptor. The Lua reference validator already enforced the keyword, and the meta-schema now allows it, so a schema that uses it passes both. (#378)
 - docs: add a reference page that describes how an extension loads and calls the Lua reference validator. The page separates the meta-schema, which validates a schema file while you write it, from the module, which validates document metadata during a render. (#383)

--- a/docs/getting-started/typst-preview.qmd
+++ b/docs/getting-started/typst-preview.qmd
@@ -80,6 +80,24 @@ A `{typst}` cell also compiles with the `font-path`, the `package-path` and the 
 A font path or a package path that starts with `/` resolves from the project root.
 Every other value stays relative, and the compile runs from the project root.
 
+## Opening a File an Option Names
+
+A `file:` option and a `preamble:` option name a file.
+Hold Ctrl, or Cmd on macOS, and select the value to open that file in the editor.
+The link appears only when the file is there.
+
+The two options accept the same paths as the preview.
+A value that starts with `/` resolves from the project root.
+Every other value resolves from the directory of the document.
+A `preamble:` entry that does not end with `.typ` is inline Typst code, so it is not a link.
+
+`file:` is a cell option alone.
+`preamble:` also works in the front matter of a document, and in `_quarto.yml` or `_metadata.yml` under `typst-render`.
+
+When a path in a document leads to no file, the editor shows a warning on the value.
+A relative path in a configuration file gets no warning.
+Every document that reads the file resolves the path from its own directory, so the file itself cannot say where the path leads.
+
 ## Commands
 
 | Command                             | What it does                                                                                           |

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { registerElementAttributeProviders } from "./providers/elementAttributeC
 import { registerInlineAttributeDiagnostics } from "./providers/inlineAttributeDiagnosticsProvider";
 import { registerSnippetCompletionProvider } from "./providers/snippetCompletionProvider";
 import { registerTypstPreview } from "./providers/typstPreview";
+import { registerTypstPathLinks } from "./providers/typstPathLinks";
 
 /**
  * This method is called when the extension is activated.
@@ -167,6 +168,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register the Typst block preview for Quarto documents
 	registerTypstPreview(context);
+
+	// Register the links the `file:` and `preamble:` options of a document carry
+	registerTypstPathLinks(context);
 
 	// Register URI handler for browser-based extension installation (e.g., vscode://mcanouil.quarto-wizard/install?repo=owner/repo)
 	context.subscriptions.push(

--- a/src/providers/typstPathLinks.ts
+++ b/src/providers/typstPathLinks.ts
@@ -4,6 +4,7 @@ import { debounce } from "../utils/debounce";
 import { logMessage } from "../utils/log";
 import { isRelevantYaml } from "../utils/metadataFilesRegistry";
 import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
+import { isFile } from "../utils/quartoProjectDiscovery";
 import {
 	findTypstPathOptions,
 	resolveTypstPathOption,
@@ -36,16 +37,6 @@ interface ResolvedPathOption {
 	target: TypstPathTarget;
 	/** Whether a file is there to open. */
 	present: boolean;
-}
-
-/** Whether a path names a file that is there. */
-async function isFile(fsPath: string): Promise<boolean> {
-	try {
-		const stat = await vscode.workspace.fs.stat(vscode.Uri.file(fsPath));
-		return (stat.type & vscode.FileType.File) !== 0;
-	} catch {
-		return false;
-	}
 }
 
 /**
@@ -168,7 +159,8 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 		return Promise.all(
 			options.map(async (option) => {
 				const target = resolveTypstPathOption(option.value, context);
-				return { option, target, present: target.path !== undefined && (await isFile(target.path)) };
+				const present = target.path !== undefined && (await isFile(vscode.Uri.file(target.path)));
+				return { option, target, present };
 			}),
 		);
 	}

--- a/src/providers/typstPathLinks.ts
+++ b/src/providers/typstPathLinks.ts
@@ -1,0 +1,190 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { debounce } from "../utils/debounce";
+import { logMessage } from "../utils/log";
+import { isRelevantYaml } from "../utils/metadataFilesRegistry";
+import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
+import {
+	findTypstPathOptions,
+	resolveTypstPathOption,
+	type TypstPathOption,
+	type TypstPathTarget,
+} from "../utils/typst/typstPathOptions";
+
+/**
+ * The documents an option can be written in.
+ *
+ * A `.qmd` carries a cell and a front matter, and a YAML file carries a level
+ * of the metadata chain. Which YAML files those are is
+ * {@link isRelevantYaml}'s answer, because a `metadata-files:` target holds a
+ * `typst-render` mapping the same way `_quarto.yml` does.
+ */
+const SELECTOR: vscode.DocumentSelector = [
+	{ language: "quarto", scheme: "file" },
+	{ language: "yaml", scheme: "file" },
+];
+
+/** How long an edit settles before the paths of a document are read again. */
+const DEBOUNCE_MS = 500;
+
+/** The diagnostic put on a path that leads to no file. */
+const MISSING_PATH = "typst-missing-path";
+
+/** One option, and the file it leads to. */
+interface ResolvedPathOption {
+	option: TypstPathOption;
+	target: TypstPathTarget;
+	/** Whether a file is there to open. */
+	present: boolean;
+}
+
+/** Whether a path names a file that is there. */
+async function isFile(fsPath: string): Promise<boolean> {
+	try {
+		const stat = await vscode.workspace.fs.stat(vscode.Uri.file(fsPath));
+		return (stat.type & vscode.FileType.File) !== 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The `file:` and `preamble:` paths of a Quarto document, as links to follow
+ * and as a diagnostic when they lead nowhere.
+ *
+ * The two surfaces share one reader, because a link and a warning are two
+ * answers to the same question and reading the document twice would let them
+ * disagree.
+ */
+export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Disposable {
+	private readonly diagnostics = vscode.languages.createDiagnosticCollection("quarto-typst-paths");
+	private readonly disposables: vscode.Disposable[] = [];
+	private readonly validateLater: ReturnType<typeof debounce>;
+
+	constructor() {
+		this.validateLater = debounce((document: vscode.TextDocument) => {
+			void this.refresh(document);
+		}, DEBOUNCE_MS);
+
+		this.disposables.push(
+			vscode.workspace.onDidOpenTextDocument((document) => void this.refresh(document)),
+			vscode.workspace.onDidChangeTextDocument((event) => this.validateLater(event.document)),
+			vscode.workspace.onDidCloseTextDocument((document) => this.diagnostics.delete(document.uri)),
+		);
+
+		// A path that led nowhere leads somewhere once the file is written, and
+		// nothing about the document itself changed when that happened.
+		const watcher = vscode.workspace.createFileSystemWatcher("**/*.typ");
+		this.disposables.push(
+			watcher,
+			watcher.onDidCreate(() => this.validateOpen()),
+			watcher.onDidDelete(() => this.validateOpen()),
+		);
+
+		this.validateOpen();
+	}
+
+	dispose(): void {
+		this.validateLater.cancel();
+		this.diagnostics.dispose();
+		for (const disposable of this.disposables) {
+			disposable.dispose();
+		}
+	}
+
+	async provideDocumentLinks(document: vscode.TextDocument): Promise<vscode.DocumentLink[]> {
+		const resolved = await this.resolve(document);
+		const links: vscode.DocumentLink[] = [];
+		for (const { option, target, present } of resolved) {
+			// Only a file that is there is offered. A link to a path that leads
+			// nowhere opens an empty editor, which says less than the warning the
+			// same reading writes.
+			if (!present || target.path === undefined) {
+				continue;
+			}
+			const uri = vscode.Uri.file(target.path);
+			const link = new vscode.DocumentLink(this.rangeOf(document, option), uri);
+			link.tooltip = vscode.workspace.asRelativePath(uri);
+			links.push(link);
+		}
+		return links;
+	}
+
+	/** Read every open document again, after something outside them changed. */
+	private validateOpen(): void {
+		for (const document of vscode.workspace.textDocuments) {
+			void this.refresh(document);
+		}
+	}
+
+	/**
+	 * Read one document again, and set the warnings it carries.
+	 *
+	 * Public so that a test can wait for the reading it starts. Every caller
+	 * inside the class starts it and does not wait.
+	 */
+	async refresh(document: vscode.TextDocument): Promise<void> {
+		const resolved = await this.resolve(document);
+		if (document.isClosed) {
+			return;
+		}
+
+		const diagnostics: vscode.Diagnostic[] = [];
+		for (const { option, target, present } of resolved) {
+			if (present || !target.reportable || target.path === undefined) {
+				continue;
+			}
+			const diagnostic = new vscode.Diagnostic(
+				this.rangeOf(document, option),
+				`The \`${option.key}\` option names \`${option.value}\`, and there is no file at \`${target.path}\`.`,
+				vscode.DiagnosticSeverity.Warning,
+			);
+			diagnostic.code = MISSING_PATH;
+			diagnostic.source = "quarto-wizard";
+			diagnostics.push(diagnostic);
+		}
+		this.diagnostics.set(document.uri, diagnostics);
+	}
+
+	/** Every path option of a document, with the file each one leads to. */
+	private async resolve(document: vscode.TextDocument): Promise<ResolvedPathOption[]> {
+		// A document that is not on disk resolves no relative path, and a YAML file
+		// that is no part of the metadata chain carries no option of this kind.
+		if (document.uri.scheme !== "file" || !isRelevantYaml(document)) {
+			return [];
+		}
+
+		const options = findTypstPathOptions(document.getText(), document.languageId);
+		if (options.length === 0) {
+			return [];
+		}
+
+		const context = {
+			directory: path.dirname(document.uri.fsPath),
+			projectRoot: await findOwningProjectRoot(document.uri),
+			configuration: document.languageId === "yaml",
+		};
+
+		return Promise.all(
+			options.map(async (option) => {
+				const target = resolveTypstPathOption(option.value, context);
+				return { option, target, present: target.path !== undefined && (await isFile(target.path)) };
+			}),
+		);
+	}
+
+	private rangeOf(document: vscode.TextDocument, option: TypstPathOption): vscode.Range {
+		return new vscode.Range(document.positionAt(option.start), document.positionAt(option.end));
+	}
+}
+
+/**
+ * Register the links and the warning that the `file:` and `preamble:` options
+ * of a document carry.
+ */
+export function registerTypstPathLinks(context: vscode.ExtensionContext): void {
+	const provider = new TypstPathLinks();
+	context.subscriptions.push(provider);
+	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(SELECTOR, provider));
+	logMessage("Typst path links registered.", "debug");
+}

--- a/src/providers/typstPathLinks.ts
+++ b/src/providers/typstPathLinks.ts
@@ -111,13 +111,20 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 	/**
 	 * Read one document again, and set the warnings it carries.
 	 *
-	 * Public so that a test can wait for the reading it starts. Every caller
+	 * Public, and it answers with what it wrote, so that a test can wait for the
+	 * reading it starts and read the result of that reading alone. Every caller
 	 * inside the class starts it and does not wait.
+	 *
+	 * The answer is empty when the document moved on while the paths were read.
+	 * The offsets were taken in the older text, so writing them now would put a
+	 * warning on characters that no longer carry the path, and an older reading
+	 * that finishes last would undo a newer one.
 	 */
-	async refresh(document: vscode.TextDocument): Promise<void> {
+	async refresh(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+		const version = document.version;
 		const resolved = await this.resolve(document);
-		if (document.isClosed) {
-			return;
+		if (document.isClosed || document.version !== version) {
+			return [];
 		}
 
 		const diagnostics: vscode.Diagnostic[] = [];
@@ -135,6 +142,7 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 			diagnostics.push(diagnostic);
 		}
 		this.diagnostics.set(document.uri, diagnostics);
+		return diagnostics;
 	}
 
 	/** Every path option of a document, with the file each one leads to. */

--- a/src/providers/typstPathLinks.ts
+++ b/src/providers/typstPathLinks.ts
@@ -50,17 +50,27 @@ interface ResolvedPathOption {
 export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Disposable {
 	private readonly diagnostics = vscode.languages.createDiagnosticCollection("quarto-typst-paths");
 	private readonly disposables: vscode.Disposable[] = [];
-	private readonly validateLater: ReturnType<typeof debounce>;
+	/**
+	 * The pending reading of each document, one per document.
+	 *
+	 * A single debounced function holds the arguments of its last call alone, so
+	 * two documents edited inside one window would leave the first of them with
+	 * the warnings of the text it no longer holds.
+	 */
+	private readonly pending = new Map<string, ReturnType<typeof debounce>>();
+	/**
+	 * How many readings of each document have started.
+	 *
+	 * A watcher and an edit can read the same text at the same time, and the
+	 * slower of the two would write its result over the newer one.
+	 */
+	private readonly readings = new Map<string, number>();
 
 	constructor() {
-		this.validateLater = debounce((document: vscode.TextDocument) => {
-			void this.refresh(document);
-		}, DEBOUNCE_MS);
-
 		this.disposables.push(
 			vscode.workspace.onDidOpenTextDocument((document) => void this.refresh(document)),
-			vscode.workspace.onDidChangeTextDocument((event) => this.validateLater(event.document)),
-			vscode.workspace.onDidCloseTextDocument((document) => this.diagnostics.delete(document.uri)),
+			vscode.workspace.onDidChangeTextDocument((event) => this.refreshLater(event.document)),
+			vscode.workspace.onDidCloseTextDocument((document) => this.forget(document)),
 		);
 
 		// A path that led nowhere leads somewhere once the file is written, and
@@ -76,7 +86,11 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 	}
 
 	dispose(): void {
-		this.validateLater.cancel();
+		for (const later of this.pending.values()) {
+			later.cancel();
+		}
+		this.pending.clear();
+		this.readings.clear();
 		this.diagnostics.dispose();
 		for (const disposable of this.disposables) {
 			disposable.dispose();
@@ -101,6 +115,28 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 		return links;
 	}
 
+	/** Read one document again once its edits settle. */
+	private refreshLater(document: vscode.TextDocument): void {
+		const key = document.uri.toString();
+		let later = this.pending.get(key);
+		if (later === undefined) {
+			// The editor holds one document object per open URI, so the one captured
+			// here is the one the key names for as long as it is open.
+			later = debounce(() => void this.refresh(document), DEBOUNCE_MS);
+			this.pending.set(key, later);
+		}
+		later();
+	}
+
+	/** Drop everything held for a document that is closed. */
+	private forget(document: vscode.TextDocument): void {
+		const key = document.uri.toString();
+		this.pending.get(key)?.cancel();
+		this.pending.delete(key);
+		this.readings.delete(key);
+		this.diagnostics.delete(document.uri);
+	}
+
 	/** Read every open document again, after something outside them changed. */
 	private validateOpen(): void {
 		for (const document of vscode.workspace.textDocuments) {
@@ -121,9 +157,15 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 	 * that finishes last would undo a newer one.
 	 */
 	async refresh(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+		const key = document.uri.toString();
+		const reading = (this.readings.get(key) ?? 0) + 1;
+		this.readings.set(key, reading);
 		const version = document.version;
+
 		const resolved = await this.resolve(document);
-		if (document.isClosed || document.version !== version) {
+		// The text moved on, or another reading of the same text started after
+		// this one and has already written what it found.
+		if (document.isClosed || document.version !== version || this.readings.get(key) !== reading) {
 			return [];
 		}
 

--- a/src/test/suite/typstPathLinks.test.ts
+++ b/src/test/suite/typstPathLinks.test.ts
@@ -1,0 +1,89 @@
+import * as assert from "assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { TypstPathLinks } from "../../providers/typstPathLinks";
+
+/** The document of a directory written for one case. */
+async function open(directory: string, name: string, content: string): Promise<vscode.TextDocument> {
+	const file = path.join(directory, name);
+	fs.writeFileSync(file, content, "utf8");
+	return vscode.workspace.openTextDocument(vscode.Uri.file(file));
+}
+
+/** The warnings this provider wrote, and none of the ones other providers did. */
+function missingPaths(uri: vscode.Uri): vscode.Diagnostic[] {
+	return vscode.languages.getDiagnostics(uri).filter((diagnostic) => diagnostic.code === "typst-missing-path");
+}
+
+suite("Typst Path Links Test Suite", () => {
+	let directory: string;
+	let provider: TypstPathLinks;
+
+	setup(() => {
+		directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-links-")));
+		provider = new TypstPathLinks();
+	});
+
+	teardown(() => {
+		provider.dispose();
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test("Should link a `file:` that names a file that is there", async () => {
+		fs.writeFileSync(path.join(directory, "_plot.typ"), "#circle()\n", "utf8");
+		const document = await open(directory, "post.qmd", "```{typst}\n//| file: _plot.typ\n```\n");
+
+		const links = await provider.provideDocumentLinks(document);
+
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].target?.fsPath, path.join(directory, "_plot.typ"));
+		assert.strictEqual(document.getText(links[0].range), "_plot.typ");
+	});
+
+	test("Should link a `preamble:` written in the front matter", async () => {
+		fs.writeFileSync(path.join(directory, "_pre.typ"), "#set text(size: 9pt)\n", "utf8");
+		const document = await open(directory, "post.qmd", "---\ntypst-render:\n  preamble: _pre.typ\n---\n");
+
+		const links = await provider.provideDocumentLinks(document);
+
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].target?.fsPath, path.join(directory, "_pre.typ"));
+	});
+
+	test("Should offer no link for a path that leads to no file", async () => {
+		const document = await open(directory, "post.qmd", "```{typst}\n//| file: _absent.typ\n```\n");
+
+		assert.deepStrictEqual(await provider.provideDocumentLinks(document), []);
+	});
+
+	test("Should warn about a path in a document that leads to no file", async () => {
+		const document = await open(directory, "post.qmd", "```{typst}\n//| file: _absent.typ\n```\n");
+
+		await provider.refresh(document);
+
+		const found = missingPaths(document.uri);
+		assert.strictEqual(found.length, 1);
+		assert.strictEqual(found[0].severity, vscode.DiagnosticSeverity.Warning);
+		assert.strictEqual(document.getText(found[0].range), "_absent.typ");
+	});
+
+	test("Should not warn about a relative path in a configuration file", async () => {
+		// Every document below the file resolves the path against its own
+		// directory, so the file itself cannot say the path leads nowhere.
+		const document = await open(directory, "_quarto.yml", "typst-render:\n  preamble: _absent.typ\n");
+
+		await provider.refresh(document);
+
+		assert.deepStrictEqual(missingPaths(document.uri), []);
+	});
+
+	test("Should write no warning for a document that names no path", async () => {
+		const document = await open(directory, "post.qmd", "```{typst}\n#circle()\n```\n");
+
+		await provider.refresh(document);
+
+		assert.deepStrictEqual(missingPaths(document.uri), []);
+	});
+});

--- a/src/test/suite/typstPathLinks.test.ts
+++ b/src/test/suite/typstPathLinks.test.ts
@@ -12,11 +12,6 @@ async function open(directory: string, name: string, content: string): Promise<v
 	return vscode.workspace.openTextDocument(vscode.Uri.file(file));
 }
 
-/** The warnings this provider wrote, and none of the ones other providers did. */
-function missingPaths(uri: vscode.Uri): vscode.Diagnostic[] {
-	return vscode.languages.getDiagnostics(uri).filter((diagnostic) => diagnostic.code === "typst-missing-path");
-}
-
 suite("Typst Path Links Test Suite", () => {
 	let directory: string;
 	let provider: TypstPathLinks;
@@ -61,10 +56,10 @@ suite("Typst Path Links Test Suite", () => {
 	test("Should warn about a path in a document that leads to no file", async () => {
 		const document = await open(directory, "post.qmd", "```{typst}\n//| file: _absent.typ\n```\n");
 
-		await provider.refresh(document);
+		const found = await provider.refresh(document);
 
-		const found = missingPaths(document.uri);
 		assert.strictEqual(found.length, 1);
+		assert.strictEqual(found[0].code, "typst-missing-path");
 		assert.strictEqual(found[0].severity, vscode.DiagnosticSeverity.Warning);
 		assert.strictEqual(document.getText(found[0].range), "_absent.typ");
 	});
@@ -74,16 +69,12 @@ suite("Typst Path Links Test Suite", () => {
 		// directory, so the file itself cannot say the path leads nowhere.
 		const document = await open(directory, "_quarto.yml", "typst-render:\n  preamble: _absent.typ\n");
 
-		await provider.refresh(document);
-
-		assert.deepStrictEqual(missingPaths(document.uri), []);
+		assert.deepStrictEqual(await provider.refresh(document), []);
 	});
 
 	test("Should write no warning for a document that names no path", async () => {
 		const document = await open(directory, "post.qmd", "```{typst}\n#circle()\n```\n");
 
-		await provider.refresh(document);
-
-		assert.deepStrictEqual(missingPaths(document.uri), []);
+		assert.deepStrictEqual(await provider.refresh(document), []);
 	});
 });

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -124,6 +124,23 @@ suite("Typst Path Options Test Suite", () => {
 			assert.deepStrictEqual(covered(text), ["_one.typ", "_two.typ"]);
 		});
 
+		test("Should find an entry written at the indent of its key", () => {
+			// A block sequence sits at the indent of its key or deeper, and both are
+			// the same document to YAML.
+			const text = "---\ntypst-render:\n  preamble:\n  - _one.typ\n  - _two.typ\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ", "_two.typ"]);
+		});
+
+		test("Should end a sequence at the next key of the same level", () => {
+			const text = "---\ntypst-render:\n  preamble:\n  - _one.typ\n  dpi: 300\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ"]);
+		});
+
+		test("Should find the entries below a key that carries a comment", () => {
+			const text = "---\ntypst-render:\n  preamble: # the preamble\n    - _one.typ\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ"]);
+		});
+
 		test("Should skip a list entry that is inline Typst code", () => {
 			const text = "---\ntypst-render:\n  preamble:\n    - _one.typ\n    - '#set page(fill: none)'\n---\n";
 			assert.deepStrictEqual(covered(text), ["_one.typ"]);

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -141,6 +141,23 @@ suite("Typst Path Options Test Suite", () => {
 			assert.deepStrictEqual(covered(text), ["_one.typ"]);
 		});
 
+		test("Should read an entry written with more than one space after the dash", () => {
+			const text = "---\ntypst-render:\n  preamble:\n    -   _one.typ\n---\n";
+			const option = only(text);
+			assert.strictEqual(option.value, "_one.typ");
+			assert.strictEqual(text.slice(option.start, option.end), "_one.typ");
+		});
+
+		test("Should find every entry of a flow sequence", () => {
+			const text = "---\ntypst-render:\n  preamble: [_one.typ, _two.typ]\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ", "_two.typ"]);
+		});
+
+		test("Should read a quoted entry of a flow sequence", () => {
+			const text = "---\ntypst-render:\n  preamble: [\"_one.typ\", '#set page(fill: none)']\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ"]);
+		});
+
 		test("Should skip a list entry that is inline Typst code", () => {
 			const text = "---\ntypst-render:\n  preamble:\n    - _one.typ\n    - '#set page(fill: none)'\n---\n";
 			assert.deepStrictEqual(covered(text), ["_one.typ"]);

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -1,0 +1,208 @@
+import * as assert from "assert";
+import * as path from "node:path";
+import { findTypstPathOptions, resolveTypstPathOption, type TypstPathOption } from "../../utils/typst/typstPathOptions";
+
+/** Every occurrence as the text it covers, which is what a link is drawn over. */
+function covered(text: string, languageId = "quarto"): string[] {
+	return findTypstPathOptions(text, languageId).map((option) => text.slice(option.start, option.end));
+}
+
+/** The one occurrence a document holds, which most cases below have. */
+function only(text: string, languageId = "quarto"): TypstPathOption {
+	const found = findTypstPathOptions(text, languageId);
+	assert.strictEqual(found.length, 1, `expected one occurrence, found ${found.length}`);
+	return found[0];
+}
+
+suite("Typst Path Options Test Suite", () => {
+	suite("Cell options", () => {
+		test("Should find a `file:` option", () => {
+			const text = "```{typst}\n//| file: _plot.typ\n```\n";
+			const option = only(text);
+			assert.strictEqual(option.key, "file");
+			assert.strictEqual(option.value, "_plot.typ");
+			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
+		});
+
+		test("Should find every path option of a cell", () => {
+			const text = "```{typst}\n//| file: _plot.typ\n//| preamble: _pre.typ\n```\n";
+			assert.deepStrictEqual(covered(text), ["_plot.typ", "_pre.typ"]);
+		});
+
+		test("Should skip a `preamble:` that is inline Typst code", () => {
+			// The filter reads an entry ending in `.typ` and treats every other one
+			// as code, so a link over the code would point at nothing.
+			const text = "```{typst}\n//| preamble: #set text(size: 10pt)\n```\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should skip an option that names no path", () => {
+			const text = "```{typst}\n//| label: fig-one\n//| dpi: 300\n```\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should exclude the quotes of a quoted value", () => {
+			const text = '```{typst}\n//| file: "_plot.typ"\n```\n';
+			const option = only(text);
+			assert.strictEqual(option.value, "_plot.typ");
+			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
+		});
+
+		test("Should exclude trailing whitespace", () => {
+			const text = "```{typst}\n//| file: _plot.typ   \n```\n";
+			assert.strictEqual(text.slice(only(text).start, only(text).end), "_plot.typ");
+		});
+
+		test("Should skip an option with an empty value", () => {
+			const text = "```{typst}\n//| file: \n```\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should keep a project-rooted path as written", () => {
+			const text = "```{typst}\n//| file: /_typst/plot.typ\n```\n";
+			assert.strictEqual(only(text).value, "/_typst/plot.typ");
+		});
+
+		test("Should stop at the end of the option run", () => {
+			// A `//|` line below the code is a warning upstream and never an option,
+			// so it is not a path either.
+			const text = "```{typst}\n//| file: _plot.typ\n#rect()\n//| preamble: _pre.typ\n```\n";
+			assert.deepStrictEqual(covered(text), ["_plot.typ"]);
+		});
+
+		test("Should ignore a plain block, whose `//|` line is a comment", () => {
+			const text = "```typst\n//| file: _plot.typ\n```\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should ignore a raw block, whose `//|` line is a comment", () => {
+			const text = "```{=typst}\n//| file: _plot.typ\n```\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should report the offset of an indented cell", () => {
+			const text = "- item\n\n  ```{typst}\n  //| file: _plot.typ\n  ```\n";
+			const option = only(text);
+			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
+		});
+
+		test("Should report the offset of a quoted cell", () => {
+			const text = "> ```{typst}\n> //| file: _plot.typ\n> ```\n";
+			const option = only(text);
+			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
+		});
+
+		test("Should report the offset of a cell below front matter", () => {
+			const text = "---\ntitle: One\n---\n\n```{typst}\n//| file: _plot.typ\n```\n";
+			const option = only(text);
+			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
+		});
+
+		test("Should read a CRLF document", () => {
+			const text = "```{typst}\r\n//| file: _plot.typ\r\n```\r\n";
+			const option = only(text);
+			assert.strictEqual(option.value, "_plot.typ");
+			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
+		});
+	});
+
+	suite("Front matter options", () => {
+		test("Should find a `preamble:` scalar", () => {
+			const text = "---\ntypst-render:\n  preamble: _pre.typ\n---\n";
+			const option = only(text);
+			assert.strictEqual(option.key, "preamble");
+			assert.strictEqual(text.slice(option.start, option.end), "_pre.typ");
+		});
+
+		test("Should find a `preamble:` under `extensions:`", () => {
+			const text = "---\nextensions:\n  typst-render:\n    preamble: _pre.typ\n---\n";
+			assert.deepStrictEqual(covered(text), ["_pre.typ"]);
+		});
+
+		test("Should find every entry of a `preamble:` list", () => {
+			const text = "---\ntypst-render:\n  preamble:\n    - _one.typ\n    - _two.typ\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ", "_two.typ"]);
+		});
+
+		test("Should skip a list entry that is inline Typst code", () => {
+			const text = "---\ntypst-render:\n  preamble:\n    - _one.typ\n    - '#set page(fill: none)'\n---\n";
+			assert.deepStrictEqual(covered(text), ["_one.typ"]);
+		});
+
+		test("Should skip a `preamble:` that belongs to another key", () => {
+			const text = "---\nother:\n  preamble: _pre.typ\n---\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should skip a `file:` in front matter, which is a block-only option", () => {
+			const text = "---\ntypst-render:\n  file: _plot.typ\n---\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
+		test("Should exclude a trailing comment", () => {
+			const text = "---\ntypst-render:\n  preamble: _pre.typ # the preamble\n---\n";
+			assert.strictEqual(only(text).value, "_pre.typ");
+		});
+
+		test("Should exclude the quotes of a quoted value", () => {
+			const text = '---\ntypst-render:\n  preamble: "_pre.typ"\n---\n';
+			const option = only(text);
+			assert.strictEqual(option.value, "_pre.typ");
+			assert.strictEqual(text.slice(option.start, option.end), "_pre.typ");
+		});
+	});
+
+	suite("Configuration files", () => {
+		test("Should read the whole of a YAML document", () => {
+			const text = "project:\n  type: website\ntypst-render:\n  preamble: _pre.typ\n";
+			assert.deepStrictEqual(covered(text, "yaml"), ["_pre.typ"]);
+		});
+
+		test("Should find nothing in a YAML document that names no preamble", () => {
+			assert.deepStrictEqual(covered("project:\n  type: website\n", "yaml"), []);
+		});
+	});
+
+	suite("resolveTypstPathOption", () => {
+		const root = path.join(path.sep, "project");
+		const directory = path.join(root, "posts");
+
+		test("Should resolve a relative path against the directory of a document", () => {
+			const target = resolveTypstPathOption("_pre.typ", { directory, projectRoot: root, configuration: false });
+			assert.strictEqual(target.path, path.join(directory, "_pre.typ"));
+			assert.strictEqual(target.reportable, true);
+		});
+
+		test("Should resolve a rooted path against the project root", () => {
+			const target = resolveTypstPathOption("/_typst/pre.typ", { directory, projectRoot: root, configuration: false });
+			assert.strictEqual(target.path, path.join(root, "_typst", "pre.typ"));
+			assert.strictEqual(target.reportable, true);
+		});
+
+		test("Should not report a relative path written in a configuration file", () => {
+			// Every document below the file resolves it against its own directory,
+			// so the file itself cannot say the path leads nowhere.
+			const target = resolveTypstPathOption("_pre.typ", { directory: root, projectRoot: root, configuration: true });
+			assert.strictEqual(target.path, path.join(root, "_pre.typ"));
+			assert.strictEqual(target.reportable, false);
+		});
+
+		test("Should report a rooted path written in a configuration file", () => {
+			const target = resolveTypstPathOption("/_pre.typ", { directory: root, projectRoot: root, configuration: true });
+			assert.strictEqual(target.path, path.join(root, "_pre.typ"));
+			assert.strictEqual(target.reportable, true);
+		});
+
+		test("Should resolve nothing for a rooted path outside every project", () => {
+			const target = resolveTypstPathOption("/_pre.typ", { directory, configuration: false });
+			assert.strictEqual(target.path, undefined);
+			assert.strictEqual(target.reportable, false);
+		});
+
+		test("Should resolve nothing for a document that is not on disk", () => {
+			const target = resolveTypstPathOption("_pre.typ", { configuration: false });
+			assert.strictEqual(target.path, undefined);
+			assert.strictEqual(target.reportable, false);
+		});
+	});
+});

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -243,7 +243,8 @@ async function directoryHasProjectMarker(dir: string): Promise<boolean> {
 	return await directoryHasInstalledExtension(vscode.Uri.file(path.join(dir, EXTENSIONS_DIR)));
 }
 
-async function isFile(uri: vscode.Uri): Promise<boolean> {
+/** Whether a URI names a file that is there. */
+export async function isFile(uri: vscode.Uri): Promise<boolean> {
 	try {
 		const stat = await vscode.workspace.fs.stat(uri);
 		return (stat.type & vscode.FileType.File) !== 0;

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -132,8 +132,12 @@ function blockBody(
  * nothing after its colon does not match either, while the same line with one
  * trailing space does: the pattern backtracks, the value becomes that space,
  * and the trim which follows leaves an empty string.
+ *
+ * Exported so that a reader which needs the position of a value, and not only
+ * the value, matches the run exactly as the parser below does. Two copies of
+ * the rule drift apart in silence.
  */
-const OPTION_LINE = /^\s*\/\/\|\s*([A-Za-z0-9-]+):\s*(.+)$/;
+export const OPTION_LINE = /^\s*\/\/\|\s*([A-Za-z0-9-]+):\s*(.+)$/;
 
 /**
  * The Lua guard at `_modules/code-cell.lua:110`, which warns about an option

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -152,6 +152,18 @@ export const OPTION_LINE = /^\s*\/\/\|\s*([A-Za-z0-9-]+):\s*(.+)$/;
  */
 const LATE_OPTION_LINE = /^\s*\/\/\|\s*[A-Za-z0-9-]+:\s/;
 
+/**
+ * The inside of a quoted value, or undefined when the value is not quoted,
+ * `code-cell.lua:99-101`.
+ *
+ * Exported for the reader which needs the position of a value as well as the
+ * value, because the quotes decide where it starts.
+ */
+export function quotedValue(raw: string): string | undefined {
+	const quoted = /^"(.*)"$/.exec(raw) ?? /^'(.*)'$/.exec(raw);
+	return quoted === null ? undefined : quoted[1];
+}
+
 /** One parsed value, following `code-cell.lua:95-102`. */
 function optionValue(raw: string): string | boolean {
 	if (raw === "true") {
@@ -160,8 +172,7 @@ function optionValue(raw: string): string | boolean {
 	if (raw === "false") {
 		return false;
 	}
-	const quoted = /^"(.*)"$/.exec(raw) ?? /^'(.*)'$/.exec(raw);
-	return quoted === null ? raw : quoted[1];
+	return quotedValue(raw) ?? raw;
 }
 
 /**

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -14,7 +14,7 @@
  */
 
 import { getYamlIndentLevel, getYamlKeyPath, stripBlockquoteMarkers, stripCarriageReturn } from "../yamlPosition";
-import { findTypstBlocks, OPTION_LINE } from "./typstBlocks";
+import { findTypstBlocks, OPTION_LINE, quotedValue } from "./typstBlocks";
 import { TYPST_RENDER } from "./typstOptions";
 import { resolveQuartoPath } from "./typstPaths";
 
@@ -44,8 +44,8 @@ interface Scalar {
  */
 function unquote(raw: string, start: number): Scalar {
 	const value = raw.replace(/\s+$/, "");
-	const quoted = /^"(.*)"$/.exec(value) ?? /^'(.*)'$/.exec(value);
-	return quoted === null ? { value, start } : { value: quoted[1], start: start + 1 };
+	const inside = quotedValue(value);
+	return inside === undefined ? { value, start } : { value: inside, start: start + 1 };
 }
 
 /**
@@ -148,12 +148,11 @@ function isPreamblePath(path: readonly string[]): boolean {
  * rule, and never inside a quoted value.
  */
 function yamlScalar(raw: string, start: number): Scalar {
-	const trimmed = raw.replace(/\s+$/, "");
-	const quoted = /^"(.*)"$/.exec(trimmed) ?? /^'(.*)'$/.exec(trimmed);
-	if (quoted !== null) {
-		return { value: quoted[1], start: start + 1 };
-	}
-	return unquote(trimmed.replace(/\s+#.*$/, ""), start);
+	const quoted = unquote(raw, start);
+	// The quotes matched, so the whole value is inside them and a `#` is part of
+	// it. They did not match either when there are none and when a comment
+	// follows the closing one, and taking the comment off answers both.
+	return quoted.start === start ? unquote(quoted.value.replace(/\s+#.*$/, ""), start) : quoted;
 }
 
 /** A `preamble:` key, with everything written after the colon. */
@@ -197,33 +196,31 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
 			sequenceOf = undefined;
 		}
 
+		// The value this line writes, which is the one on a `preamble:` line and
+		// the one an entry below it carries.
+		let scalar: Scalar | undefined;
 		const key = PREAMBLE_KEY.exec(line);
 		if (key !== null && isPreamblePath(getYamlKeyPath(lines, index, languageId))) {
-			const scalar = yamlScalar(key[2], line.length - key[2].length);
+			scalar = yamlScalar(key[2], line.length - key[2].length);
 			if (scalar.value === "") {
 				// Nothing on the line, so the entries are written below it.
 				sequenceOf = indent;
-			} else if (namesFile("preamble", scalar.value)) {
-				found.push({
-					key: "preamble",
-					value: scalar.value,
-					start: lineStart + scalar.start,
-					end: lineStart + scalar.start + scalar.value.length,
-				});
+				scalar = undefined;
 			}
 		} else if (sequenceOf !== undefined) {
 			const entry = SEQUENCE_ENTRY.exec(line);
 			if (entry !== null && entry[1].length > sequenceOf) {
-				const scalar = yamlScalar(entry[2], line.length - entry[2].length);
-				if (namesFile("preamble", scalar.value)) {
-					found.push({
-						key: "preamble",
-						value: scalar.value,
-						start: lineStart + scalar.start,
-						end: lineStart + scalar.start + scalar.value.length,
-					});
-				}
+				scalar = yamlScalar(entry[2], line.length - entry[2].length);
 			}
+		}
+
+		if (scalar !== undefined && namesFile("preamble", scalar.value)) {
+			found.push({
+				key: "preamble",
+				value: scalar.value,
+				start: lineStart + scalar.start,
+				end: lineStart + scalar.start + scalar.value.length,
+			});
 		}
 
 		lineStart += lines[index].length + 1;

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -164,8 +164,38 @@ function yamlScalar(raw: string, start: number): Scalar {
 /** A `preamble:` key, with everything written after the colon. */
 const PREAMBLE_KEY = /^(\s*)preamble:\s*(.*)$/;
 
-/** One entry of a block sequence. */
-const SEQUENCE_ENTRY = /^(\s*)- (.+)$/;
+/**
+ * One entry of a block sequence.
+ *
+ * The dash is followed by whitespace of any width, which is one space in most
+ * documents and more in a document whose entries are aligned. The value capture
+ * runs to the end of the line, so its offset follows from its length whatever
+ * that width is.
+ */
+const SEQUENCE_ENTRY = /^(\s*)-\s+(.+)$/;
+
+/**
+ * The entries of a flow sequence, `preamble: [_one.typ, _two.typ]`, or
+ * undefined when the value is not one.
+ *
+ * A flow sequence is a list the same way a block sequence is, and a reader that
+ * takes it for one value finds no path in it and says nothing at all.
+ */
+function flowEntries(scalar: Scalar): Scalar[] | undefined {
+	const flow = /^\[(.*)\]$/.exec(scalar.value);
+	if (flow === null) {
+		return undefined;
+	}
+	const entries: Scalar[] = [];
+	// Past the opening bracket, then past each entry and the comma after it.
+	let start = scalar.start + 1;
+	for (const part of flow[1].split(",")) {
+		const lead = part.length - part.trimStart().length;
+		entries.push(unquote(part.trimStart(), start + lead));
+		start += part.length + 1;
+	}
+	return entries;
+}
 
 /**
  * The `preamble:` of every `typst-render` mapping in the YAML of a document.
@@ -222,13 +252,15 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
 			scalar = yamlScalar(entry[2], line.length - entry[2].length);
 		}
 
-		if (scalar !== undefined && namesFile("preamble", scalar.value)) {
-			found.push({
-				key: "preamble",
-				value: scalar.value,
-				start: lineStart + scalar.start,
-				end: lineStart + scalar.start + scalar.value.length,
-			});
+		for (const value of scalar === undefined ? [] : (flowEntries(scalar) ?? [scalar])) {
+			if (namesFile("preamble", value.value)) {
+				found.push({
+					key: "preamble",
+					value: value.value,
+					start: lineStart + value.start,
+					end: lineStart + value.start + value.value.length,
+				});
+			}
 		}
 
 		lineStart += lines[index].length + 1;

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -1,0 +1,291 @@
+/**
+ * The options that name a file, and where their values sit in the document.
+ *
+ * The preview reads these paths already. This reports where each one is
+ * written, which is what a link is drawn over and what a diagnostic is put on.
+ *
+ * Two options name a file, and they are not written in the same places.
+ * `file:` is block-only (`typst-render.lua:1788-1794` reads it at no global
+ * level), so it is a cell option and nothing else. `preamble:` is read at every
+ * level, so it is written in a cell, in the front matter, and in a
+ * configuration file.
+ *
+ * No `vscode` here, the way nothing under `src/utils/typst/` imports it.
+ */
+
+import { getYamlIndentLevel, getYamlKeyPath, stripBlockquoteMarkers, stripCarriageReturn } from "../yamlPosition";
+import { findTypstBlocks, OPTION_LINE } from "./typstBlocks";
+import { TYPST_RENDER } from "./typstOptions";
+import { resolveQuartoPath } from "./typstPaths";
+
+/** One option value that names a file. */
+export interface TypstPathOption {
+	/** The option that named the path. */
+	key: "file" | "preamble";
+	/** The path as written, without its quotes. */
+	value: string;
+	/** Offset of the first character of the value in the document. */
+	start: number;
+	/** Offset one past the last character of the value. */
+	end: number;
+}
+
+/** A value read from a line, with the offset it starts at within that line. */
+interface Scalar {
+	value: string;
+	start: number;
+}
+
+/**
+ * A value with its trailing whitespace and its quotes taken off.
+ *
+ * The offset moves with the value, because a link over the quotes of a quoted
+ * path underlines two characters that are not part of it.
+ */
+function unquote(raw: string, start: number): Scalar {
+	const value = raw.replace(/\s+$/, "");
+	const quoted = /^"(.*)"$/.exec(value) ?? /^'(.*)'$/.exec(value);
+	return quoted === null ? { value, start } : { value: quoted[1], start: start + 1 };
+}
+
+/**
+ * Whether an entry of a `preamble:` names a file.
+ *
+ * `resolvePreamble` reads an entry ending in `.typ` and treats every other one
+ * as inline Typst code, so only the first kind has a file to point at. A
+ * `file:` carries no such test: the filter reads whatever it names.
+ */
+function namesFile(key: TypstPathOption["key"], value: string): boolean {
+	return value !== "" && (key === "file" || value.endsWith(".typ"));
+}
+
+/**
+ * The quote depth of a block, measured on its opening fence.
+ *
+ * The same rule `blockBody` applies: a marker beyond the depth of the fence is
+ * content, so stripping without the limit would read `> > //| file: x` in a
+ * quoted block as an option line when the block sees a line of Typst.
+ */
+function quoteDepth(text: string, fenceStart: number): number {
+	const newline = text.indexOf("\n", fenceStart);
+	const line = text.slice(fenceStart, newline === -1 ? text.length : newline);
+	return stripBlockquoteMarkers(stripCarriageReturn(line)).depth;
+}
+
+/**
+ * The path options of the `//|` run of every cell.
+ *
+ * The run is read from the document text rather than from `block.body`, which
+ * is de-indented and stripped of its blockquote markers: an offset taken in
+ * that body does not map back to a position in the document.
+ */
+function cellPathOptions(text: string): TypstPathOption[] {
+	const found: TypstPathOption[] = [];
+
+	for (const block of findTypstBlocks(text)) {
+		// Only a cell carries options. In the other two kinds a `//|` line is an
+		// ordinary Typst comment.
+		if (block.kind !== "cell") {
+			continue;
+		}
+
+		const depth = quoteDepth(text, block.fenceStart);
+		let lineStart = block.bodyStart;
+		while (lineStart < block.bodyEnd) {
+			const newline = text.indexOf("\n", lineStart);
+			const lineEnd = newline === -1 || newline > block.bodyEnd ? block.bodyEnd : newline;
+			const line = stripCarriageReturn(text.slice(lineStart, lineEnd));
+			const { content } = stripBlockquoteMarkers(line, depth);
+			const match = OPTION_LINE.exec(content);
+			// The run ends at the first line that is not an option, which is where
+			// `parseOptions` stops as well. A `//|` line below the code is a warning
+			// upstream and never an option.
+			if (match === null) {
+				break;
+			}
+
+			const key = match[1];
+			if (key === "file" || key === "preamble") {
+				// The value capture runs to the end of the line, so it is the tail of
+				// the content and its offset follows from its length. The blockquote
+				// markers are counted back in, because they are part of the document.
+				const prefix = line.length - content.length;
+				const raw = unquote(match[2], prefix + content.length - match[2].length);
+				if (namesFile(key, raw.value)) {
+					found.push({
+						key,
+						value: raw.value,
+						start: lineStart + raw.start,
+						end: lineStart + raw.start + raw.value.length,
+					});
+				}
+			}
+
+			lineStart = lineEnd + 1;
+		}
+	}
+
+	return found;
+}
+
+/** Whether a key path names the `typst-render` mapping of a level. */
+function isExtensionPath(path: readonly string[]): boolean {
+	if (path.length === 1) {
+		return path[0] === TYPST_RENDER;
+	}
+	return path.length === 2 && path[0] === "extensions" && path[1] === TYPST_RENDER;
+}
+
+/** Whether a key path names the `preamble:` of a level. */
+function isPreamblePath(path: readonly string[]): boolean {
+	return path.length > 1 && path[path.length - 1] === "preamble" && isExtensionPath(path.slice(0, -1));
+}
+
+/**
+ * A YAML value with its trailing comment taken off.
+ *
+ * A `#` is a comment only when whitespace comes before it, which is the YAML
+ * rule, and never inside a quoted value.
+ */
+function yamlScalar(raw: string, start: number): Scalar {
+	const trimmed = raw.replace(/\s+$/, "");
+	const quoted = /^"(.*)"$/.exec(trimmed) ?? /^'(.*)'$/.exec(trimmed);
+	if (quoted !== null) {
+		return { value: quoted[1], start: start + 1 };
+	}
+	return unquote(trimmed.replace(/\s+#.*$/, ""), start);
+}
+
+/** A `preamble:` key, with everything written after the colon. */
+const PREAMBLE_KEY = /^(\s*)preamble:\s*(.*)$/;
+
+/** One entry of a block sequence. */
+const SEQUENCE_ENTRY = /^(\s*)- (.+)$/;
+
+/**
+ * The `preamble:` of every `typst-render` mapping in the YAML of a document.
+ *
+ * The whole document for a configuration file, and the front matter alone for a
+ * Quarto document: `getYamlKeyPath` answers with an empty path below the front
+ * matter, so a `preamble:` written in prose is never read as one.
+ *
+ * The key path is resolved for a `preamble:` line and for nothing else. The
+ * entries below one are recognised by their indent instead, because resolving
+ * the path of every sequence entry walks the document again for each of them,
+ * and a website configuration carries hundreds.
+ */
+function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
+	const found: TypstPathOption[] = [];
+	const lines = text.split("\n");
+	// The indent of a `preamble:` whose entries are written below it, and
+	// undefined when the reader is not inside one.
+	let sequenceOf: number | undefined;
+	let lineStart = 0;
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = stripCarriageReturn(lines[index]);
+		const trimmed = line.trim();
+		// A blank line and a comment line sit inside the block they interrupt, so
+		// neither ends a sequence.
+		if (trimmed === "" || trimmed.startsWith("#")) {
+			lineStart += lines[index].length + 1;
+			continue;
+		}
+
+		const indent = getYamlIndentLevel(line);
+		if (sequenceOf !== undefined && indent <= sequenceOf) {
+			sequenceOf = undefined;
+		}
+
+		const key = PREAMBLE_KEY.exec(line);
+		if (key !== null && isPreamblePath(getYamlKeyPath(lines, index, languageId))) {
+			const scalar = yamlScalar(key[2], line.length - key[2].length);
+			if (scalar.value === "") {
+				// Nothing on the line, so the entries are written below it.
+				sequenceOf = indent;
+			} else if (namesFile("preamble", scalar.value)) {
+				found.push({
+					key: "preamble",
+					value: scalar.value,
+					start: lineStart + scalar.start,
+					end: lineStart + scalar.start + scalar.value.length,
+				});
+			}
+		} else if (sequenceOf !== undefined) {
+			const entry = SEQUENCE_ENTRY.exec(line);
+			if (entry !== null && entry[1].length > sequenceOf) {
+				const scalar = yamlScalar(entry[2], line.length - entry[2].length);
+				if (namesFile("preamble", scalar.value)) {
+					found.push({
+						key: "preamble",
+						value: scalar.value,
+						start: lineStart + scalar.start,
+						end: lineStart + scalar.start + scalar.value.length,
+					});
+				}
+			}
+		}
+
+		lineStart += lines[index].length + 1;
+	}
+
+	return found;
+}
+
+/**
+ * Every option of a document that names a file, in document order.
+ *
+ * @param text - The document text.
+ * @param languageId - The VS Code language identifier, which decides where the
+ *   YAML of the document is and whether it holds cells at all.
+ */
+export function findTypstPathOptions(text: string, languageId: string): TypstPathOption[] {
+	const cells = languageId === "yaml" ? [] : cellPathOptions(text);
+	const yamlOptions = yamlPathOptions(text, languageId);
+	return [...yamlOptions, ...cells].sort((left, right) => left.start - right.start);
+}
+
+/** Where the file holding an option sits, and what kind of file it is. */
+export interface TypstPathContext {
+	/** The directory of the file that holds the option. */
+	directory?: string;
+	/** The project root that owns that file, when one does. */
+	projectRoot?: string;
+	/**
+	 * Whether the file is a configuration file rather than a document.
+	 *
+	 * A configuration file is read by every document below it, and the filter
+	 * resolves a relative path against the directory of the document it is
+	 * rendering. So the file itself does not decide where such a path leads.
+	 */
+	configuration: boolean;
+}
+
+/** Where an option leads, and whether this file is enough to say so. */
+export interface TypstPathTarget {
+	/** The absolute path, or undefined when nothing here resolves it. */
+	path?: string;
+	/**
+	 * Whether a file that is not there can be reported against this document.
+	 *
+	 * False for a relative path in a configuration file, where the path is
+	 * resolved against each document that reads it: the resolved path is a guess
+	 * good enough to follow and not good enough to warn about.
+	 */
+	reportable: boolean;
+}
+
+/**
+ * The file an option names, `_modules/paths.lua:34-48`.
+ *
+ * A leading `/` means the project root, and every other path is relative to the
+ * directory passed in. This is the rule `preamble:` and `file:` follow, and not
+ * the one `root:`, `font-path:` and `package-path:` follow.
+ */
+export function resolveTypstPathOption(value: string, context: TypstPathContext): TypstPathTarget {
+	const resolved = resolveQuartoPath(value, context.directory, context.projectRoot);
+	if (resolved === undefined) {
+		return { reportable: false };
+	}
+	return { path: resolved, reportable: !context.configuration || value.startsWith("/") };
+}

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -152,7 +152,13 @@ function yamlScalar(raw: string, start: number): Scalar {
 	// The quotes matched, so the whole value is inside them and a `#` is part of
 	// it. They did not match either when there are none and when a comment
 	// follows the closing one, and taking the comment off answers both.
-	return quoted.start === start ? unquote(quoted.value.replace(/\s+#.*$/, ""), start) : quoted;
+	if (quoted.start !== start) {
+		return quoted;
+	}
+	const value = quoted.value.replace(/\s+#.*$/, "");
+	// A line that carries a comment and nothing else writes no value, which is
+	// what a key followed by a block sequence looks like.
+	return unquote(value.startsWith("#") ? "" : value, start);
 }
 
 /** A `preamble:` key, with everything written after the colon. */
@@ -192,7 +198,12 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
 		}
 
 		const indent = getYamlIndentLevel(line);
-		if (sequenceOf !== undefined && indent <= sequenceOf) {
+		const entry = SEQUENCE_ENTRY.exec(line);
+		// A block sequence is written at the indent of its key or deeper, so the
+		// indent alone does not say where it ends. The first line that is not an
+		// entry of it does, and a sibling key is such a line.
+		const inSequence = sequenceOf !== undefined && entry !== null && indent >= sequenceOf;
+		if (!inSequence) {
 			sequenceOf = undefined;
 		}
 
@@ -207,11 +218,8 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
 				sequenceOf = indent;
 				scalar = undefined;
 			}
-		} else if (sequenceOf !== undefined) {
-			const entry = SEQUENCE_ENTRY.exec(line);
-			if (entry !== null && entry[1].length > sequenceOf) {
-				scalar = yamlScalar(entry[2], line.length - entry[2].length);
-			}
+		} else if (inSequence && entry !== null) {
+			scalar = yamlScalar(entry[2], line.length - entry[2].length);
 		}
 
 		if (scalar !== undefined && namesFile("preamble", scalar.value)) {


### PR DESCRIPTION
A `file:` or a `preamble:` option names a file, and following that path meant finding the file by hand. The value is now a document link: hold Ctrl, or Cmd on macOS, and select it to open the file. A path that leads to no file carries a warning where it is written, rather than failing later in a preview or a render.

The link is offered in three places.

- `//| file:` and `//| preamble:` in a `{typst}` cell.
- `preamble:` under `typst-render` in the front matter of a document.
- `preamble:` under `typst-render` in `_quarto.yml`, `_metadata.yml`, and any `metadata-files:` target.

`file:` is a cell option alone, because the filter reads it at no global level. A `preamble:` entry that does not end in `.typ` is inline Typst code, so it is not a link. Both block sequences and flow sequences are read.

The paths follow the rule the preview already follows: a leading `/` resolves from the project root, and every other path from the directory of the document. A relative path in a configuration file gets a link resolved from the directory of that file, and never a warning, because each document that reads the file resolves the path from its own directory.

`src/utils/typst/typstPathOptions.ts` holds the scanner and the resolver, imports no `vscode`, and is covered by unit tests. `src/providers/typstPathLinks.ts` holds the link provider and the warnings.