### PR TITLE
fix: repair the Typst preview before the release

### DIFF
--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -961,8 +961,16 @@ export class TypstPreviewController implements vscode.Disposable {
 					return;
 				}
 				if (isRelevantDocument(document)) {
+					// Both delays run the same rebuild, so the save answers whichever
+					// of them was waiting, and it answers a save that neither was.
+					// Cancelling the cursor delay and flushing the edit delay dropped
+					// the case where the cursor had just moved and no edit was pending,
+					// which left the panel on the block the cursor had left. An
+					// unchanged source is a cache hit, so a save that changed nothing
+					// spawns nothing.
 					this.selectionDebounce.cancel();
-					this.documentDebounce?.flush();
+					this.documentDebounce?.cancel();
+					this.refresh();
 				}
 			}),
 		);

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -965,9 +965,13 @@ export class TypstPreviewController implements vscode.Disposable {
 					// of them was waiting, and it answers a save that neither was.
 					// Cancelling the cursor delay and flushing the edit delay dropped
 					// the case where the cursor had just moved and no edit was pending,
-					// which left the panel on the block the cursor had left. An
-					// unchanged source is a cache hit, so a save that changed nothing
-					// spawns nothing.
+					// which left the panel on the block the cursor had left.
+					//
+					// This does cost a request on every save of a document with a
+					// block, which is the document text and the files a cell reads.
+					// Only the compile itself is spared, because an unchanged source
+					// is a cache hit, and a save is rare enough and deliberate enough
+					// to be worth reading the document for.
 					this.selectionDebounce.cancel();
 					this.documentDebounce?.cancel();
 					this.refresh();

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -961,20 +961,18 @@ export class TypstPreviewController implements vscode.Disposable {
 					return;
 				}
 				if (isRelevantDocument(document)) {
-					// Both delays run the same rebuild, so the save answers whichever
-					// of them was waiting, and it answers a save that neither was.
-					// Cancelling the cursor delay and flushing the edit delay dropped
-					// the case where the cursor had just moved and no edit was pending,
+					// Both delays run the same rebuild, so whichever of them is waiting
+					// is answered now. Cancelling the cursor delay instead dropped the
+					// case where the cursor had just moved and no edit was pending,
 					// which left the panel on the block the cursor had left.
 					//
-					// This does cost a request on every save of a document with a
-					// block, which is the document text and the files a cell reads.
-					// Only the compile itself is spared, because an unchanged source
-					// is a cache hit, and a save is rare enough and deliberate enough
-					// to be worth reading the document for.
-					this.selectionDebounce.cancel();
-					this.documentDebounce?.cancel();
-					this.refresh();
+					// A flush with nothing pending does nothing, which is what keeps a
+					// save cheap. Rebuilding unconditionally would read the document
+					// and the files a cell names on every save, and under
+					// `files.autoSave` a save follows every pause in typing, so that
+					// would be steady-state work rather than an occasional one.
+					this.documentDebounce?.flush();
+					this.selectionDebounce.flush();
 				}
 			}),
 		);

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -961,18 +961,22 @@ export class TypstPreviewController implements vscode.Disposable {
 					return;
 				}
 				if (isRelevantDocument(document)) {
-					// Both delays run the same rebuild, so whichever of them is waiting
-					// is answered now. Cancelling the cursor delay instead dropped the
-					// case where the cursor had just moved and no edit was pending,
-					// which left the panel on the block the cursor had left.
+					// Both delays run the same rebuild, so a save that either of them
+					// was waiting on runs it once, now. Cancelling the cursor delay
+					// dropped the case where the cursor had just moved and no edit was
+					// pending, which left the panel on the block the cursor had left,
+					// and flushing both ran the rebuild twice when both were waiting.
 					//
-					// A flush with nothing pending does nothing, which is what keeps a
-					// save cheap. Rebuilding unconditionally would read the document
-					// and the files a cell names on every save, and under
-					// `files.autoSave` a save follows every pause in typing, so that
-					// would be steady-state work rather than an occasional one.
-					this.documentDebounce?.flush();
-					this.selectionDebounce.flush();
+					// A save that neither was waiting on rebuilds nothing. Rebuilding
+					// regardless would read the document and the files a cell names on
+					// every save, and under `files.autoSave` a save follows every pause
+					// in typing, so that would be steady-state work.
+					const waiting = this.documentDebounce?.pending() === true || this.selectionDebounce.pending();
+					this.documentDebounce?.cancel();
+					this.selectionDebounce.cancel();
+					if (waiting) {
+						this.refresh();
+					}
 				}
 			}),
 		);

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -33,8 +33,8 @@ export class TypstPreviewPanel {
 	/** What the page is already showing, so an unchanged image is not sent again. */
 	private shownSvg: string | undefined;
 	private shownHeader: string | undefined;
+	/** The failure reported over the image, which is also whether one is showing. */
 	private shownError: string | undefined;
-	private showingError = false;
 	private readonly disposables: vscode.Disposable[] = [];
 	private readonly onDidDisposeEmitter = new vscode.EventEmitter<void>();
 	private closed = false;
@@ -90,13 +90,12 @@ export class TypstPreviewPanel {
 		// an image arrives, so a block that is broken and then restored compiles to
 		// the image already shown, and skipping that message would leave a failure
 		// reported over a block that compiles.
-		if (svg === this.shownSvg && header === this.shownHeader && !this.showingError) {
+		if (svg === this.shownSvg && header === this.shownHeader && this.shownError === undefined) {
 			return;
 		}
 		this.shownSvg = svg;
 		this.shownHeader = header;
 		this.shownError = undefined;
-		this.showingError = false;
 		this.post({ type: "image", uri: svgDataUri(svg), header });
 	}
 
@@ -111,7 +110,6 @@ export class TypstPreviewPanel {
 		this.shownSvg = undefined;
 		this.shownHeader = undefined;
 		this.shownError = undefined;
-		this.showingError = false;
 		this.post({ type: "clear" });
 	}
 
@@ -123,7 +121,6 @@ export class TypstPreviewPanel {
 	 * keystroke.
 	 */
 	showError(message: string): void {
-		this.showingError = true;
 		this.shownError = message;
 		this.post({ type: "error", message });
 	}
@@ -172,14 +169,10 @@ export class TypstPreviewPanel {
 	 */
 	private paint(): void {
 		if (this.shownSvg !== undefined) {
-			void this.panel.webview.postMessage({
-				type: "image",
-				uri: svgDataUri(this.shownSvg),
-				header: this.shownHeader ?? "",
-			});
+			this.post({ type: "image", uri: svgDataUri(this.shownSvg), header: this.shownHeader ?? "" });
 		}
-		if (this.showingError && this.shownError !== undefined) {
-			void this.panel.webview.postMessage({ type: "error", message: this.shownError });
+		if (this.shownError !== undefined) {
+			this.post({ type: "error", message: this.shownError });
 		}
 	}
 

--- a/src/providers/typstPreview/typstPreviewPanel.ts
+++ b/src/providers/typstPreview/typstPreviewPanel.ts
@@ -30,20 +30,10 @@ export class TypstPreviewPanel {
 
 	/** Whether the page has reported that it is listening. */
 	private ready = false;
-	/**
-	 * The updates that arrived before the page was listening.
-	 *
-	 * The page is loaded asynchronously, and the first compile usually finishes
-	 * first, so without this queue the first image is posted into nothing. The
-	 * two kinds are held apart, because an image and the error over it are not
-	 * alternatives: a single slot would drop the image and show a panel that is
-	 * empty behind its error.
-	 */
-	private pendingImage: PreviewMessage | undefined;
-	private pendingError: PreviewMessage | undefined;
 	/** What the page is already showing, so an unchanged image is not sent again. */
 	private shownSvg: string | undefined;
 	private shownHeader: string | undefined;
+	private shownError: string | undefined;
 	private showingError = false;
 	private readonly disposables: vscode.Disposable[] = [];
 	private readonly onDidDisposeEmitter = new vscode.EventEmitter<void>();
@@ -83,15 +73,7 @@ export class TypstPreviewPanel {
 					return;
 				}
 				this.ready = true;
-				// The image goes first, so the error lands on top of it and not
-				// underneath.
-				for (const queued of [this.pendingImage, this.pendingError]) {
-					if (queued) {
-						void panel.webview.postMessage(queued);
-					}
-				}
-				this.pendingImage = undefined;
-				this.pendingError = undefined;
+				this.paint();
 			}),
 		);
 
@@ -113,6 +95,7 @@ export class TypstPreviewPanel {
 		}
 		this.shownSvg = svg;
 		this.shownHeader = header;
+		this.shownError = undefined;
 		this.showingError = false;
 		this.post({ type: "image", uri: svgDataUri(svg), header });
 	}
@@ -127,6 +110,7 @@ export class TypstPreviewPanel {
 	clear(): void {
 		this.shownSvg = undefined;
 		this.shownHeader = undefined;
+		this.shownError = undefined;
 		this.showingError = false;
 		this.post({ type: "clear" });
 	}
@@ -140,6 +124,7 @@ export class TypstPreviewPanel {
 	 */
 	showError(message: string): void {
 		this.showingError = true;
+		this.shownError = message;
 		this.post({ type: "error", message });
 	}
 
@@ -171,6 +156,33 @@ export class TypstPreviewPanel {
 		this.disposables.length = 0;
 	}
 
+	/**
+	 * Send the page what it should be showing.
+	 *
+	 * The page is loaded asynchronously and the first compile usually finishes
+	 * first, so the first image would otherwise be posted into nothing. A page
+	 * that reloads after it has gone live has the same problem and no update to
+	 * follow: moving the panel to another editor group rebuilds the document, and
+	 * the image and the header are unchanged, so `show` would send nothing and the
+	 * panel would stay blank until the block itself changed.
+	 *
+	 * Both are answered by sending what is on screen rather than by queueing what
+	 * arrived early. The image goes first, so the error lands on top of it and not
+	 * underneath.
+	 */
+	private paint(): void {
+		if (this.shownSvg !== undefined) {
+			void this.panel.webview.postMessage({
+				type: "image",
+				uri: svgDataUri(this.shownSvg),
+				header: this.shownHeader ?? "",
+			});
+		}
+		if (this.showingError && this.shownError !== undefined) {
+			void this.panel.webview.postMessage({ type: "error", message: this.shownError });
+		}
+	}
+
 	private post(message: PreviewMessage): void {
 		if (this.closed) {
 			// A compile can outlive the panel: it runs for up to the timeout, and
@@ -180,15 +192,8 @@ export class TypstPreviewPanel {
 			return;
 		}
 		if (!this.ready) {
-			if (message.type === "error") {
-				this.pendingError = message;
-			} else {
-				// A compile that succeeded answers the failure before it, and so does
-				// moving to another block, so the queued error is stale and must not
-				// replay over what replaced it.
-				this.pendingImage = message;
-				this.pendingError = undefined;
-			}
+			// Every caller records what it is showing before it posts, so the page
+			// is painted from that state once it reports in.
 			return;
 		}
 		void this.panel.webview.postMessage(message);

--- a/src/test/suite/debounce.test.ts
+++ b/src/test/suite/debounce.test.ts
@@ -1,0 +1,35 @@
+import * as assert from "assert";
+import { debounce } from "../../utils/debounce";
+
+/** Let the delay pass. */
+function after(delayMs: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+suite("Debounce Test Suite", () => {
+	test("Should report whether a call is waiting", async () => {
+		// A caller that has to run the delayed work now, and only once, needs to
+		// know which of several delays was waiting. Flushing them all runs the same
+		// work more than once, and cancelling them all drops it.
+		const debounced = debounce(() => undefined, 20);
+		assert.strictEqual(debounced.pending(), false);
+
+		debounced();
+		assert.strictEqual(debounced.pending(), true);
+
+		await after(40);
+		assert.strictEqual(debounced.pending(), false);
+	});
+
+	test("Should report nothing waiting after a flush or a cancel", () => {
+		const flushed = debounce(() => undefined, 20);
+		flushed();
+		flushed.flush();
+		assert.strictEqual(flushed.pending(), false);
+
+		const cancelled = debounce(() => undefined, 20);
+		cancelled();
+		cancelled.cancel();
+		assert.strictEqual(cancelled.pending(), false);
+	});
+});

--- a/src/test/suite/typstPathLinks.test.ts
+++ b/src/test/suite/typstPathLinks.test.ts
@@ -17,7 +17,10 @@ suite("Typst Path Links Test Suite", () => {
 	let provider: TypstPathLinks;
 
 	setup(() => {
-		directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-links-")));
+		// Spelled as the editor spells it. Every path under test reaches the
+		// assertion through a `Uri`, and on Windows that lower-cases the drive
+		// letter, so a raw temporary directory differs from it by that letter alone.
+		directory = vscode.Uri.file(fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-links-")))).fsPath;
 		provider = new TypstPathLinks();
 	});
 

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -129,6 +129,18 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(file.source.endsWith("\n#circle()"));
 		});
 
+		test("Should say that it ignored an option that is not text", async () => {
+			// The render reads the option whatever it holds, so an image built
+			// without it is not the image the render produces. Dropping it in
+			// silence would leave the reader with no way to see that.
+			const built = await buildCell(cell(["file: true", "preamble: false"]), context);
+			assert.ok(!isUnavailable(built));
+			assert.deepStrictEqual(
+				built.notes.filter((note) => note.includes("was ignored")),
+				["the `preamble` option is not text and was ignored", "the `file` option is not text and was ignored"],
+			);
+		});
+
 		test("Should say so when a file option cannot be read", async () => {
 			// The filter renders nothing here. A blank image with no reason beside
 			// it would look like the block itself was empty.

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -319,7 +319,11 @@ suite("Typst Preview Context Test Suite", () => {
 
 		/** A temporary project, with `typst-render` installed when asked. */
 		function project(withExtension: boolean | "ownerless"): string {
-			const directory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-gate-")));
+			// Spelled as the editor spells it. The root and the working directory
+			// under test both reach the assertion through a `Uri`, and on Windows
+			// that lower-cases the drive letter, so a raw temporary directory
+			// differs from them by that letter alone.
+			const directory = vscode.Uri.file(fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "typst-gate-")))).fsPath;
 			fs.writeFileSync(path.join(directory, "_quarto.yml"), "project:\n  type: default\n");
 			if (withExtension) {
 				// An extension installed from a repository sits under its owner, and a

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -147,6 +147,15 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(built.notes.some((note) => note.includes("compiled as code")));
 		});
 
+		test("Should not note a late option line the file option threw away", async () => {
+			// A `file:` replaces the body outright, so the line below the run is not
+			// compiled at all and a note saying that it is would be wrong.
+			const block = cell(["file: diagram.typ"], "#circle()\n//| width: 3cm");
+			const built = await buildCell(block, { ...context, readFile: reader({ "diagram.typ": "#rect()\n" }) });
+			assert.ok(!isUnavailable(built));
+			assert.ok(!built.notes.some((note) => note.includes("compiled as code")));
+		});
+
 		test("Should read the colours of the mode in force", async () => {
 			const brand = splitBrand({
 				color: { background: { light: "#fdf6e3", dark: "#101418" } },

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -114,12 +114,37 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.ok(built.source.endsWith("#circle()"));
 		});
 
+		test("Should ignore a boolean where a string option is expected", async () => {
+			// `true` and `false` become booleans, which `preamble:` and `file:` are
+			// never written with. Passing one through raised a `TypeError` from
+			// inside the assembler, so the reader was shown a JavaScript message in
+			// place of the block.
+			const preamble = await buildCell(cell(["preamble: false"]), context);
+			assert.ok(!isUnavailable(preamble));
+			assert.ok(preamble.source.endsWith("\n#circle()"));
+
+			const file = await buildCell(cell(["file: true"]), context);
+			assert.ok(!isUnavailable(file));
+			assert.strictEqual(file.externalFile, undefined);
+			assert.ok(file.source.endsWith("\n#circle()"));
+		});
+
 		test("Should say so when a file option cannot be read", async () => {
 			// The filter renders nothing here. A blank image with no reason beside
 			// it would look like the block itself was empty.
 			const built = await buildCell(cell(["file: missing.typ"]), context);
 			assert.ok(isUnavailable(built));
 			assert.ok(built.unavailable.includes("missing.typ"));
+		});
+
+		test("Should note an option line the run below it does not read", async () => {
+			// `code-cell.lua:110-118` warns and leaves the line as code. The two
+			// spellings look the same in the block, so the note is what says which
+			// one this is.
+			const block = cell(["margin: 2mm"], "#circle()\n//| width: 3cm");
+			const built = await buildCell(block, context);
+			assert.ok(!isUnavailable(built));
+			assert.ok(built.notes.some((note) => note.includes("compiled as code")));
 		});
 
 		test("Should read the colours of the mode in force", async () => {

--- a/src/test/suite/typstPreviewLifecycle.test.ts
+++ b/src/test/suite/typstPreviewLifecycle.test.ts
@@ -443,6 +443,32 @@ suite("Typst Preview Lifecycle Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should follow the cursor when a save lands just after it moved", async () => {
+		// A save answered the edit delay and cancelled the cursor delay, so a save
+		// arriving in the 250 ms after the cursor moved, with no edit waiting,
+		// threw the cursor away and rebuilt nothing. The panel then held the block
+		// the cursor had left until some later event moved it.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const { controller } = makeController(compiler);
+		const document = await twoBlockFile();
+
+		const editor = await vscode.window.showTextDocument(document, {
+			selection: new vscode.Range(INSIDE_BLOCK, INSIDE_BLOCK),
+		});
+		await settle(500);
+		// An edit of the first block, left long enough for its own delay to pass,
+		// so the edit delay has fired and holds nothing.
+		await editBlock(document);
+		await settle(700);
+
+		editor.selection = new vscode.Selection(SECOND_BLOCK, SECOND_BLOCK);
+		await document.save();
+		await settle(400);
+
+		assert.ok(compiler.sources.at(-1)?.includes("#square()"), "the block under the cursor is what compiled last");
+		controller.dispose();
+	});
+
 	test("Should say once that there is no Typst binary", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const { controller, messages } = makeController(compiler, { binary: undefined });

--- a/src/test/suite/typstPreviewPanel.test.ts
+++ b/src/test/suite/typstPreviewPanel.test.ts
@@ -80,6 +80,55 @@ suite("Typst Preview Panel Test Suite", () => {
 		assert.strictEqual(closed, 1);
 	});
 
+	test("Should paint the page again when it reloads", () => {
+		// Moving the panel to another editor group reloads the page, which comes
+		// back with an empty document and posts `initialized` a second time. The
+		// image and the header are unchanged, so nothing else would repaint it and
+		// the panel would stay blank until the block itself changed.
+		const { panel, posted, ready } = fakePanel();
+		ready();
+		panel.show("<svg id='a'/>", "doc.qmd · line 3");
+		posted.length = 0;
+
+		ready();
+
+		assert.deepStrictEqual(
+			posted.map((message) => message.type),
+			["image"],
+		);
+		panel.dispose();
+	});
+
+	test("Should paint the error again when the page reloads under one", () => {
+		// The error sits over the last good image, so a reload has to restore both
+		// and in that order, or the page comes back showing an image that a failure
+		// has already replaced.
+		const { panel, posted, ready } = fakePanel();
+		ready();
+		panel.show("<svg id='a'/>", "doc.qmd · line 3");
+		panel.showError("error at line 1, column 1 of the block: expected expression");
+		posted.length = 0;
+
+		ready();
+
+		assert.deepStrictEqual(
+			posted.map((message) => message.type),
+			["image", "error"],
+		);
+		panel.dispose();
+	});
+
+	test("Should send nothing when a page with no image reloads", () => {
+		const { panel, posted, ready } = fakePanel();
+		ready();
+		posted.length = 0;
+
+		ready();
+
+		assert.deepStrictEqual(posted, []);
+		panel.dispose();
+	});
+
 	test("Should ignore an update that arrives after it was closed", () => {
 		// A compile runs for up to the timeout and the user can close the tab
 		// meanwhile. Posting to a disposed webview throws, and the throw would

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -4,6 +4,8 @@
 export type DebouncedFunction<T extends (...args: never[]) => void> = T & {
 	cancel: () => void;
 	flush: () => void;
+	/** Whether a call is waiting for its delay to pass. */
+	pending: () => boolean;
 };
 
 /**
@@ -43,6 +45,8 @@ export function debounce<T extends (...args: any[]) => void>(fn: T, delay: numbe
 		}
 		pendingArgs = undefined;
 	};
+
+	debounced.pending = () => pendingArgs !== undefined;
 
 	debounced.flush = () => {
 		if (timeoutId !== undefined) {

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -380,6 +380,21 @@ export function cellNotes(options: ResolvedTypstOptions): string[] {
  * are resolved and merged, the block options are merged over them, the colours
  * of the mode in force are picked out, and the parts are assembled.
  */
+/**
+ * One option that has to be text, and a record of it when it is not.
+ *
+ * The name is collected rather than dropped in silence. The render reads the
+ * option whatever it holds, so a preview that ignores it and says nothing shows
+ * an image the render does not produce.
+ */
+function textOption(value: unknown, name: string, dropped: string[]): string | readonly string[] | undefined {
+	if (value === undefined || typeof value === "string" || Array.isArray(value)) {
+		return value as string | readonly string[] | undefined;
+	}
+	dropped.push(name);
+	return undefined;
+}
+
 export async function buildCell(block: TypstBlock, context: CellContext): Promise<AssembledCell | Unavailable> {
 	const brand = brandColourReader(context.brand);
 	const global = mergeGlobalConfigs(context.levels, brand);
@@ -390,9 +405,10 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	// assembler would raise a `TypeError` inside a compile that has no reason to
 	// fail and the reader would be shown that in place of the block. `input:` is
 	// guarded the same way below.
-	const preambleOption =
-		typeof options.preamble === "string" || Array.isArray(options.preamble) ? options.preamble : undefined;
-	const fileOption = typeof options.file === "string" && options.file !== "" ? options.file : undefined;
+	const droppedOptions: string[] = [];
+	const preambleOption = textOption(options.preamble, "preamble", droppedOptions);
+	const fileText = textOption(options.file, "file", droppedOptions);
+	const fileOption = typeof fileText === "string" && fileText !== "" ? fileText : undefined;
 
 	// The preamble and the `file:` are independent reads, so they run together.
 	const [preamble, code] = await Promise.all([
@@ -451,6 +467,9 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	// outright, so that line is not compiled at all and the note would be wrong.
 	if (code === undefined && hasLateOptionLine(block)) {
 		notes.push("an option line below the first run is compiled as code, not read as an option");
+	}
+	for (const name of droppedOptions) {
+		notes.push(`the \`${name}\` option is not text and was ignored`);
 	}
 	return { ...assembled, command, notes, bodyLineOffset, externalFile };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -1,4 +1,4 @@
-import { precedingRawBlocks, type TypstBlock } from "./typstBlocks";
+import { hasLateOptionLine, precedingRawBlocks, type TypstBlock } from "./typstBlocks";
 import { brandColourReader, brandDictionary, type Brand } from "./typstBrand";
 import { buildTypstCommand, type TypstCommand } from "./typstCli";
 import type { TypstPaths } from "./typstPaths";
@@ -385,17 +385,26 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	const global = mergeGlobalConfigs(context.levels, brand);
 	const options = resolveTypstOptions(block, global, brand);
 
+	// `true` and `false` parse as booleans, and these two options are written and
+	// read as text. A boolean is ignored rather than carried on, because the
+	// assembler would raise a `TypeError` inside a compile that has no reason to
+	// fail and the reader would be shown that in place of the block. `input:` is
+	// guarded the same way below.
+	const preambleOption =
+		typeof options.preamble === "string" || Array.isArray(options.preamble) ? options.preamble : undefined;
+	const fileOption = typeof options.file === "string" && options.file !== "" ? options.file : undefined;
+
 	// The preamble and the `file:` are independent reads, so they run together.
 	const [preamble, code] = await Promise.all([
-		resolvePreamble(options.preamble, context.readFile),
-		options.file === undefined || options.file === "" ? undefined : context.readFile(options.file),
+		resolvePreamble(preambleOption, context.readFile),
+		fileOption === undefined ? undefined : context.readFile(fileOption),
 	]);
 
 	// A `file:` replaces the cell body entirely. The filter logs and renders
 	// nothing when the read fails, which in a preview would be a blank image with
 	// no reason beside it.
-	if (options.file !== undefined && options.file !== "" && code === undefined) {
-		return { unavailable: `The file option names \`${options.file}\`, and it could not be read.` };
+	if (fileOption !== undefined && code === undefined) {
+		return { unavailable: `The file option names \`${fileOption}\`, and it could not be read.` };
 	}
 
 	// The compiled code starts below the block's own option run, and a `file:`
@@ -423,7 +432,7 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	// Named only when the file actually replaced the body. An empty `file:` skips
 	// the read and compiles the body, and reporting it as the external file would
 	// print a position "of " with no name and drop the option run correction.
-	const externalFile = code === undefined ? undefined : options.file;
+	const externalFile = code === undefined ? undefined : fileOption;
 	// The global configuration and not the merged options, because the filter
 	// reads `root`, `font-path` and `package-path` from it alone. The block's own
 	// `input:` is read from the block, because the merge drops it: it is a string
@@ -435,5 +444,12 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 		foreground,
 		paths: context.paths,
 	});
-	return { ...assembled, command, notes: cellNotes(options), bodyLineOffset, externalFile };
+	const notes = cellNotes(options);
+	// The upstream warning at `code-cell.lua:110-118`. An option line below the
+	// leading run is left as code, and the two spellings look the same in the
+	// block, so the reader is told which one this is.
+	if (hasLateOptionLine(block)) {
+		notes.push("an option line below the first run is compiled as code, not read as an option");
+	}
+	return { ...assembled, command, notes, bodyLineOffset, externalFile };
 }

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -447,8 +447,9 @@ export async function buildCell(block: TypstBlock, context: CellContext): Promis
 	const notes = cellNotes(options);
 	// The upstream warning at `code-cell.lua:110-118`. An option line below the
 	// leading run is left as code, and the two spellings look the same in the
-	// block, so the reader is told which one this is.
-	if (hasLateOptionLine(block)) {
+	// block, so the reader is told which one this is. A `file:` replaces the body
+	// outright, so that line is not compiled at all and the note would be wrong.
+	if (code === undefined && hasLateOptionLine(block)) {
 		notes.push("an option line below the first run is compiled as code, not read as an option");
 	}
 	return { ...assembled, command, notes, bodyLineOffset, externalFile };


### PR DESCRIPTION
A review of `src/providers/typstPreview/` and `src/utils/typst/` before the next release returned four defects. Each one is fixed here, with a test that fails without the fix.

- The panel painted its page only from the updates that arrived before the page reported in, so a page that reloads after it has gone live came back empty and nothing repainted it. Moving the panel to another editor group does exactly that, and the panel then stayed blank until the block itself changed. It now sends what is on screen whenever the page reports in, which answers the first load and every later one.
- A `true` or a `false` on `preamble:` or `file:` raised a `TypeError` from inside the assembler, and the reader was shown that in place of the block. Both options are read as text, so a value that is not text is ignored and named in the notes beside the image.
- A save cancelled a pending cursor follow and flushed an edit that was not pending, which left the panel on the block the cursor had left. The handler now asks whether either delay was waiting and rebuilds once if one was. A save that neither was waiting on rebuilds nothing, so a workspace using `files.autoSave` pays nothing for this.
- An option line below the leading run of a cell is compiled as code rather than read as an option. The parser reported that and no surface said so, so the note now reaches the reader. It is not written when a `file:` replaced the body, because that line is then not compiled at all.

Two changes fall out of the above. `DebouncedFunction` gains a `pending()` query, which is what lets the save handler rebuild exactly once. The panel drops its pre-ready message queue and its `showingError` flag, because both are derivable from what it records as being on screen.

There is no changelog entry. Every defect here is inside the Typst preview, which is unreleased, so the feature entry that ships it covers them.


One unrelated repair rides along, because it blocks this pull request and the release alike. Three tests from #401 and two from #402 fail on Windows and pass everywhere else. Each compares a path the code returned, which reaches the assertion through a `Uri` and so carries a lower-case drive letter, against a temporary directory spelled with an upper-case one. The two fixtures now spell their directory the way the editor does. Neither pull request saw this, because the Windows job of each was cancelled or skipped rather than run.
