### PR TITLE
fix: stop project root discovery from leaking scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`. (#385)
 - fix: find a Typst block written between two `---` lines that open no front matter. A document whose second line is blank or is itself `---` has no front matter, which is the rule Pandoc applies. (#397)
 - fix: compile a Typst preview under the root a render uses, so a block that reads a file beside its own document no longer fails. A `{typst}` cell also compiles with the `root`, `font-path`, `package-path` and `input` values of the `typst-render` extension. (#401)
+- fix: stop the search for Quarto projects from collecting search processes. The search ignored the exclude settings of the editor, it could not be stopped, and it ran again each time a document opened, so the processes stayed alive until they used all of the CPU.
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. An extension in a repository whose default branch is `master` failed to install. (#385)
 - fix: find a Typst block written between two `---` lines that open no front matter. (#397)
 - fix: compile a Typst preview under the root a render uses, so a block that reads a file beside its own document no longer fails. (#401)
-- fix: stop the search for Quarto projects from collecting search processes. The search now applies the `files.exclude` and `search.exclude` settings, and it stops when a newer search replaces it.
+- fix: stop the search for Quarto projects from collecting search processes. The search now applies the `files.exclude` and `search.exclude` settings, and it stops when a newer search replaces it. (#404)
 
 ## 3.2.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,20 @@
 
 ### New Features
 
-- feat: preview a Typst block from a Quarto document. The block under the cursor compiles with the Typst binary that ships inside Quarto, and the image is shown in a panel beside the editor or in a hover. (#395)
-- feat: open the file that a `file:` or a `preamble:` option names. The value is a link in a `{typst}` cell, in the front matter of a document, and in a configuration file, and a path that leads to no file carries a warning. (#402)
-- feat: publish the Lua reference validator of the v2 extension schema vocabulary at `https://m.canouil.dev/quarto-wizard/assets/schema/v2/schema.lua`. The vocabulary and the validator carry the same version, and extensions can now resolve the module by URL. (#374)
-- feat: accept `uniqueItems` in a field descriptor. The Lua reference validator already enforced the keyword, and the meta-schema now allows it, so a schema that uses it passes both. (#378)
-- docs: add a reference page that describes how an extension loads and calls the Lua reference validator. The page separates the meta-schema, which validates a schema file while you write it, from the module, which validates document metadata during a render. (#383)
+- feat: preview a Typst block from a Quarto document. The block under the cursor is shown in a panel beside the editor or in a hover. (#395)
+- feat: open the file that a `file:` or a `preamble:` option names. A path that leads to no file carries a warning. (#402)
+- feat: publish the Lua reference validator of the v2 extension schema vocabulary, so an extension can resolve the module by URL. (#374)
+- feat: accept `uniqueItems` in a field descriptor, which the Lua reference validator already enforced. (#378)
+- docs: add a reference page on how an extension loads and calls the Lua reference validator. (#383)
 
 ### Bug Fixes
 
-- fix: show every keyword of the vocabulary in the published example schemas. The v2 examples gained `uniqueItems`, the v1 examples gained `minimum` and `maximum`, every example gained the two content keywords, and a test now holds each example to the vocabulary of its version. (#381)
-- fix: teach the canonical v2 vocabulary in the schema generation prompt. The prompt named 15 v1 spellings that the declared v2 meta-schema rejects, and a test now holds the prompt to that vocabulary. (#382)
-- fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. The branch was assumed to be `main`, so an extension in a repository whose default branch is `master` failed to install unless the user wrote `@master`. (#385)
-- fix: find a Typst block written between two `---` lines that open no front matter. A document whose second line is blank or is itself `---` has no front matter, which is the rule Pandoc applies. (#397)
-- fix: compile a Typst preview under the root a render uses, so a block that reads a file beside its own document no longer fails. A `{typst}` cell also compiles with the `root`, `font-path`, `package-path` and `input` values of the `typst-render` extension. (#401)
-- fix: stop the search for Quarto projects from collecting search processes. The search ignored the exclude settings of the editor, it could not be stopped, and it ran again each time a document opened, so the processes stayed alive until they used all of the CPU.
+- fix: show every keyword of the vocabulary in the published example schemas. (#381)
+- fix: teach the canonical v2 vocabulary in the schema generation prompt, which named 15 spellings the v2 meta-schema rejects. (#382)
+- fix: read the default branch from GitHub for a repository that has no release, no tag and no registry entry. An extension in a repository whose default branch is `master` failed to install. (#385)
+- fix: find a Typst block written between two `---` lines that open no front matter. (#397)
+- fix: compile a Typst preview under the root a render uses, so a block that reads a file beside its own document no longer fails. (#401)
+- fix: stop the search for Quarto projects from collecting search processes. The search now applies the `files.exclude` and `search.exclude` settings, and it stops when a newer search replaces it.
 
 ## 3.2.0 (2026-08-02)
 

--- a/src/test/suite/projectRootsRegistry.test.ts
+++ b/src/test/suite/projectRootsRegistry.test.ts
@@ -7,6 +7,7 @@ import {
 	findOwningProjectRoot,
 	findOwningProjectRootSync,
 	invalidateProjectRoots,
+	refreshProjectRoots,
 	setProjectRoots,
 } from "../../utils/projectRootsRegistry";
 import { makeFolder, makeRoot } from "./projectFixtures";
@@ -95,6 +96,88 @@ suite("Project Roots Registry Test Suite", () => {
 		invalidateProjectRoots();
 
 		assert.strictEqual(findOwningProjectRootSync(path.join(nestedA.fsPath, "doc.qmd")), undefined);
+	});
+
+	/** Resolves once `predicate` holds, so a test can wait for a scan to start. */
+	async function waitFor(predicate: () => boolean): Promise<void> {
+		for (let attempt = 0; attempt < 200; attempt += 1) {
+			if (predicate()) {
+				return;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		assert.fail("timed out waiting for the scans to start");
+	}
+
+	test("ensureProjectRoots joins an in-flight refresh rather than cancelling it", async () => {
+		invalidateProjectRoots();
+
+		Object.defineProperty(vscode.workspace, "workspaceFolders", {
+			get: () => [workspace],
+			configurable: true,
+		});
+
+		let scans = 0;
+		let releaseFindFiles: () => void = () => undefined;
+		const blockUntil = new Promise<void>((resolve) => {
+			releaseFindFiles = resolve;
+		});
+		vscode.workspace.findFiles = (() => {
+			scans += 1;
+			return blockUntil.then(() => [] as vscode.Uri[]);
+		}) as typeof vscode.workspace.findFiles;
+
+		// The tree view refreshes on activation while a provider asks for the roots.
+		const refreshed = refreshProjectRoots();
+		const ensured = ensureProjectRoots();
+		await waitFor(() => scans >= 2);
+		releaseFindFiles();
+		const [refreshedRoots, ensuredRoots] = await Promise.all([refreshed, ensured]);
+
+		// One discovery runs two scans. A second discovery would cancel the first,
+		// and the tree view would render nothing.
+		assert.strictEqual(scans, 2);
+		assert.ok(refreshedRoots, "the refresh must not report itself superseded");
+		assert.deepStrictEqual(
+			ensuredRoots.map((root) => root.fsPath),
+			[workspaceFsPath],
+		);
+	});
+
+	test("a superseded discovery leaves the in-flight promise of the newer one alone", async () => {
+		invalidateProjectRoots();
+
+		Object.defineProperty(vscode.workspace, "workspaceFolders", {
+			get: () => [workspace],
+			configurable: true,
+		});
+
+		let scans = 0;
+		const gates: (() => void)[] = [];
+		vscode.workspace.findFiles = (() => {
+			scans += 1;
+			return new Promise<vscode.Uri[]>((resolve) => {
+				gates.push(() => resolve([]));
+			});
+		}) as typeof vscode.workspace.findFiles;
+
+		const first = ensureProjectRoots();
+		await waitFor(() => scans >= 2);
+		invalidateProjectRoots();
+		const second = ensureProjectRoots();
+		await waitFor(() => scans >= 4);
+
+		// The superseded discovery settles last, after the newer one is in flight.
+		gates[0]();
+		gates[1]();
+		await first;
+
+		const third = ensureProjectRoots();
+		gates[2]();
+		gates[3]();
+		await Promise.all([second, third]);
+
+		assert.strictEqual(scans, 4);
 	});
 
 	test("invalidateProjectRoots cancels the scan an in-flight discovery started", async () => {

--- a/src/test/suite/projectRootsRegistry.test.ts
+++ b/src/test/suite/projectRootsRegistry.test.ts
@@ -97,6 +97,44 @@ suite("Project Roots Registry Test Suite", () => {
 		assert.strictEqual(findOwningProjectRootSync(path.join(nestedA.fsPath, "doc.qmd")), undefined);
 	});
 
+	test("invalidateProjectRoots cancels the scan an in-flight discovery started", async () => {
+		invalidateProjectRoots();
+
+		Object.defineProperty(vscode.workspace, "workspaceFolders", {
+			get: () => [workspace],
+			configurable: true,
+		});
+
+		let capturedToken: vscode.CancellationToken | undefined;
+		let signalCalled: () => void = () => undefined;
+		const findFilesCalled = new Promise<void>((resolve) => {
+			signalCalled = resolve;
+		});
+		let releaseFindFiles: () => void = () => undefined;
+		const blockUntil = new Promise<void>((resolve) => {
+			releaseFindFiles = resolve;
+		});
+		vscode.workspace.findFiles = ((
+			_include: vscode.GlobPattern,
+			_exclude?: vscode.GlobPattern | null,
+			_maxResults?: number,
+			token?: vscode.CancellationToken,
+		) => {
+			capturedToken = token;
+			signalCalled();
+			return blockUntil.then(() => [] as vscode.Uri[]);
+		}) as typeof vscode.workspace.findFiles;
+
+		const pending = ensureProjectRoots();
+		await findFilesCalled;
+		invalidateProjectRoots();
+		releaseFindFiles();
+		await pending;
+
+		assert.ok(capturedToken, "discovery must pass a cancellation token to findFiles");
+		assert.strictEqual(capturedToken?.isCancellationRequested, true);
+	});
+
 	test("setProjectRoots wins over an older in-flight ensureProjectRoots discovery", async () => {
 		// Force `ensureProjectRoots` down the discovery branch by leaving state uninitialised.
 		invalidateProjectRoots();

--- a/src/test/suite/projectRootsRegistry.test.ts
+++ b/src/test/suite/projectRootsRegistry.test.ts
@@ -144,6 +144,46 @@ suite("Project Roots Registry Test Suite", () => {
 		);
 	});
 
+	test("ensureProjectRoots waits for the discovery that superseded the one it joined", async () => {
+		invalidateProjectRoots();
+
+		Object.defineProperty(vscode.workspace, "workspaceFolders", {
+			get: () => [workspace],
+			configurable: true,
+		});
+
+		let scans = 0;
+		const gates: (() => void)[] = [];
+		vscode.workspace.findFiles = (() => {
+			scans += 1;
+			return new Promise<vscode.Uri[]>((resolve) => {
+				gates.push(() => resolve([]));
+			});
+		}) as typeof vscode.workspace.findFiles;
+
+		// A provider asks for the roots, then a watcher event supersedes that scan.
+		const ensured = ensureProjectRoots();
+		await waitFor(() => scans >= 2);
+		const refreshed = refreshProjectRoots();
+		await waitFor(() => scans >= 4);
+
+		// The superseded scans answer first, while the snapshot is still empty.
+		gates[0]();
+		gates[1]();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		gates[2]();
+		gates[3]();
+
+		const [ensuredRoots, refreshedRoots] = await Promise.all([ensured, refreshed]);
+
+		// The empty snapshot would make `selectWorkspaceFolder` report no workspace.
+		assert.deepStrictEqual(
+			ensuredRoots.map((root) => root.fsPath),
+			[workspaceFsPath],
+		);
+		assert.deepStrictEqual(ensuredRoots, refreshedRoots);
+	});
+
 	test("a superseded discovery leaves the in-flight promise of the newer one alone", async () => {
 		invalidateProjectRoots();
 
@@ -167,15 +207,16 @@ suite("Project Roots Registry Test Suite", () => {
 		const second = ensureProjectRoots();
 		await waitFor(() => scans >= 4);
 
-		// The superseded discovery settles last, after the newer one is in flight.
+		// The superseded discovery settles while the newer one is still in flight.
 		gates[0]();
 		gates[1]();
-		await first;
+		await new Promise((resolve) => setTimeout(resolve, 0));
 
+		// Its `finally` must leave the newer discovery in place for this caller to join.
 		const third = ensureProjectRoots();
 		gates[2]();
 		gates[3]();
-		await Promise.all([second, third]);
+		await Promise.all([first, second, third]);
 
 		assert.strictEqual(scans, 4);
 	});

--- a/src/test/suite/projectRootsRegistry.test.ts
+++ b/src/test/suite/projectRootsRegistry.test.ts
@@ -229,11 +229,7 @@ suite("Project Roots Registry Test Suite", () => {
 			configurable: true,
 		});
 
-		let capturedToken: vscode.CancellationToken | undefined;
-		let signalCalled: () => void = () => undefined;
-		const findFilesCalled = new Promise<void>((resolve) => {
-			signalCalled = resolve;
-		});
+		const tokens: (vscode.CancellationToken | undefined)[] = [];
 		let releaseFindFiles: () => void = () => undefined;
 		const blockUntil = new Promise<void>((resolve) => {
 			releaseFindFiles = resolve;
@@ -244,19 +240,24 @@ suite("Project Roots Registry Test Suite", () => {
 			_maxResults?: number,
 			token?: vscode.CancellationToken,
 		) => {
-			capturedToken = token;
-			signalCalled();
+			tokens.push(token);
 			return blockUntil.then(() => [] as vscode.Uri[]);
 		}) as typeof vscode.workspace.findFiles;
 
 		const pending = ensureProjectRoots();
-		await findFilesCalled;
+		await waitFor(() => tokens.length >= 2);
 		invalidateProjectRoots();
 		releaseFindFiles();
-		await pending;
+		const roots = await pending;
 
-		assert.ok(capturedToken, "discovery must pass a cancellation token to findFiles");
-		assert.strictEqual(capturedToken?.isCancellationRequested, true);
+		assert.ok(tokens[0], "discovery must pass a cancellation token to findFiles");
+		assert.strictEqual(tokens[0]?.isCancellationRequested, true);
+		// Nothing replaced the cancelled discovery, and the debounced refresh of the
+		// tree view is 500 ms away, so the caller must run one of its own.
+		assert.deepStrictEqual(
+			roots.map((root) => root.fsPath),
+			[workspaceFsPath],
+		);
 	});
 
 	test("setProjectRoots wins over an older in-flight ensureProjectRoots discovery", async () => {

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -34,6 +34,8 @@ suite("Quarto Project Discovery Test Suite", () => {
 
 	let mockedTextDocuments: readonly vscode.TextDocument[];
 	let mockedConfig: MockedConfig;
+	let mockedFilesExclude: Record<string, boolean> | undefined;
+	let mockedSearchExclude: Record<string, boolean> | undefined;
 
 	setup(() => {
 		// Normalise via Uri.file so Windows drive-letter casing matches what `findFiles`
@@ -42,6 +44,8 @@ suite("Quarto Project Discovery Test Suite", () => {
 
 		mockedTextDocuments = [];
 		mockedConfig = { autoProjectDetection: "subFolders" };
+		mockedFilesExclude = undefined;
+		mockedSearchExclude = undefined;
 
 		originalFindFiles = vscode.workspace.findFiles;
 		// Default: scan the temp tree on disk and dispatch by glob to mirror the real findFiles.
@@ -70,6 +74,19 @@ suite("Quarto Project Discovery Test Suite", () => {
 
 		originalGetConfiguration = vscode.workspace.getConfiguration;
 		vscode.workspace.getConfiguration = ((section?: string) => {
+			const mockedExclude =
+				section === "files" ? mockedFilesExclude : section === "search" ? mockedSearchExclude : undefined;
+			if (mockedExclude) {
+				return {
+					get: <T>(key: string, defaultValue?: T): T =>
+						key === "exclude" ? (mockedExclude as T) : (defaultValue as T),
+					has: () => true,
+					inspect: () => undefined,
+					update: async () => {
+						/* no-op */
+					},
+				} as unknown as vscode.WorkspaceConfiguration;
+			}
 			if (section === "quartoWizard") {
 				return {
 					get: <T>(key: string, defaultValue?: T): T => {
@@ -465,8 +482,10 @@ suite("Quarto Project Discovery Test Suite", () => {
 		});
 	}
 
-	test("scans with the default excludes, a result cap, and the caller's cancellation token", async () => {
+	test("scans with the exclude settings of the editor, a result cap, and the caller's token", async () => {
 		writeQuartoYml(path.join(tempDir, "site-a"));
+		mockedFilesExclude = { "**/.git": true, "**/.hg": false };
+		mockedSearchExclude = { "**/node_modules": true };
 
 		interface ScanCall {
 			exclude: vscode.GlobPattern | null | undefined;
@@ -493,9 +512,10 @@ suite("Quarto Project Discovery Test Suite", () => {
 
 		assert.strictEqual(calls.length, 2);
 		for (const call of calls) {
-			// A `null` exclude turns every exclude off, which sends the scan through
-			// `node_modules`, `.git` and build output.
-			assert.strictEqual(call.exclude, undefined);
+			// A `null` exclude turns every exclude off, and an `undefined` exclude
+			// applies `files.exclude` alone, which holds neither `node_modules` nor
+			// build output. Both send the scan through the whole tree.
+			assert.strictEqual(call.exclude, "{**/.git,**/node_modules}");
 			assert.strictEqual(typeof call.maxResults, "number");
 			assert.strictEqual(call.token, source.token);
 		}

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { EXTENSIONS_DIR, MANIFEST_FILENAMES } from "@quarto-wizard/core";
 import {
+	buildExcludeGlob,
 	discoverQuartoProjectRoots,
 	EXTENSION_MANIFEST_DIRECT_GLOB,
 	EXTENSION_MANIFEST_GLOB,
@@ -519,6 +520,16 @@ suite("Quarto Project Discovery Test Suite", () => {
 			assert.strictEqual(typeof call.maxResults, "number");
 			assert.strictEqual(call.token, source.token);
 		}
+	});
+
+	test("drops an exclude pattern that holds a comma, which would split the brace group", async () => {
+		mockedFilesExclude = { "**/data, raw": true, "**/.git": true };
+		mockedSearchExclude = { "**/{node_modules,dist}": true };
+
+		const exclude = buildExcludeGlob(vscode.Uri.file(tempDir));
+
+		// `**/data` alone would hide every `data` directory, and the projects under it.
+		assert.strictEqual(exclude, "{**/.git,**/{node_modules,dist}}");
 	});
 
 	test("populated root _extensions/ short-circuits before any scan", async () => {

--- a/src/test/suite/quartoProjectDiscovery.test.ts
+++ b/src/test/suite/quartoProjectDiscovery.test.ts
@@ -465,6 +465,42 @@ suite("Quarto Project Discovery Test Suite", () => {
 		});
 	}
 
+	test("scans with the default excludes, a result cap, and the caller's cancellation token", async () => {
+		writeQuartoYml(path.join(tempDir, "site-a"));
+
+		interface ScanCall {
+			exclude: vscode.GlobPattern | null | undefined;
+			maxResults: number | undefined;
+			token: vscode.CancellationToken | undefined;
+		}
+		const calls: ScanCall[] = [];
+		vscode.workspace.findFiles = ((
+			_include: vscode.GlobPattern,
+			exclude?: vscode.GlobPattern | null,
+			maxResults?: number,
+			token?: vscode.CancellationToken,
+		) => {
+			calls.push({ exclude, maxResults, token });
+			return Promise.resolve([]);
+		}) as typeof vscode.workspace.findFiles;
+
+		const source = new vscode.CancellationTokenSource();
+		try {
+			await discoverQuartoProjectRoots([makeFolder("workspace", tempDir)], source.token);
+		} finally {
+			source.dispose();
+		}
+
+		assert.strictEqual(calls.length, 2);
+		for (const call of calls) {
+			// A `null` exclude turns every exclude off, which sends the scan through
+			// `node_modules`, `.git` and build output.
+			assert.strictEqual(call.exclude, undefined);
+			assert.strictEqual(typeof call.maxResults, "number");
+			assert.strictEqual(call.token, source.token);
+		}
+	});
+
 	test("populated root _extensions/ short-circuits before any scan", async () => {
 		writeExtensionRepoFixture();
 		let findFilesCalled = false;

--- a/src/test/suite/workspace.test.ts
+++ b/src/test/suite/workspace.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { selectWorkspaceFolder } from "../../utils/workspace";
+import { invalidateProjectRoots } from "../../utils/projectRootsRegistry";
 
 interface MockQuickPickResult {
 	root: { fsPath: string };
@@ -29,6 +30,10 @@ suite("Workspace Utils Test Suite", () => {
 		quickPickResult = undefined;
 		lastQuickPickItems = undefined;
 		lastQuickPickOptions = undefined;
+
+		// `selectWorkspaceFolder` reads the shared registry, and each test installs
+		// its own workspace folders without the events that refresh the snapshot.
+		invalidateProjectRoots();
 
 		Object.defineProperty(vscode.workspace, "workspaceFolders", {
 			get: () => mockWorkspaceFolders,
@@ -79,6 +84,7 @@ suite("Workspace Utils Test Suite", () => {
 			value: originalWorkspaceFolders,
 			configurable: true,
 		});
+		invalidateProjectRoots();
 		vscode.window.showQuickPick = originalShowQuickPick;
 		vscode.workspace.findFiles = originalFindFiles;
 		vscode.workspace.getConfiguration = originalGetConfiguration;

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -12,12 +12,12 @@ import { getAutoProjectDetection } from "../utils/extensionDetails";
 import { getSourceBase, resolveLocalSourcePath } from "../utils/extensions";
 import { invalidateInstalledExtensionsCache } from "../utils/installedExtensionsCache";
 import { invalidateWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import { QUARTO_PROJECT_GLOB, EXTENSION_MANIFEST_GLOB } from "../utils/quartoProjectDiscovery";
 import {
-	discoverQuartoProjectRoots,
-	QUARTO_PROJECT_GLOB,
-	EXTENSION_MANIFEST_GLOB,
-} from "../utils/quartoProjectDiscovery";
-import { findOwningProjectRootSync, invalidateProjectRoots, setProjectRoots } from "../utils/projectRootsRegistry";
+	findOwningProjectRootSync,
+	invalidateProjectRoots,
+	refreshProjectRoots as rediscoverProjectRoots,
+} from "../utils/projectRootsRegistry";
 import { debounce } from "../utils/debounce";
 import { WorkspaceFolderTreeItem, ExtensionTreeItem, SnippetItemTreeItem } from "./extensionTreeItems";
 import { QuartoExtensionTreeDataProvider } from "./extensionTreeDataProvider";
@@ -66,38 +66,19 @@ export class ExtensionsInstalled {
 			return vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath;
 		};
 
-		// Cancels the scans of the discovery a newer trigger supersedes. Without it every
-		// trigger leaves its scan running, and the scan processes collect.
-		let discoveryCancellation: vscode.CancellationTokenSource | undefined;
-		context.subscriptions.push({
-			dispose: () => {
-				discoveryCancellation?.cancel();
-				discoveryCancellation = undefined;
-			},
-		});
-
 		const updateProjectRoots = async (): Promise<boolean> => {
-			const folders = vscode.workspace.workspaceFolders ?? [];
-			discoveryCancellation?.cancel();
-			const cancellation = new vscode.CancellationTokenSource();
-			discoveryCancellation = cancellation;
 			try {
-				const roots = await discoverQuartoProjectRoots(folders, cancellation.token);
-				// A cancelled scan returns a partial result, so a superseded discovery
-				// must not write it over the roots the newer discovery finds.
-				if (cancellation.token.isCancellationRequested) {
+				// The registry owns the scans and cancels the ones a newer trigger
+				// supersedes. A superseded discovery reports nothing, and the newer
+				// one updates the view.
+				const roots = await rediscoverProjectRoots();
+				if (!roots) {
 					return false;
 				}
-				setProjectRoots(roots);
 				return this.treeDataProvider.setProjectRoots(roots);
 			} catch (error) {
 				logMessage(`Failed to discover Quarto project roots: ${getErrorMessage(error)}.`, "error");
 				return false;
-			} finally {
-				if (discoveryCancellation === cancellation) {
-					discoveryCancellation = undefined;
-				}
-				cancellation.dispose();
 			}
 		};
 
@@ -158,12 +139,13 @@ export class ExtensionsInstalled {
 		// The other modes do not read the open documents, and a recursive scan on every
 		// editor event is expensive, so the trigger is confined to `openEditors`.
 		const onEditorChanged = (document: vscode.TextDocument) => {
+			if (document.uri.scheme !== "file" || document.isUntitled) {
+				return;
+			}
 			if (getAutoProjectDetection() !== "openEditors") {
 				return;
 			}
-			if (document.uri.scheme === "file" && !document.isUntitled) {
-				refreshProjectRoots();
-			}
+			refreshProjectRoots();
 		};
 		context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(onEditorChanged));
 		context.subscriptions.push(vscode.workspace.onDidCloseTextDocument(onEditorChanged));

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -12,6 +12,7 @@ import { getAutoProjectDetection } from "../utils/extensionDetails";
 import { getSourceBase, resolveLocalSourcePath } from "../utils/extensions";
 import { invalidateInstalledExtensionsCache } from "../utils/installedExtensionsCache";
 import { invalidateWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
+import { invalidateMetadataFiles } from "../utils/metadataFilesRegistry";
 import { QUARTO_PROJECT_GLOB, EXTENSION_MANIFEST_GLOB } from "../utils/quartoProjectDiscovery";
 import {
 	findOwningProjectRootSync,
@@ -112,6 +113,14 @@ export class ExtensionsInstalled {
 
 		context.subscriptions.push(
 			vscode.workspace.onDidChangeConfiguration((event) => {
+				// The scans read the exclude settings, so a change to either one changes
+				// which projects and which metadata files the scans can reach.
+				if (event.affectsConfiguration("files.exclude") || event.affectsConfiguration("search.exclude")) {
+					invalidateMetadataFiles();
+					invalidateProjectRoots();
+					refreshProjectRoots();
+					return;
+				}
 				if (event.affectsConfiguration("quartoWizard.autoProjectDetection")) {
 					refreshProjectRoots();
 				}

--- a/src/ui/extensionsInstalled.ts
+++ b/src/ui/extensionsInstalled.ts
@@ -8,6 +8,7 @@ import { removeQuartoExtension, removeQuartoExtensions, installQuartoExtension }
 import { withProgressNotification } from "../utils/withProgressNotification";
 import { installQuartoExtensionFolderCommand } from "../commands/installQuartoExtension";
 import { getAuthConfig } from "../utils/auth";
+import { getAutoProjectDetection } from "../utils/extensionDetails";
 import { getSourceBase, resolveLocalSourcePath } from "../utils/extensions";
 import { invalidateInstalledExtensionsCache } from "../utils/installedExtensionsCache";
 import { invalidateWorkspaceSchemaIndex } from "../utils/workspaceSchemaIndex";
@@ -65,15 +66,38 @@ export class ExtensionsInstalled {
 			return vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath;
 		};
 
+		// Cancels the scans of the discovery a newer trigger supersedes. Without it every
+		// trigger leaves its scan running, and the scan processes collect.
+		let discoveryCancellation: vscode.CancellationTokenSource | undefined;
+		context.subscriptions.push({
+			dispose: () => {
+				discoveryCancellation?.cancel();
+				discoveryCancellation = undefined;
+			},
+		});
+
 		const updateProjectRoots = async (): Promise<boolean> => {
 			const folders = vscode.workspace.workspaceFolders ?? [];
+			discoveryCancellation?.cancel();
+			const cancellation = new vscode.CancellationTokenSource();
+			discoveryCancellation = cancellation;
 			try {
-				const roots = await discoverQuartoProjectRoots(folders);
+				const roots = await discoverQuartoProjectRoots(folders, cancellation.token);
+				// A cancelled scan returns a partial result, so a superseded discovery
+				// must not write it over the roots the newer discovery finds.
+				if (cancellation.token.isCancellationRequested) {
+					return false;
+				}
 				setProjectRoots(roots);
 				return this.treeDataProvider.setProjectRoots(roots);
 			} catch (error) {
 				logMessage(`Failed to discover Quarto project roots: ${getErrorMessage(error)}.`, "error");
 				return false;
+			} finally {
+				if (discoveryCancellation === cancellation) {
+					discoveryCancellation = undefined;
+				}
+				cancellation.dispose();
 			}
 		};
 
@@ -131,7 +155,12 @@ export class ExtensionsInstalled {
 
 		// `openEditors` mode walks parents of open documents; refresh when the doc set changes.
 		// Filter to real files so output channels and untitled buffers don't queue work.
+		// The other modes do not read the open documents, and a recursive scan on every
+		// editor event is expensive, so the trigger is confined to `openEditors`.
 		const onEditorChanged = (document: vscode.TextDocument) => {
+			if (getAutoProjectDetection() !== "openEditors") {
+				return;
+			}
 			if (document.uri.scheme === "file" && !document.isUntitled) {
 				refreshProjectRoots();
 			}

--- a/src/utils/metadataFilesRegistry.ts
+++ b/src/utils/metadataFilesRegistry.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 import * as yaml from "js-yaml";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { isInside } from "./quartoProjectDiscovery";
+import { isInside, MAX_SCAN_RESULTS } from "./quartoProjectDiscovery";
 import { logMessage } from "./log";
 
 /**
@@ -200,9 +200,13 @@ async function parseAndUpdateSource(projectRoot: string, sourceFsPath: string): 
 async function buildForRoot(projectRoot: string): Promise<void> {
 	const folderUri = vscode.Uri.file(projectRoot);
 	try {
+		// An `undefined` exclude applies the user's `files.exclude` and `search.exclude`.
+		// A `null` exclude turns every exclude off, which sends the scan through
+		// `node_modules`, `.git` and build output.
 		const uris = await vscode.workspace.findFiles(
 			new vscode.RelativePattern(folderUri, QUARTO_AND_METADATA_PATTERN),
-			null,
+			undefined,
+			MAX_SCAN_RESULTS,
 		);
 
 		const sources = new Set<string>();

--- a/src/utils/metadataFilesRegistry.ts
+++ b/src/utils/metadataFilesRegistry.ts
@@ -209,6 +209,10 @@ async function buildForRoot(projectRoot: string): Promise<void> {
 			MAX_SCAN_RESULTS,
 		);
 
+		if (uris.length >= MAX_SCAN_RESULTS) {
+			logMessage(`Scan of ${projectRoot} reached the ${MAX_SCAN_RESULTS} match limit; some files are missing.`, "warn");
+		}
+
 		const sources = new Set<string>();
 		for (const uri of uris) {
 			if (uri.scheme !== "file") {

--- a/src/utils/metadataFilesRegistry.ts
+++ b/src/utils/metadataFilesRegistry.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 import * as yaml from "js-yaml";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { isInside, MAX_SCAN_RESULTS } from "./quartoProjectDiscovery";
+import { buildExcludeGlob, isInside, MAX_SCAN_RESULTS } from "./quartoProjectDiscovery";
 import { logMessage } from "./log";
 
 /**
@@ -200,12 +200,9 @@ async function parseAndUpdateSource(projectRoot: string, sourceFsPath: string): 
 async function buildForRoot(projectRoot: string): Promise<void> {
 	const folderUri = vscode.Uri.file(projectRoot);
 	try {
-		// An `undefined` exclude applies the user's `files.exclude` and `search.exclude`.
-		// A `null` exclude turns every exclude off, which sends the scan through
-		// `node_modules`, `.git` and build output.
 		const uris = await vscode.workspace.findFiles(
 			new vscode.RelativePattern(folderUri, QUARTO_AND_METADATA_PATTERN),
-			undefined,
+			buildExcludeGlob(folderUri),
 			MAX_SCAN_RESULTS,
 		);
 

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -11,13 +11,10 @@ import { discoverQuartoProjectRoots, isInside, type QuartoProjectRoot } from "./
 let currentRoots: readonly QuartoProjectRoot[] = [];
 let initialised = false;
 let inFlight: Promise<readonly QuartoProjectRoot[]> | undefined;
-// Cancels the file scans of the in-flight discovery. Dropping the promise alone
-// leaves the scan running, and repeated triggers collect scan processes.
+// Cancels the file scans of the in-flight discovery, so a superseded discovery
+// cannot write the snapshot and cannot leave its scan running. Dropping the
+// promise alone leaves the scan alive, and repeated triggers collect scans.
 let inFlightCancellation: vscode.CancellationTokenSource | undefined;
-// Bumped by `setProjectRoots` and `invalidateProjectRoots` so a queued
-// `ensureProjectRoots` continuation from an earlier generation cannot
-// overwrite state written after it started.
-let generation = 0;
 
 /**
  * Returns the cached snapshot, running discovery once if needed.
@@ -30,28 +27,40 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 	if (inFlight) {
 		return inFlight;
 	}
-	const folders = vscode.workspace.workspaceFolders ?? [];
-	const startedAt = generation;
-	const cancellation = new vscode.CancellationTokenSource();
-	inFlightCancellation = cancellation;
-	inFlight = discoverQuartoProjectRoots(folders, cancellation.token)
-		.then((roots) => {
-			// A cancelled scan returns a partial result, so only an uncancelled
-			// discovery of the current generation may write the snapshot.
-			if (generation === startedAt && !cancellation.token.isCancellationRequested) {
-				currentRoots = roots;
-				initialised = true;
-			}
-			return currentRoots;
-		})
+	inFlight = refreshProjectRoots()
+		.then((roots) => roots ?? currentRoots)
 		.finally(() => {
 			inFlight = undefined;
-			if (inFlightCancellation === cancellation) {
-				inFlightCancellation = undefined;
-			}
-			cancellation.dispose();
 		});
 	return inFlight;
+}
+
+/**
+ * Runs discovery and writes the snapshot. Cancels the discovery this call
+ * supersedes, so only one set of file scans is ever running.
+ *
+ * @returns The discovered roots, or `undefined` when a newer call superseded
+ *          this one, which leaves the snapshot to that newer call.
+ */
+export async function refreshProjectRoots(): Promise<readonly QuartoProjectRoot[] | undefined> {
+	cancelInFlightDiscovery();
+	const cancellation = new vscode.CancellationTokenSource();
+	inFlightCancellation = cancellation;
+	try {
+		const folders = vscode.workspace.workspaceFolders ?? [];
+		const roots = await discoverQuartoProjectRoots(folders, cancellation.token);
+		if (cancellation.token.isCancellationRequested) {
+			return undefined;
+		}
+		currentRoots = roots;
+		initialised = true;
+		return roots;
+	} finally {
+		if (inFlightCancellation === cancellation) {
+			inFlightCancellation = undefined;
+		}
+		cancellation.dispose();
+	}
 }
 
 /** Cancels the in-flight discovery so its file scans stop. */
@@ -69,7 +78,6 @@ export function setProjectRoots(roots: readonly QuartoProjectRoot[]): void {
 	currentRoots = roots;
 	initialised = true;
 	inFlight = undefined;
-	generation += 1;
 }
 
 /**
@@ -81,7 +89,6 @@ export function invalidateProjectRoots(): void {
 	currentRoots = [];
 	initialised = false;
 	inFlight = undefined;
-	generation += 1;
 }
 
 /**

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -11,6 +11,9 @@ import { discoverQuartoProjectRoots, isInside, type QuartoProjectRoot } from "./
 let currentRoots: readonly QuartoProjectRoot[] = [];
 let initialised = false;
 let inFlight: Promise<readonly QuartoProjectRoot[]> | undefined;
+// Cancels the file scans of the in-flight discovery. Dropping the promise alone
+// leaves the scan running, and repeated triggers collect scan processes.
+let inFlightCancellation: vscode.CancellationTokenSource | undefined;
 // Bumped by `setProjectRoots` and `invalidateProjectRoots` so a queued
 // `ensureProjectRoots` continuation from an earlier generation cannot
 // overwrite state written after it started.
@@ -29,9 +32,13 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 	}
 	const folders = vscode.workspace.workspaceFolders ?? [];
 	const startedAt = generation;
-	inFlight = discoverQuartoProjectRoots(folders)
+	const cancellation = new vscode.CancellationTokenSource();
+	inFlightCancellation = cancellation;
+	inFlight = discoverQuartoProjectRoots(folders, cancellation.token)
 		.then((roots) => {
-			if (generation === startedAt) {
+			// A cancelled scan returns a partial result, so only an uncancelled
+			// discovery of the current generation may write the snapshot.
+			if (generation === startedAt && !cancellation.token.isCancellationRequested) {
 				currentRoots = roots;
 				initialised = true;
 			}
@@ -39,8 +46,18 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 		})
 		.finally(() => {
 			inFlight = undefined;
+			if (inFlightCancellation === cancellation) {
+				inFlightCancellation = undefined;
+			}
+			cancellation.dispose();
 		});
 	return inFlight;
+}
+
+/** Cancels the in-flight discovery so its file scans stop. */
+function cancelInFlightDiscovery(): void {
+	inFlightCancellation?.cancel();
+	inFlightCancellation = undefined;
 }
 
 /**
@@ -48,6 +65,7 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
  * a concurrent `ensureProjectRoots` cannot race-overwrite this snapshot.
  */
 export function setProjectRoots(roots: readonly QuartoProjectRoot[]): void {
+	cancelInFlightDiscovery();
 	currentRoots = roots;
 	initialised = true;
 	inFlight = undefined;
@@ -59,6 +77,7 @@ export function setProjectRoots(roots: readonly QuartoProjectRoot[]): void {
  * discovery.
  */
 export function invalidateProjectRoots(): void {
+	cancelInFlightDiscovery();
 	currentRoots = [];
 	initialised = false;
 	inFlight = undefined;

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -42,13 +42,9 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 			return currentRoots;
 		}
 		// A superseded discovery reports nothing, so follow the discovery that
-		// replaced it. When nothing replaced it the snapshot is the answer, and
-		// starting another scan here would fight the refresh that comes next.
-		const successor = inFlight;
-		if (!successor) {
-			break;
-		}
-		pending = successor;
+		// replaced it. When nothing replaced it, run one here: the refresh of the
+		// tree view is debounced, and the empty snapshot would report no project.
+		pending = inFlight ?? refreshProjectRoots();
 	}
 	return currentRoots;
 }

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -8,6 +8,12 @@ import { discoverQuartoProjectRoots, isInside, type QuartoProjectRoot } from "./
  * snippets).
  */
 
+/**
+ * How many times a waiting caller follows a superseded discovery to the one that
+ * replaced it. A trigger storm cannot hold the caller for ever.
+ */
+const MAX_DISCOVERY_ATTEMPTS = 5;
+
 let currentRoots: readonly QuartoProjectRoot[] = [];
 let initialised = false;
 let inFlight: Promise<readonly QuartoProjectRoot[] | undefined> | undefined;
@@ -26,8 +32,25 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 	}
 	// Join the discovery that is already running. A second one would cancel it,
 	// and both callers would then hold an empty snapshot.
-	const roots = await (inFlight ?? refreshProjectRoots());
-	return roots ?? currentRoots;
+	let pending = inFlight ?? refreshProjectRoots();
+	for (let attempt = 0; attempt < MAX_DISCOVERY_ATTEMPTS; attempt += 1) {
+		const roots = await pending;
+		if (roots) {
+			return roots;
+		}
+		if (initialised) {
+			return currentRoots;
+		}
+		// A superseded discovery reports nothing, so follow the discovery that
+		// replaced it. When nothing replaced it the snapshot is the answer, and
+		// starting another scan here would fight the refresh that comes next.
+		const successor = inFlight;
+		if (!successor) {
+			break;
+		}
+		pending = successor;
+	}
+	return currentRoots;
 }
 
 /**
@@ -78,6 +101,9 @@ function cancelInFlightDiscovery(): void {
 /**
  * Overwrites the cached snapshot and cancels any in-flight discovery so
  * a concurrent `ensureProjectRoots` cannot race-overwrite this snapshot.
+ *
+ * Seeds the registry for a test. Production code reaches the snapshot through
+ * {@link ensureProjectRoots} and {@link refreshProjectRoots}.
  */
 export function setProjectRoots(roots: readonly QuartoProjectRoot[]): void {
 	cancelInFlightDiscovery();

--- a/src/utils/projectRootsRegistry.ts
+++ b/src/utils/projectRootsRegistry.ts
@@ -10,7 +10,7 @@ import { discoverQuartoProjectRoots, isInside, type QuartoProjectRoot } from "./
 
 let currentRoots: readonly QuartoProjectRoot[] = [];
 let initialised = false;
-let inFlight: Promise<readonly QuartoProjectRoot[]> | undefined;
+let inFlight: Promise<readonly QuartoProjectRoot[] | undefined> | undefined;
 // Cancels the file scans of the in-flight discovery, so a superseded discovery
 // cannot write the snapshot and cannot leave its scan running. Dropping the
 // promise alone leaves the scan alive, and repeated triggers collect scans.
@@ -24,15 +24,10 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
 	if (initialised) {
 		return currentRoots;
 	}
-	if (inFlight) {
-		return inFlight;
-	}
-	inFlight = refreshProjectRoots()
-		.then((roots) => roots ?? currentRoots)
-		.finally(() => {
-			inFlight = undefined;
-		});
-	return inFlight;
+	// Join the discovery that is already running. A second one would cancel it,
+	// and both callers would then hold an empty snapshot.
+	const roots = await (inFlight ?? refreshProjectRoots());
+	return roots ?? currentRoots;
 }
 
 /**
@@ -42,25 +37,36 @@ export async function ensureProjectRoots(): Promise<readonly QuartoProjectRoot[]
  * @returns The discovered roots, or `undefined` when a newer call superseded
  *          this one, which leaves the snapshot to that newer call.
  */
-export async function refreshProjectRoots(): Promise<readonly QuartoProjectRoot[] | undefined> {
+export function refreshProjectRoots(): Promise<readonly QuartoProjectRoot[] | undefined> {
 	cancelInFlightDiscovery();
 	const cancellation = new vscode.CancellationTokenSource();
 	inFlightCancellation = cancellation;
-	try {
-		const folders = vscode.workspace.workspaceFolders ?? [];
-		const roots = await discoverQuartoProjectRoots(folders, cancellation.token);
-		if (cancellation.token.isCancellationRequested) {
-			return undefined;
+	const discovery = runDiscovery(cancellation).finally(() => {
+		// A superseded discovery settles after the newer one started, so it clears
+		// only the state that is still its own.
+		if (inFlight === discovery) {
+			inFlight = undefined;
 		}
-		currentRoots = roots;
-		initialised = true;
-		return roots;
-	} finally {
 		if (inFlightCancellation === cancellation) {
 			inFlightCancellation = undefined;
 		}
 		cancellation.dispose();
+	});
+	inFlight = discovery;
+	return discovery;
+}
+
+async function runDiscovery(
+	cancellation: vscode.CancellationTokenSource,
+): Promise<readonly QuartoProjectRoot[] | undefined> {
+	const folders = vscode.workspace.workspaceFolders ?? [];
+	const roots = await discoverQuartoProjectRoots(folders, cancellation.token);
+	if (cancellation.token.isCancellationRequested) {
+		return undefined;
 	}
+	currentRoots = roots;
+	initialised = true;
+	return roots;
 }
 
 /** Cancels the in-flight discovery so its file scans stop. */

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -122,7 +122,7 @@ export async function discoverQuartoProjectRoots(
 		const ignorePatterns = readQuartoIgnore(folderPath);
 		const discovered =
 			setting === "openEditors"
-				? await findOpenEditorProjectDirs(folder)
+				? await findOpenEditorProjectDirs(folder, token)
 				: await findSubFolderProjectDirs(folder, setting === true, token);
 
 		const candidates = new Set<string>();
@@ -215,10 +215,19 @@ function projectRootFromManifestPath(manifestPath: string): string | undefined {
 	return segments.slice(0, idx).join(path.sep);
 }
 
-async function findOpenEditorProjectDirs(folder: vscode.WorkspaceFolder): Promise<string[]> {
+async function findOpenEditorProjectDirs(
+	folder: vscode.WorkspaceFolder,
+	token?: vscode.CancellationToken,
+): Promise<string[]> {
 	const folderPath = folder.uri.fsPath;
 	const dirs = new Set<string>();
+	// Open documents share their ancestors, and probing one directory reads it from
+	// disk, so the answers are held for the whole pass.
+	const markers = new Map<string, boolean>();
 	for (const document of vscode.workspace.textDocuments) {
+		if (token?.isCancellationRequested) {
+			break;
+		}
 		if (document.uri.scheme !== "file" || document.isUntitled) {
 			continue;
 		}
@@ -226,7 +235,7 @@ async function findOpenEditorProjectDirs(folder: vscode.WorkspaceFolder): Promis
 		if (!isInside(folderPath, documentPath)) {
 			continue;
 		}
-		const projectDir = await ascendForProjectFile(folderPath, path.dirname(documentPath));
+		const projectDir = await ascendForProjectFile(folderPath, path.dirname(documentPath), markers);
 		if (projectDir) {
 			dirs.add(projectDir);
 		}
@@ -237,11 +246,21 @@ async function findOpenEditorProjectDirs(folder: vscode.WorkspaceFolder): Promis
 /**
  * Walks `start` upward (inclusive) until a Quarto project marker is found or the workspace
  * folder boundary is reached. Returns the deepest directory containing a marker.
+ * `markers` holds the answer for each directory the pass already probed.
  */
-async function ascendForProjectFile(folderPath: string, start: string): Promise<string | undefined> {
+async function ascendForProjectFile(
+	folderPath: string,
+	start: string,
+	markers: Map<string, boolean>,
+): Promise<string | undefined> {
 	let current = start;
 	while (isInside(folderPath, current)) {
-		if (await directoryHasProjectMarker(current)) {
+		let hasMarker = markers.get(current);
+		if (hasMarker === undefined) {
+			hasMarker = await directoryHasProjectMarker(current);
+			markers.set(current, hasMarker);
+		}
+		if (hasMarker) {
 			return current;
 		}
 		const parent = path.dirname(current);

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -67,15 +67,33 @@ export function buildExcludeGlob(scope: vscode.Uri): string | undefined {
 	for (const section of ["files", "search"]) {
 		const excludes = vscode.workspace.getConfiguration(section, scope).get<Record<string, unknown>>("exclude");
 		for (const [pattern, enabled] of Object.entries(excludes ?? {})) {
-			if (enabled === true) {
-				patterns.add(pattern);
+			if (enabled !== true) {
+				continue;
 			}
+			// A comma outside a brace group would split the pattern in two, and each
+			// half would exclude more than the pattern names.
+			if (hasBareComma(pattern)) {
+				logMessage(`Skipping the exclude pattern ${pattern}: a comma outside a brace group.`, "warn");
+				continue;
+			}
+			patterns.add(pattern);
 		}
 	}
 	if (patterns.size === 0) {
 		return undefined;
 	}
 	return `{${[...patterns].join(",")}}`;
+}
+
+/** True when `pattern` holds a comma that no brace group encloses. */
+function hasBareComma(pattern: string): boolean {
+	let depth = 0;
+	for (const character of pattern) {
+		if (character === "{") depth += 1;
+		else if (character === "}") depth -= 1;
+		else if (character === "," && depth <= 0) return true;
+	}
+	return false;
 }
 
 /**

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -46,6 +46,13 @@ export const EXTENSION_MANIFEST_DIRECT_GLOB = `*/${EXTENSIONS_DIR}/**/_extension
 export const QUARTO_PROJECT_FILENAMES = ["_quarto.yml", "_quarto.yaml"] as const;
 
 /**
+ * Upper bound on the matches one scan returns.
+ * A workspace folder that holds more project markers than this is far outside the
+ * shape the tree view serves, so the cap stops a runaway walk instead of the scan.
+ */
+export const MAX_SCAN_RESULTS = 5000;
+
+/**
  * A discovered Quarto project root.
  */
 export interface QuartoProjectRoot {
@@ -77,9 +84,15 @@ export interface QuartoProjectRoot {
  *  - else, all detected sub-roots are returned;
  *  - if nothing is detected, the folder root is returned as a fallback so the tree view
  *    keeps its empty-state messaging.
+ *
+ * `token` cancels the file scans. Without it a superseded scan keeps its `ripgrep`
+ * process alive, and repeated triggers collect processes until they exhaust the CPU.
+ * A cancelled scan returns whatever it had, so the caller must discard the result when
+ * its token was cancelled.
  */
 export async function discoverQuartoProjectRoots(
 	workspaceFolders: readonly vscode.WorkspaceFolder[],
+	token?: vscode.CancellationToken,
 ): Promise<QuartoProjectRoot[]> {
 	if (workspaceFolders.length === 0) {
 		return [];
@@ -110,7 +123,7 @@ export async function discoverQuartoProjectRoots(
 		const discovered =
 			setting === "openEditors"
 				? await findOpenEditorProjectDirs(folder)
-				: await findSubFolderProjectDirs(folder, setting === true);
+				: await findSubFolderProjectDirs(folder, setting === true, token);
 
 		const candidates = new Set<string>();
 		for (const dir of discovered) {
@@ -144,7 +157,11 @@ function buildRoot(folder: vscode.WorkspaceFolder, fsPath: string): QuartoProjec
 	return { fsPath, workspaceFolder: folder, label: `${folder.name}/${toRelativePosixPath(folder.uri.fsPath, fsPath)}` };
 }
 
-async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder, recursive: boolean): Promise<string[]> {
+async function findSubFolderProjectDirs(
+	folder: vscode.WorkspaceFolder,
+	recursive: boolean,
+	token?: vscode.CancellationToken,
+): Promise<string[]> {
 	const folderPath = folder.uri.fsPath;
 	const quartoGlob = recursive ? QUARTO_PROJECT_GLOB : QUARTO_PROJECT_DIRECT_GLOB;
 	const manifestGlob = recursive ? EXTENSION_MANIFEST_GLOB : EXTENSION_MANIFEST_DIRECT_GLOB;
@@ -152,13 +169,20 @@ async function findSubFolderProjectDirs(folder: vscode.WorkspaceFolder, recursiv
 		// In direct-only mode the workspace root cannot be matched by the depth-1 glob,
 		// so probe it explicitly: the smart-merge in `discoverQuartoProjectRoots` collapses
 		// to the workspace folder when it is among the candidates.
-		// `null` exclude lets VSCode honour the user's `files.exclude` and `search.exclude`,
-		// matching how the Git extension scopes its repository scans.
+		// An `undefined` exclude applies the user's `files.exclude` and `search.exclude`,
+		// which keep the walk out of `node_modules`, `.git` and build output. A `null`
+		// exclude does the opposite: it turns every exclude off.
 		const [hasRootMarker, quartoUris, manifestUris] = await Promise.all([
 			recursive ? Promise.resolve(false) : directoryHasProjectMarker(folderPath),
-			vscode.workspace.findFiles(new vscode.RelativePattern(folder, quartoGlob), null),
-			vscode.workspace.findFiles(new vscode.RelativePattern(folder, manifestGlob), null),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, quartoGlob), undefined, MAX_SCAN_RESULTS, token),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, manifestGlob), undefined, MAX_SCAN_RESULTS, token),
 		]);
+		if (quartoUris.length >= MAX_SCAN_RESULTS || manifestUris.length >= MAX_SCAN_RESULTS) {
+			logMessage(
+				`Scan of ${folderPath} reached the ${MAX_SCAN_RESULTS} match limit; some projects are missing.`,
+				"warn",
+			);
+		}
 		const dirs: string[] = [];
 		if (hasRootMarker) dirs.push(folderPath);
 		for (const uri of quartoUris) {

--- a/src/utils/quartoProjectDiscovery.ts
+++ b/src/utils/quartoProjectDiscovery.ts
@@ -53,6 +53,32 @@ export const QUARTO_PROJECT_FILENAMES = ["_quarto.yml", "_quarto.yaml"] as const
 export const MAX_SCAN_RESULTS = 5000;
 
 /**
+ * Builds the exclude pattern for a file scan from the exclude settings of the editor.
+ *
+ * `findFiles` applies no exclude at all for a `null` argument, and applies `files.exclude`
+ * alone for an `undefined` one. Neither holds `node_modules` or build output, which live
+ * in `search.exclude`, so the pattern joins the two settings.
+ *
+ * @param scope - The resource the settings are read for.
+ * @returns A brace pattern of the enabled excludes, or `undefined` when there are none.
+ */
+export function buildExcludeGlob(scope: vscode.Uri): string | undefined {
+	const patterns = new Set<string>();
+	for (const section of ["files", "search"]) {
+		const excludes = vscode.workspace.getConfiguration(section, scope).get<Record<string, unknown>>("exclude");
+		for (const [pattern, enabled] of Object.entries(excludes ?? {})) {
+			if (enabled === true) {
+				patterns.add(pattern);
+			}
+		}
+	}
+	if (patterns.size === 0) {
+		return undefined;
+	}
+	return `{${[...patterns].join(",")}}`;
+}
+
+/**
  * A discovered Quarto project root.
  */
 export interface QuartoProjectRoot {
@@ -169,13 +195,11 @@ async function findSubFolderProjectDirs(
 		// In direct-only mode the workspace root cannot be matched by the depth-1 glob,
 		// so probe it explicitly: the smart-merge in `discoverQuartoProjectRoots` collapses
 		// to the workspace folder when it is among the candidates.
-		// An `undefined` exclude applies the user's `files.exclude` and `search.exclude`,
-		// which keep the walk out of `node_modules`, `.git` and build output. A `null`
-		// exclude does the opposite: it turns every exclude off.
+		const exclude = buildExcludeGlob(folder.uri);
 		const [hasRootMarker, quartoUris, manifestUris] = await Promise.all([
 			recursive ? Promise.resolve(false) : directoryHasProjectMarker(folderPath),
-			vscode.workspace.findFiles(new vscode.RelativePattern(folder, quartoGlob), undefined, MAX_SCAN_RESULTS, token),
-			vscode.workspace.findFiles(new vscode.RelativePattern(folder, manifestGlob), undefined, MAX_SCAN_RESULTS, token),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, quartoGlob), exclude, MAX_SCAN_RESULTS, token),
+			vscode.workspace.findFiles(new vscode.RelativePattern(folder, manifestGlob), exclude, MAX_SCAN_RESULTS, token),
 		]);
 		if (quartoUris.length >= MAX_SCAN_RESULTS || manifestUris.length >= MAX_SCAN_RESULTS) {
 			logMessage(

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
-import { discoverQuartoProjectRoots, type QuartoProjectRoot } from "./quartoProjectDiscovery";
+import type { QuartoProjectRoot } from "./quartoProjectDiscovery";
+import { ensureProjectRoots } from "./projectRootsRegistry";
 
 /**
  * Quick pick item used when prompting the user to choose between detected Quarto project roots.
@@ -11,9 +12,10 @@ interface ProjectRootQuickPickItem extends vscode.QuickPickItem {
 /**
  * Resolves the Quarto project root the user wants to act on.
  *
- * The candidate list comes from {@link discoverQuartoProjectRoots}, so the returned path is
+ * The candidate list comes from {@link ensureProjectRoots}, so the returned path is
  * either a workspace folder root or a detected sub-folder containing `_quarto.{yml,yaml}`,
- * depending on the `quartoWizard.autoProjectDetection` setting.
+ * depending on the `quartoWizard.autoProjectDetection` setting. The registry keeps the
+ * snapshot current, so a command does not start a scan of its own.
  *
  * @returns The selected project root path, or `undefined` if no workspace folder is open or the
  *          user dismissed the picker.
@@ -24,7 +26,7 @@ export async function selectWorkspaceFolder(): Promise<string | undefined> {
 		return undefined;
 	}
 
-	const roots = await discoverQuartoProjectRoots(workspaceFolders);
+	const roots = await ensureProjectRoots();
 	if (roots.length === 0) {
 		return undefined;
 	}


### PR DESCRIPTION
Project root discovery leaked search processes. In a large workspace folder the processes never stopped, and they collected until they used all of the CPU.

Three faults produced the leak, and each one is fixed here.

- The scans passed `null` as the exclude argument, which turns every exclude off, so the walk read `node_modules`, `.git` and build output. The scans now pass a pattern built from the enabled keys of `files.exclude` and `search.exclude`. An `undefined` exclude applies `files.exclude` alone, which holds neither `node_modules` nor build output, so it is not enough.
- The scans carried no cancellation token, so a superseded scan stayed alive. `projectRootsRegistry` now owns the token. It cancels the discovery a newer trigger supersedes, and a caller that waits for the roots follows the discovery that replaced the one it joined.
- The document open and close triggers ran in every mode. They now run only when `quartoWizard.autoProjectDetection` is set to `openEditors`, which is the only mode that reads the open documents.

The tree view and `selectWorkspaceFolder` read the registry instead of starting scans of their own, and each scan stops at a match limit. The metadata files scan applies the same exclude pattern and the same limit.