### PR TITLE
refactor: share one fenced block scan

### DIFF
--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -5,6 +5,7 @@ import {
 	getYamlIndentLevel,
 	getExistingKeysAtPath,
 	getCodeBlockRanges,
+	findFencedBlocks,
 	getInlineCodeSpanRanges,
 	getYamlFrontMatterRange,
 	isInCodeBlockRange,
@@ -595,6 +596,80 @@ suite("YAML Position Utils Test Suite", () => {
 			const ranges = getCodeBlockRanges(text);
 			assert.strictEqual(ranges.length, 1);
 			assert.strictEqual(text.slice(ranges[0].start, ranges[0].end), "> code");
+		});
+	});
+
+	suite("findFencedBlocks", () => {
+		test("should report the indent, the fence run and the info string of a plain fence", () => {
+			const text = "before\n```{r}\nx <- 1\n```\nafter";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].indent, 0);
+			assert.strictEqual(found[0].fence, "```");
+			assert.strictEqual(found[0].info, "{r}");
+			assert.strictEqual(found[0].quoteDepth, 0);
+			assert.strictEqual(found[0].fenceLine, 1);
+			assert.strictEqual(text.slice(found[0].fenceStart, found[0].start), "```{r}\n");
+			assert.strictEqual(text.slice(found[0].start, found[0].end), "x <- 1\n```");
+		});
+
+		test("should report the whole run of a tilde fence", () => {
+			// The run decides which lines close the block, so a reader that keeps it
+			// does not have to match the fence a second time.
+			const text = "~~~~{=typst}\n#x\n~~~~\n";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].fence, "~~~~");
+			assert.strictEqual(found[0].info, "{=typst}");
+			assert.strictEqual(found[0].fenceLine, 0);
+			assert.strictEqual(found[0].fenceStart, 0);
+		});
+
+		test("should report the indent of a fence inside a list item", () => {
+			const text = "1. Step\n\n   ```python\n   x = 1\n   ```\n";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].indent, 3);
+			assert.strictEqual(found[0].info, "python");
+			assert.strictEqual(found[0].fenceLine, 2);
+		});
+
+		test("should report the indent of a tab-indented fence in columns", () => {
+			// A tab advances to the next multiple of four, so the fence owns four
+			// columns and not one character.
+			const text = "1. Step one\n\n\t```{r}\n\tx = 1\n\t```\n";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].indent, 4);
+		});
+
+		test("should report how many blockquote markers the fence line carries", () => {
+			// A reader that de-indents the body needs the marker count as well as the
+			// indent, because both are structure rather than content.
+			const text = "> > ~~~python\n> > x = 1\n> > ~~~\n";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].quoteDepth, 2);
+			assert.strictEqual(found[0].indent, 0);
+			assert.strictEqual(found[0].info, "python");
+		});
+
+		test("should report the fence line of an unclosed block that ends the text", () => {
+			const text = "before\n```typst";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].fenceStart, text.indexOf("```typst"));
+			assert.strictEqual(found[0].fenceLine, 1);
+			assert.strictEqual(found[0].start, text.length);
+			assert.strictEqual(found[0].end, text.length);
+		});
+
+		test("should give getCodeBlockRanges the same offsets it reports itself", () => {
+			const text = "```\na\n```\nbetween\n\n> ```{r}\n> b\n> ```\n";
+			assert.deepStrictEqual(
+				getCodeBlockRanges(text),
+				findFencedBlocks(text).map((block) => ({ start: block.start, end: block.end })),
+			);
 		});
 	});
 

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -667,8 +667,8 @@ suite("YAML Position Utils Test Suite", () => {
 		test("should give getCodeBlockRanges the same offsets it reports itself", () => {
 			const text = "```\na\n```\nbetween\n\n> ```{r}\n> b\n> ```\n";
 			assert.deepStrictEqual(
-				getCodeBlockRanges(text),
-				findFencedBlocks(text).map((block) => ({ start: block.start, end: block.end })),
+				getCodeBlockRanges(text).map((range) => [range.start, range.end]),
+				findFencedBlocks(text).map((block) => [block.start, block.end]),
 			);
 		});
 	});

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -1,7 +1,6 @@
 import {
-	getCodeBlockRanges,
+	findFencedBlocks,
 	getYamlFrontMatterRange,
-	parseOpeningFence,
 	closingFenceRegExp,
 	stripBlockquoteMarkers,
 	stripCarriageReturn,
@@ -48,19 +47,6 @@ export interface TypstBlock {
 	fenceLine: number;
 	/** Indent of the opening fence, measured after any blockquote markers. */
 	indent: number;
-}
-
-/**
- * The opening fence line that precedes a code block body.
- *
- * `getCodeBlockRanges` starts each range after the opening fence line, so the
- * info string has to be recovered by walking back. When the opening fence is
- * the last line and the document has no trailing newline, the range is empty
- * and starts at the end of the text, which is why the newline test comes first.
- */
-function fenceLineRange(text: string, bodyStart: number): { start: number; end: number } {
-	const end = bodyStart > 0 && text[bodyStart - 1] === "\n" ? bodyStart - 1 : bodyStart;
-	return { start: text.lastIndexOf("\n", end - 1) + 1, end };
 }
 
 /** The kind an info string declares, or undefined when it is not Typst. */
@@ -224,14 +210,14 @@ export function hasLateOptionLine(block: TypstBlock): boolean {
 /**
  * Every Typst block in a document, in document order.
  *
- * Block scanning reuses `getCodeBlockRanges`, which already handles CRLF, an
- * indented fence, an unclosed block, and the CommonMark rule that a backtick
- * info string carries no bare backtick. It also means a fence nested inside a
- * longer fence, as in a Markdown demonstration block, is part of that outer
- * block and is never reported here.
+ * A filter over `findFencedBlocks`, which already handles CRLF, an indented
+ * fence, a fence inside a blockquote, an unclosed block, and the CommonMark rule
+ * that a backtick info string carries no bare backtick. It also means a fence
+ * nested inside a longer fence, as in a Markdown demonstration block, is part of
+ * that outer block and is never reported here.
  */
 export function findTypstBlocks(text: string): TypstBlock[] {
-	// Scan below the front matter rather than dropping its ranges afterwards. A
+	// Scan below the front matter rather than dropping its blocks afterwards. A
 	// block scalar can hold a line that looks like a fence, and that opens a
 	// block which only closes on a bare fence line, so it swallows the opening
 	// fence of the first real block and takes it out of the results entirely.
@@ -239,39 +225,23 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 	const from = frontMatter?.end ?? 0;
 	const source = from === 0 ? text : text.slice(from);
 
-	const blocks: TypstBlock[] = [];
-	// The ranges come back sorted, so the line number of each fence continues
-	// from the last one. Counting from the start of the document for every block
-	// would walk the whole prefix again each time, and a page of examples can
-	// carry ninety fences.
-	let counted = 0;
-	let line = 0;
+	// The scan reports a line number against the slice, so the lines above the
+	// slice are counted once here rather than per block.
+	let firstLine = 0;
 	for (let index = 0; index < from; index++) {
 		if (text[index] === "\n") {
-			line++;
+			firstLine++;
 		}
 	}
 
-	for (const range of getCodeBlockRanges(source)) {
-		const fence = fenceLineRange(source, range.start);
-		const fenceLineText = stripBlockquoteMarkers(stripCarriageReturn(source.slice(fence.start, fence.end)));
-		const opening = parseOpeningFence(fenceLineText.content);
-		if (opening === undefined) {
-			continue;
-		}
-
-		const kind = classifyInfoString(opening.info);
+	const blocks: TypstBlock[] = [];
+	for (const found of findFencedBlocks(source)) {
+		const kind = classifyInfoString(found.info);
 		if (kind === undefined) {
 			continue;
 		}
 
-		for (; counted < fence.start; counted++) {
-			if (source[counted] === "\n") {
-				line++;
-			}
-		}
-
-		const body = blockBody(source, range.start, range.end, opening.fence, opening.indent, fenceLineText.depth);
+		const body = blockBody(source, found.start, found.end, found.fence, found.indent, found.quoteDepth);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
 		// ordinary Typst comment, so the body passes through untouched.
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };
@@ -282,11 +252,11 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			code: parsed.code,
 			options: parsed.options,
 			// Offsets are reported against the document, not against the slice.
-			bodyStart: range.start + from,
-			bodyEnd: range.end + from,
-			fenceStart: fence.start + from,
-			fenceLine: line,
-			indent: opening.indent,
+			bodyStart: found.start + from,
+			bodyEnd: found.end + from,
+			fenceStart: found.fenceStart + from,
+			fenceLine: found.fenceLine + firstLine,
+			indent: found.indent,
 		});
 	}
 

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -5,6 +5,7 @@ import {
 	stripBlockquoteMarkers,
 	stripCarriageReturn,
 	removeIndentColumns,
+	type FencedBlock,
 } from "../yamlPosition";
 
 /**
@@ -71,29 +72,22 @@ function classifyInfoString(info: string): TypstBlockKind | undefined {
  * Typst is whitespace sensitive and knows nothing about Markdown, so neither an
  * indent nor a quote marker may survive into the compiled source.
  */
-function blockBody(
-	text: string,
-	bodyStart: number,
-	bodyEnd: number,
-	fence: string,
-	indent: number,
-	quoteDepth: number,
-): string {
+function blockBody(text: string, block: FencedBlock): string {
 	// Chosen once. How deep the block sits is a property of the fence, not of
 	// each line, so testing it per line says the same thing many times and
 	// invites the two uses below to drift apart.
 	//
 	// At most the depth of the fence is removed. A marker beyond that is content:
 	// one quote deep, the line `> > #x` reaches Typst as the text `> #x`.
-	const unquote =
-		quoteDepth > 0 ? (line: string) => stripBlockquoteMarkers(line, quoteDepth).content : (line: string) => line;
+	const depth = block.quoteDepth;
+	const unquote = depth > 0 ? (line: string) => stripBlockquoteMarkers(line, depth).content : (line: string) => line;
 
 	// Cut at the start of the closing fence line rather than dropping that line
 	// after a split, which would take the newline of the line above with it and
 	// glue the last body line to whatever follows it.
-	const slice = text.slice(bodyStart, bodyEnd);
+	const slice = text.slice(block.start, block.end);
 	const lastNewline = slice.lastIndexOf("\n");
-	const closing = closingFenceRegExp(fence);
+	const closing = closingFenceRegExp(block.fence);
 	const lastLine = stripCarriageReturn(slice.slice(lastNewline + 1));
 	const body = closing.test(unquote(lastLine)) ? slice.slice(0, lastNewline + 1) : slice;
 
@@ -102,7 +96,7 @@ function blockBody(
 	// ending on a CRLF document, and is left alone.
 	return body
 		.split("\n")
-		.map((line) => removeIndentColumns(unquote(line), indent))
+		.map((line) => removeIndentColumns(unquote(line), block.indent))
 		.join("\n");
 }
 
@@ -241,7 +235,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			continue;
 		}
 
-		const body = blockBody(source, found.start, found.end, found.fence, found.indent, found.quoteDepth);
+		const body = blockBody(source, found);
 		// Only a cell carries options. For the other two kinds a `//|` line is an
 		// ordinary Typst comment, so the body passes through untouched.
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -214,7 +214,7 @@ export function stripBlockquoteMarkers(line: string, limit = Number.POSITIVE_INF
 }
 
 /** An opening fence, as read from one line. */
-export interface OpeningFence {
+interface OpeningFence {
 	/** The indent of the fence, measured after any blockquote markers. */
 	indent: number;
 	/** The run of the fence, which a closing fence must match or exceed. */
@@ -226,16 +226,12 @@ export interface OpeningFence {
 /**
  * Read an opening fence from a line, or report that the line is not one.
  *
- * Exported so that a reader which derives the info string of a block, such as
- * the Typst block scanner, matches the fence exactly as this module does. Two
- * copies of the rule drift apart in silence.
- *
  * The indent limit is not applied here, because it depends on the container the
  * line sits in, which only a reader walking the whole document knows.
  *
  * @param content - One line, with its blockquote markers already removed.
  */
-export function parseOpeningFence(content: string): OpeningFence | undefined {
+function parseOpeningFence(content: string): OpeningFence | undefined {
 	const found = OPENING_FENCE.exec(content);
 	if (found === null) {
 		return undefined;
@@ -263,26 +259,54 @@ export function closingFenceRegExp(fence: string): RegExp {
 }
 
 /**
- * Find all fenced code block body regions in the document text.
+ * One fenced code block, with everything the scan read on the way past it.
+ *
+ * The body range is the `TextRange` the offset readers consume, and the rest is
+ * what a reader would otherwise have to recover by matching the fence line a
+ * second time.
+ */
+export interface FencedBlock extends TextRange {
+	/** The indent of the opening fence, in columns, after any blockquote markers. */
+	indent: number;
+	/** The run of the opening fence, which a closing fence must match or exceed. */
+	fence: string;
+	/** The info string that follows the run, untrimmed. */
+	info: string;
+	/** How many blockquote markers the opening fence line carries. */
+	quoteDepth: number;
+	/** Offset of the first character of the opening fence line. */
+	fenceStart: number;
+	/** Zero-based line number of the opening fence. */
+	fenceLine: number;
+}
+
+/**
+ * Find all fenced code blocks in the document text.
  *
  * Recognises both backtick (`` ``` ``) and tilde (`~~~`) fences, with
  * any info string (including executable cells like `{r}`, `{python}`).
  *
- * Each range starts _after_ the opening fence line (so the fence header
+ * Each body range starts _after_ the opening fence line (so the fence header
  * with its `{r}` or `{python}` attributes remains outside the range and
  * is still eligible for attribute completion/hover) and extends through
  * the end of the closing fence line (or end of text for unclosed blocks).
  *
+ * The indent, the fence run, the info string and the blockquote depth are
+ * reported because the scan reads all four to decide where the block ends. A
+ * reader that needs them and is given only offsets has to match the fence line
+ * again, and a second copy of the fence rules drifts apart in silence.
+ *
  * @param text - The full document text.
- * @returns An array of ranges sorted by start offset.
+ * @returns An array of blocks sorted by body start offset.
  */
-export function getCodeBlockRanges(text: string): TextRange[] {
-	const ranges: TextRange[] = [];
+export function findFencedBlocks(text: string): FencedBlock[] {
+	const blocks: FencedBlock[] = [];
 	const lines = text.split("\n");
 	let offset = 0;
-	let inBlock = false;
-	let blockStart = 0;
-	let blockDepth = 0;
+	// The block whose closing fence the scan is looking for. At most one is open
+	// at a time, because a fence inside a block is content, so each is pushed in
+	// the order it opened.
+	let open: FencedBlock | undefined;
 	let closingFenceRe: RegExp | undefined;
 	// The content column of the innermost open container, as far as one scan can
 	// tell. A fence is measured against this and not against the document,
@@ -311,21 +335,22 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 
 		const { content, depth } = stripBlockquoteMarkers(line);
 
-		if (inBlock) {
-			if (depth > blockDepth) {
+		if (open) {
+			if (depth > open.quoteDepth) {
 				// A line quoted more deeply than the block is content. Inside a fenced
 				// block the container parsing stops, so the extra marker is text the
 				// author wrote, and testing the stripped line for a closing fence
 				// would close the block on its own body.
 				continue;
 			}
-			if (depth === blockDepth) {
+			if (depth === open.quoteDepth) {
 				// Check for closing fence: same character, at least as many
 				// repetitions, optionally followed by whitespace, at the start of the
 				// line.
 				if (closingFenceRe?.test(content)) {
-					ranges.push({ start: blockStart, end: lineEnd });
-					inBlock = false;
+					open.end = lineEnd;
+					blocks.push(open);
+					open = undefined;
 				}
 				continue;
 			}
@@ -334,8 +359,9 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 			// of a code block. The line itself is not part of the block, so it falls
 			// through and can open the next one. The block ends at the end of the
 			// line above, which is one character back from the start of this one.
-			ranges.push({ start: blockStart, end: Math.max(blockStart, lineStart - 1) });
-			inBlock = false;
+			open.end = Math.max(open.start, lineStart - 1);
+			blocks.push(open);
+			open = undefined;
 		}
 
 		const contentStart = firstNonWhitespace(content);
@@ -362,22 +388,45 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 
 		const opening = parseOpeningFence(content);
 		if (opening && opening.indent <= containerIndent + MAX_FENCE_INDENT) {
-			inBlock = true;
-			blockDepth = depth;
-			// Start the range after the opening fence line so that
-			// attributes in the header (e.g. {r}, {python}) stay outside.
-			blockStart = offset;
+			open = {
+				indent: opening.indent,
+				fence: opening.fence,
+				info: opening.info,
+				quoteDepth: depth,
+				fenceStart: lineStart,
+				fenceLine: i,
+				// Start the range after the opening fence line so that
+				// attributes in the header (e.g. {r}, {python}) stay outside.
+				start: offset,
+				// Replaced when the block closes, and left here for the unclosed
+				// block that ends the text with nothing in it.
+				end: offset,
+			};
 			// Compile the closing fence regex once per block.
 			closingFenceRe = closingFenceRegExp(opening.fence);
 		}
 	}
 
 	// Unclosed block extends to end of text.
-	if (inBlock) {
-		ranges.push({ start: blockStart, end: text.length });
+	if (open) {
+		open.end = text.length;
+		blocks.push(open);
 	}
 
-	return ranges;
+	return blocks;
+}
+
+/**
+ * Find all fenced code block body regions in the document text.
+ *
+ * A projection of `findFencedBlocks` for the readers that need only the
+ * offsets, which is every reader that skips over code rather than reading it.
+ *
+ * @param text - The full document text.
+ * @returns An array of ranges sorted by start offset.
+ */
+export function getCodeBlockRanges(text: string): TextRange[] {
+	return findFencedBlocks(text).map((block) => ({ start: block.start, end: block.end }));
 }
 
 /**

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -419,14 +419,16 @@ export function findFencedBlocks(text: string): FencedBlock[] {
 /**
  * Find all fenced code block body regions in the document text.
  *
- * A projection of `findFencedBlocks` for the readers that need only the
- * offsets, which is every reader that skips over code rather than reading it.
+ * A narrowing of `findFencedBlocks` for the readers that need only the offsets,
+ * which is every reader that skips over code rather than reading it. The blocks
+ * themselves are returned, because a `FencedBlock` is a `TextRange`, so nothing
+ * is copied on a path that runs on every keystroke. No reader writes to a range.
  *
  * @param text - The full document text.
  * @returns An array of ranges sorted by start offset.
  */
 export function getCodeBlockRanges(text: string): TextRange[] {
-	return findFencedBlocks(text).map((block) => ({ start: block.start, end: block.end }));
+	return findFencedBlocks(text);
 }
 
 /**


### PR DESCRIPTION
Several readers scan the same document text for fenced blocks.
`getCodeBlockRanges` read the indent, the fence run and the info string of every block in order to decide where that block ended, then returned offsets only.
The Typst block reader needed all three, so it walked back from each body start to the fence line and matched the fence a second time.

One scan now reports what it read.

- `findFencedBlocks` yields the indent, the fence run, the info string, the blockquote depth, the fence offset and the fence line of each block.
- `getCodeBlockRanges` narrows that to the offsets its own readers need, and copies nothing, because a fenced block is already a text range.
- `findTypstBlocks` is a filter over the result. Its second fence match, its `fenceLineRange` helper and its incremental line count are gone, and `parseOpeningFence` is no longer exported, because nothing outside the module reads a fence line any more.

Neither the offsets nor the classification change, so the existing suites pass unchanged.
New cases assert the reported indent, fence run, info string and blockquote depth for a plain fence, a tilde fence, a fence indented inside a list item, a tab-indented fence and a quoted fence.

This is deliberately the narrow slice.
A full shared token model, as in the upstream `quarto-core` package, is a much larger change and is not in scope.

One known defect of this scan is left exactly as it was.
A tab is measured from the quoted content rather than from the whole line, so a tab-indented fence inside a blockquote is charged four columns instead of the two it takes.
Correcting it is a behaviour change that threads a starting column through three shared signatures, so it does not belong in a refactor that changes no behaviour.
The gap stays recorded in the `containerIndent` comment.