### PR TITLE
perf: cache the document scan per document version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: Read a document again when it takes the name of an untitled document that closed. The new document was shown the Typst blocks of the one before it. (#407)
+
 ## 3.3.0 (2026-09-03)
 
 ### New Features

--- a/src/providers/elementAttributeCompletionProvider.ts
+++ b/src/providers/elementAttributeCompletionProvider.ts
@@ -296,7 +296,7 @@ export class ElementAttributeCompletionProvider implements vscode.CompletionItem
 				return null;
 			}
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
 			const parsed = parseAttributeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;
@@ -528,7 +528,7 @@ export class ElementAttributeHoverProvider implements vscode.HoverProvider {
 			const text = document.getText();
 			const offset = document.offsetAt(position);
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
 			const parsed = parseAttributeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;

--- a/src/providers/elementAttributeCompletionProvider.ts
+++ b/src/providers/elementAttributeCompletionProvider.ts
@@ -7,7 +7,7 @@ import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 import { parseAttributeAtPosition, type PandocElementType } from "../utils/elementAttributeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
-import { getCodeBlockRanges } from "../utils/yamlPosition";
+import { getDocumentCodeBlockRanges } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 
 /**
@@ -296,7 +296,7 @@ export class ElementAttributeCompletionProvider implements vscode.CompletionItem
 				return null;
 			}
 
-			const codeBlockRanges = getCodeBlockRanges(text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
 			const parsed = parseAttributeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;
@@ -528,7 +528,7 @@ export class ElementAttributeHoverProvider implements vscode.HoverProvider {
 			const text = document.getText();
 			const offset = document.offsetAt(position);
 
-			const codeBlockRanges = getCodeBlockRanges(text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
 			const parsed = parseAttributeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -18,6 +18,7 @@ import {
 	isInCodeBlockRange,
 	type TextRange,
 } from "../utils/yamlPosition";
+import { getDocumentCodeBlockRanges } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 import { debounce } from "../utils/debounce";
 
@@ -958,7 +959,7 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 
 		const version = ++this.validationVersion;
 		const text = document.getText();
-		const codeBlockRanges = getCodeBlockRanges(text);
+		const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
 		const blocks = extractBlocks(text, codeBlockRanges);
 		const diagnostics: vscode.Diagnostic[] = [];
 

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -268,8 +268,8 @@ interface BlockMatch {
  * contains quoted backticks that look like an inline code span.
  */
 function overlapsExclusionRanges(
-	fencedRanges: TextRange[],
-	inlineRanges: TextRange[],
+	fencedRanges: readonly TextRange[],
+	inlineRanges: readonly TextRange[],
 	matchStart: number,
 	matchEnd: number,
 ): boolean {
@@ -288,7 +288,7 @@ function overlapsExclusionRanges(
  * excluding matches that fall inside fenced code blocks, the YAML front
  * matter, or inline code spans.
  */
-export function extractBlocks(text: string, codeBlockRanges?: TextRange[]): BlockMatch[] {
+export function extractBlocks(text: string, codeBlockRanges?: readonly TextRange[]): BlockMatch[] {
 	const codeRanges = codeBlockRanges ?? getCodeBlockRanges(text);
 	const yamlRange = getYamlFrontMatterRange(text);
 	const fencedRanges = yamlRange ? [yamlRange, ...codeRanges] : codeRanges;
@@ -1050,7 +1050,7 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 		schemas: ElementAttributeSchemas,
 		document: vscode.TextDocument,
 		diagnostics: vscode.Diagnostic[],
-		codeBlockRanges: TextRange[],
+		codeBlockRanges: readonly TextRange[],
 		reportUnknown: boolean,
 	): void {
 		// Use the parser as a context filter: the offset just inside the closing `}`.
@@ -1151,7 +1151,7 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 		schemas: Map<string, ShortcodeSchema>,
 		document: vscode.TextDocument,
 		diagnostics: vscode.Diagnostic[],
-		codeBlockRanges: TextRange[],
+		codeBlockRanges: readonly TextRange[],
 	): void {
 		// Use the parser as a context filter.
 		const blockEndOffset = block.contentOffset + block.content.length;

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -959,7 +959,7 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 
 		const version = ++this.validationVersion;
 		const text = document.getText();
-		const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
+		const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
 		const blocks = extractBlocks(text, codeBlockRanges);
 		const diagnostics: vscode.Diagnostic[] = [];
 
@@ -1290,7 +1290,7 @@ export class InlineAttributeCodeActionProvider implements vscode.CodeActionProvi
 		}
 
 		const text = document.getText();
-		const blocks = extractBlocks(text);
+		const blocks = extractBlocks(text, getDocumentCodeBlockRanges(document, text));
 
 		for (const diagnostic of relevant) {
 			for (const block of blocks) {

--- a/src/providers/shortcodeCompletionProvider.ts
+++ b/src/providers/shortcodeCompletionProvider.ts
@@ -7,7 +7,7 @@ import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 import { parseShortcodeAtPosition } from "../utils/shortcodeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
-import { getCodeBlockRanges } from "../utils/yamlPosition";
+import { getDocumentCodeBlockRanges } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 
 /**
@@ -40,7 +40,7 @@ export class ShortcodeCompletionProvider implements vscode.CompletionItemProvide
 				return null;
 			}
 
-			const codeBlockRanges = getCodeBlockRanges(text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
 			const parsed = parseShortcodeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;
@@ -497,7 +497,7 @@ export class ShortcodeHoverProvider implements vscode.HoverProvider {
 			const text = document.getText();
 			const offset = document.offsetAt(position);
 
-			const codeBlockRanges = getCodeBlockRanges(text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
 			const parsed = parseShortcodeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;

--- a/src/providers/shortcodeCompletionProvider.ts
+++ b/src/providers/shortcodeCompletionProvider.ts
@@ -40,7 +40,7 @@ export class ShortcodeCompletionProvider implements vscode.CompletionItemProvide
 				return null;
 			}
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
 			const parsed = parseShortcodeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;
@@ -497,7 +497,7 @@ export class ShortcodeHoverProvider implements vscode.HoverProvider {
 			const text = document.getText();
 			const offset = document.offsetAt(position);
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, () => text);
+			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
 			const parsed = parseShortcodeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;

--- a/src/providers/typstPathLinks.ts
+++ b/src/providers/typstPathLinks.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { debounce } from "../utils/debounce";
+import { getDocumentTypstBlocks } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 import { isRelevantYaml } from "../utils/metadataFilesRegistry";
 import { findOwningProjectRoot } from "../utils/projectRootsRegistry";
@@ -195,7 +196,8 @@ export class TypstPathLinks implements vscode.DocumentLinkProvider, vscode.Dispo
 			return [];
 		}
 
-		const options = findTypstPathOptions(document.getText(), document.languageId);
+		const text = document.getText();
+		const options = findTypstPathOptions(text, document.languageId, () => getDocumentTypstBlocks(document, () => text));
 		if (options.length === 0) {
 			return [];
 		}

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as semver from "semver";
-import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { blockAtOffset, type TypstBlock } from "../../utils/typst/typstBlocks";
 import {
 	buildPlainSource,
 	buildRawSource,
@@ -11,6 +11,7 @@ import {
 import { TYPST_RENDER, documentBrandMode, type TypstBrandMode } from "../../utils/typst/typstOptions";
 import { buildTypstCommand, type TypstCommand } from "../../utils/typst/typstCli";
 import { EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
+import { getDocumentTypstBlocks } from "../../utils/documentScan";
 import { getInstalledExtensionsCached } from "../../utils/installedExtensionsCache";
 import { getYamlFrontMatterRange } from "../../utils/yamlPosition";
 import { findOwningProjectRoot } from "../../utils/projectRootsRegistry";
@@ -202,36 +203,16 @@ function frontMatterText(text: string): string {
 }
 
 /**
- * What a request would otherwise read again on every keystroke.
+ * What a request would otherwise read from disk on every keystroke.
  *
- * The two halves are keyed differently because they depend on different things.
- * The blocks are a function of the whole text, so the document version is the
- * whole key. The metadata chain reads the front matter and then the disk, so it
- * survives every edit that leaves the front matter alone, and a watcher is what
- * forgets it when the disk moves.
+ * The metadata chain reads the front matter and then the disk, so it survives
+ * every edit that leaves the front matter alone, and a watcher is what forgets
+ * it when the disk moves. The blocks of the document are keyed on the document
+ * version instead, so they are held by `getDocumentTypstBlocks` beside the scans
+ * of the other readers rather than here.
  */
 export class TypstContextCache {
-	private readonly blocks = new Map<string, { version: number; blocks: TypstBlock[] }>();
 	private readonly cells = new Map<string, { frontMatter: string; context: Promise<CellContext> }>();
-
-	/**
-	 * The blocks of one document version.
-	 *
-	 * The text is taken as a thunk, because a hit needs none of it. Every surface
-	 * asks on its hot path, and `getText()` copies the whole document, so passing
-	 * the text itself spent one copy of a large file per hover and per code lens
-	 * refresh to return a list that was already built.
-	 */
-	blocksOf(document: vscode.TextDocument, readText: () => string): TypstBlock[] {
-		const key = document.uri.toString();
-		const held = this.blocks.get(key);
-		if (held?.version === document.version) {
-			return held.blocks;
-		}
-		const blocks = findTypstBlocks(readText());
-		this.blocks.set(key, { version: document.version, blocks });
-		return blocks;
-	}
 
 	/** What one document's cells read from disk. */
 	cellContext(document: vscode.TextDocument, text: string): Promise<CellContext> {
@@ -256,9 +237,7 @@ export class TypstContextCache {
 
 	/** Forget one document, which a closed document no longer needs. */
 	forget(uri: vscode.Uri): void {
-		const key = uri.toString();
-		this.blocks.delete(key);
-		this.cells.delete(key);
+		this.cells.delete(uri.toString());
 	}
 
 	/**
@@ -272,11 +251,6 @@ export class TypstContextCache {
 	forgetFiles(): void {
 		this.cells.clear();
 	}
-
-	clear(): void {
-		this.blocks.clear();
-		this.cells.clear();
-	}
 }
 
 /**
@@ -288,8 +262,8 @@ export class TypstContextCache {
  * force, and a second set of directives above them would show an image the
  * render does not produce.
  *
- * @param cache - What a caller repeating the request remembers. A caller that
- *   asks once builds an empty one, which reads the document and the disk.
+ * @param cache - What a caller repeating the request remembers of the disk. A
+ *   caller that asks once builds an empty one, which reads every file again.
  * @param brandMode - The side of the brand to resolve a cell against. Named by
  *   the reader through the toggle command, and absent for every other caller.
  */
@@ -304,7 +278,7 @@ export async function buildCompileRequest(
 	// The whole list is kept, because a raw block compiles with the raw blocks
 	// above it and scanning the document a second time would say the same thing
 	// twice.
-	const blocks = cache.blocksOf(document, () => text);
+	const blocks = getDocumentTypstBlocks(document, () => text);
 	const block = blockAtOffset(blocks, document.offsetAt(position));
 	if (block === undefined) {
 		return { unavailable: NO_BLOCK_MESSAGE };

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -5,6 +5,7 @@ import { blockAtOffset, invalidatesPreview, type TypstBlock } from "../../utils/
 import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { debounce, type DebouncedFunction } from "../../utils/debounce";
+import { getDocumentTypstBlocks } from "../../utils/documentScan";
 import { generateHashKey } from "../../utils/hash";
 import { logMessage } from "../../utils/log";
 import { isQmdFile } from "../../utils/metadataFilesRegistry";
@@ -408,7 +409,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	 * however many surfaces ask.
 	 */
 	blocksOf(document: vscode.TextDocument): TypstBlock[] {
-		return this.contexts.blocksOf(document, () => document.getText());
+		return getDocumentTypstBlocks(document, () => document.getText());
 	}
 
 	/** Preview the block under a position, because the user asked for it. */
@@ -585,7 +586,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		this.uncancelled.dispose();
 		this.resultEmitter.dispose();
 		this.forgetImages();
-		this.contexts.clear();
+		this.contexts.forgetFiles();
 		this.result = undefined;
 		this.tracked = undefined;
 	}

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -401,13 +401,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		return this.tracked ?? this.result;
 	}
 
-	/**
-	 * The Typst blocks of a document, as the preview reads them.
-	 *
-	 * The surfaces need the same list the compile was built from, and the cache
-	 * is keyed on the document version, so asking here costs one scan per edit
-	 * however many surfaces ask.
-	 */
+	/** The Typst blocks of a document, which is the list a compile was built from. */
 	blocksOf(document: vscode.TextDocument): TypstBlock[] {
 		return getDocumentTypstBlocks(document, () => document.getText());
 	}

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -402,7 +402,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	}
 
 	/** The Typst blocks of a document, which is the list a compile was built from. */
-	blocksOf(document: vscode.TextDocument): TypstBlock[] {
+	blocksOf(document: vscode.TextDocument): readonly TypstBlock[] {
 		return getDocumentTypstBlocks(document, () => document.getText());
 	}
 

--- a/src/test/suite/documentScan.test.ts
+++ b/src/test/suite/documentScan.test.ts
@@ -35,6 +35,17 @@ suite("Document scan cache", () => {
 		assert.strictEqual(getDocumentCodeBlockRanges(one, TEXT), first);
 	});
 
+	test("Should read the text again for the document that took a reused name", () => {
+		// The key is the document and not its URI. An untitled name is handed out
+		// again once the document holding it closes, and the document taking it
+		// starts at version one with other text, so a URI and a version together
+		// name two documents. This is what a preview answered from the image of
+		// the document before it, and the whole suite passes without this case.
+		const first = getDocumentCodeBlockRanges(document("/untitled-1").document, TEXT);
+		const again = getDocumentCodeBlockRanges(document("/untitled-1").document, TEXT);
+		assert.notStrictEqual(again, first);
+	});
+
 	test("Should hold the Typst blocks beside the ranges of one version", () => {
 		// The two readers scan by different rules, so one entry holds both. A
 		// reader asking must not forget what the other one already built.

--- a/src/test/suite/documentScan.test.ts
+++ b/src/test/suite/documentScan.test.ts
@@ -1,0 +1,70 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocumentCodeBlockRanges, getDocumentTypstBlocks } from "../../utils/documentScan";
+
+/** One document, as the cache sees it: a URI and a version. */
+function document(uri: string, version: number): vscode.TextDocument {
+	return { uri: vscode.Uri.file(uri), version } as vscode.TextDocument;
+}
+
+const TEXT = "```typst\n#circle()\n```\n\n```python\n1\n```\n";
+
+suite("Document scan cache", () => {
+	test("Should return the same ranges again at the same document version", () => {
+		const held = document("/same-version.qmd", 1);
+		const first = getDocumentCodeBlockRanges(held, () => TEXT);
+		assert.strictEqual(
+			getDocumentCodeBlockRanges(held, () => TEXT),
+			first,
+		);
+		assert.strictEqual(first.length, 2);
+	});
+
+	test("Should read the text again when the document version moves", () => {
+		const first = getDocumentCodeBlockRanges(document("/moved-version.qmd", 1), () => TEXT);
+		const again = getDocumentCodeBlockRanges(document("/moved-version.qmd", 2), () => TEXT);
+		assert.notStrictEqual(again, first);
+	});
+
+	test("Should read the text again when another document asks", () => {
+		const first = getDocumentCodeBlockRanges(document("/one.qmd", 1), () => TEXT);
+		getDocumentCodeBlockRanges(document("/two.qmd", 1), () => TEXT);
+		assert.notStrictEqual(
+			getDocumentCodeBlockRanges(document("/one.qmd", 1), () => TEXT),
+			first,
+		);
+	});
+
+	test("Should read nothing on a hit", () => {
+		const held = document("/no-read.qmd", 1);
+		getDocumentCodeBlockRanges(held, () => TEXT);
+		getDocumentCodeBlockRanges(held, () => {
+			assert.fail("a hit read the document text");
+		});
+	});
+
+	test("Should hold the Typst blocks beside the ranges of one version", () => {
+		// The two readers scan by different rules, so one entry holds both. A
+		// reader asking must not forget what the other one already built.
+		const held = document("/both.qmd", 1);
+		const ranges = getDocumentCodeBlockRanges(held, () => TEXT);
+		const blocks = getDocumentTypstBlocks(held, () => TEXT);
+		assert.strictEqual(blocks.length, 1);
+		assert.strictEqual(
+			getDocumentCodeBlockRanges(held, () => TEXT),
+			ranges,
+		);
+		assert.strictEqual(
+			getDocumentTypstBlocks(held, () => TEXT),
+			blocks,
+		);
+	});
+
+	test("Should read the Typst blocks again when the document version moves", () => {
+		const first = getDocumentTypstBlocks(document("/moved-blocks.qmd", 1), () => TEXT);
+		assert.notStrictEqual(
+			getDocumentTypstBlocks(document("/moved-blocks.qmd", 2), () => TEXT),
+			first,
+		);
+	});
+});

--- a/src/test/suite/documentScan.test.ts
+++ b/src/test/suite/documentScan.test.ts
@@ -2,68 +2,76 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDocumentCodeBlockRanges, getDocumentTypstBlocks } from "../../utils/documentScan";
 
-/** One document, as the cache sees it: a URI and a version. */
-function document(uri: string, version: number): vscode.TextDocument {
-	return { uri: vscode.Uri.file(uri), version } as vscode.TextDocument;
+/** One document, as the cache sees it: an identity, a URI and a version. */
+function document(uri: string, version = 1): { document: vscode.TextDocument; edit: () => void } {
+	const held = { uri: vscode.Uri.file(uri), version };
+	return { document: held as vscode.TextDocument, edit: () => held.version++ };
 }
 
 const TEXT = "```typst\n#circle()\n```\n\n```python\n1\n```\n";
 
 suite("Document scan cache", () => {
 	test("Should return the same ranges again at the same document version", () => {
-		const held = document("/same-version.qmd", 1);
-		const first = getDocumentCodeBlockRanges(held, () => TEXT);
-		assert.strictEqual(
-			getDocumentCodeBlockRanges(held, () => TEXT),
-			first,
-		);
+		const { document: held } = document("/same-version.qmd");
+		const first = getDocumentCodeBlockRanges(held, TEXT);
+		assert.strictEqual(getDocumentCodeBlockRanges(held, TEXT), first);
 		assert.strictEqual(first.length, 2);
 	});
 
 	test("Should read the text again when the document version moves", () => {
-		const first = getDocumentCodeBlockRanges(document("/moved-version.qmd", 1), () => TEXT);
-		const again = getDocumentCodeBlockRanges(document("/moved-version.qmd", 2), () => TEXT);
-		assert.notStrictEqual(again, first);
+		const { document: held, edit } = document("/moved-version.qmd");
+		const first = getDocumentCodeBlockRanges(held, TEXT);
+		edit();
+		assert.notStrictEqual(getDocumentCodeBlockRanges(held, TEXT), first);
 	});
 
-	test("Should read the text again when another document asks", () => {
-		const first = getDocumentCodeBlockRanges(document("/one.qmd", 1), () => TEXT);
-		getDocumentCodeBlockRanges(document("/two.qmd", 1), () => TEXT);
-		assert.notStrictEqual(
-			getDocumentCodeBlockRanges(document("/one.qmd", 1), () => TEXT),
-			first,
-		);
+	test("Should keep what one document holds while another is read", () => {
+		// Two sweeps read every open document in turn, and two editors side by side
+		// alternate, so a single entry would be rebuilt on every other call.
+		const { document: one } = document("/one.qmd");
+		const { document: two } = document("/two.qmd");
+		const first = getDocumentCodeBlockRanges(one, TEXT);
+		getDocumentCodeBlockRanges(two, TEXT);
+		assert.strictEqual(getDocumentCodeBlockRanges(one, TEXT), first);
 	});
 
-	test("Should read nothing on a hit", () => {
-		const held = document("/no-read.qmd", 1);
-		getDocumentCodeBlockRanges(held, () => TEXT);
-		getDocumentCodeBlockRanges(held, () => {
-			assert.fail("a hit read the document text");
-		});
+	test("Should read the text again for a document reusing a name", () => {
+		// An untitled name is handed out again once the document holding it closes,
+		// and the document taking it starts at version one with other text.
+		const { document: closed } = document("/untitled-1");
+		const first = getDocumentCodeBlockRanges(closed, TEXT);
+		const { document: reopened } = document("/untitled-1");
+		assert.notStrictEqual(getDocumentCodeBlockRanges(reopened, TEXT), first);
 	});
 
 	test("Should hold the Typst blocks beside the ranges of one version", () => {
 		// The two readers scan by different rules, so one entry holds both. A
 		// reader asking must not forget what the other one already built.
-		const held = document("/both.qmd", 1);
-		const ranges = getDocumentCodeBlockRanges(held, () => TEXT);
+		const { document: held } = document("/both.qmd");
+		const ranges = getDocumentCodeBlockRanges(held, TEXT);
 		const blocks = getDocumentTypstBlocks(held, () => TEXT);
 		assert.strictEqual(blocks.length, 1);
-		assert.strictEqual(
-			getDocumentCodeBlockRanges(held, () => TEXT),
-			ranges,
-		);
+		assert.strictEqual(getDocumentCodeBlockRanges(held, TEXT), ranges);
 		assert.strictEqual(
 			getDocumentTypstBlocks(held, () => TEXT),
 			blocks,
 		);
 	});
 
+	test("Should read nothing on a Typst block hit", () => {
+		const { document: held } = document("/no-read.qmd");
+		getDocumentTypstBlocks(held, () => TEXT);
+		getDocumentTypstBlocks(held, () => {
+			assert.fail("a hit read the document text");
+		});
+	});
+
 	test("Should read the Typst blocks again when the document version moves", () => {
-		const first = getDocumentTypstBlocks(document("/moved-blocks.qmd", 1), () => TEXT);
+		const { document: held, edit } = document("/moved-blocks.qmd");
+		const first = getDocumentTypstBlocks(held, () => TEXT);
+		edit();
 		assert.notStrictEqual(
-			getDocumentTypstBlocks(document("/moved-blocks.qmd", 2), () => TEXT),
+			getDocumentTypstBlocks(held, () => TEXT),
 			first,
 		);
 	});

--- a/src/test/suite/documentScan.test.ts
+++ b/src/test/suite/documentScan.test.ts
@@ -35,15 +35,6 @@ suite("Document scan cache", () => {
 		assert.strictEqual(getDocumentCodeBlockRanges(one, TEXT), first);
 	});
 
-	test("Should read the text again for a document reusing a name", () => {
-		// An untitled name is handed out again once the document holding it closes,
-		// and the document taking it starts at version one with other text.
-		const { document: closed } = document("/untitled-1");
-		const first = getDocumentCodeBlockRanges(closed, TEXT);
-		const { document: reopened } = document("/untitled-1");
-		assert.notStrictEqual(getDocumentCodeBlockRanges(reopened, TEXT), first);
-	});
-
 	test("Should hold the Typst blocks beside the ranges of one version", () => {
 		// The two readers scan by different rules, so one entry holds both. A
 		// reader asking must not forget what the other one already built.

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -1,15 +1,18 @@
 import * as assert from "assert";
 import * as path from "node:path";
+import { findTypstBlocks } from "../../utils/typst/typstBlocks";
 import { findTypstPathOptions, resolveTypstPathOption, type TypstPathOption } from "../../utils/typst/typstPathOptions";
 
 /** Every occurrence as the text it covers, which is what a link is drawn over. */
 function covered(text: string, languageId = "quarto"): string[] {
-	return findTypstPathOptions(text, languageId).map((option) => text.slice(option.start, option.end));
+	return findTypstPathOptions(text, languageId, () => findTypstBlocks(text)).map((option) =>
+		text.slice(option.start, option.end),
+	);
 }
 
 /** The one occurrence a document holds, which most cases below have. */
 function only(text: string, languageId = "quarto"): TypstPathOption {
-	const found = findTypstPathOptions(text, languageId);
+	const found = findTypstPathOptions(text, languageId, () => findTypstBlocks(text));
 	assert.strictEqual(found.length, 1, `expected one occurrence, found ${found.length}`);
 	return found[0];
 }

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -797,31 +797,13 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.notStrictEqual(await moved, await first, "a front matter edit reads again");
 		});
 
-		test("Should read the document again when its version moves", async () => {
-			// The blocks are a function of the whole text, so the version is the whole
-			// key, which is the half of the cache the front matter does not decide.
+		test("Should read the disk again after a file changed", async () => {
+			// A file on disk moving is what the front matter cannot say, so the whole
+			// chain is read again rather than worked out entry by entry.
 			const cache = new TypstContextCache();
-			const first = cache.blocksOf(document(1), () => "```typst\n#circle()\n```\n");
-			assert.strictEqual(
-				cache.blocksOf(document(1), () => "```typst\n#circle()\n```\n"),
-				first,
-			);
-			assert.notStrictEqual(
-				cache.blocksOf(document(2), () => "```typst\n#square()\n```\n"),
-				first,
-			);
-		});
-
-		test("Should forget what a file changing can move, and keep the rest", async () => {
-			const cache = new TypstContextCache();
-			const blocks = cache.blocksOf(document(1), () => "```typst\n#circle()\n```\n");
 			const context = await cache.cellContext(document(1), `${FRONT_MATTER}Body\n`);
 
 			cache.forgetFiles();
-			assert.strictEqual(
-				cache.blocksOf(document(1), () => "```typst\n#circle()\n```\n"),
-				blocks,
-			);
 			assert.notStrictEqual(await cache.cellContext(document(1), `${FRONT_MATTER}Body\n`), context);
 		});
 	});

--- a/src/utils/documentScan.ts
+++ b/src/utils/documentScan.ts
@@ -1,0 +1,79 @@
+/**
+ * What the fence readers of one document version built, held once.
+ *
+ * Several readers answer the same keystroke, and each one scanned the whole
+ * document to do it: a completion, a hover and a diagnostic pass all ask what
+ * the fenced blocks of the document are, and the Typst surfaces ask again by
+ * their own rules. The scan is a function of the text alone, so the document
+ * version is the whole key.
+ *
+ * One entry is enough, because the document being typed in is the one every
+ * reader asks about. A second document asking forgets the first, which costs
+ * that document one scan and keeps the cache a single object.
+ *
+ * The entry holds the two scans side by side. They read the same text by
+ * different rules, so neither is derived from the other, and a reader asking
+ * for one must not forget what another reader already built.
+ *
+ * **The arrays are shared, so no reader may write to one.** `getCodeBlockRanges`
+ * narrows the blocks of `findFencedBlocks` rather than copying them, so the same
+ * objects reach the offset readers and the Typst reader. A reader that needs a
+ * list of its own builds one.
+ */
+
+import type * as vscode from "vscode";
+import { findTypstBlocks, type TypstBlock } from "./typst/typstBlocks";
+import { findFencedBlocks, type FencedBlock, type TextRange } from "./yamlPosition";
+
+/** The scans of one document version, each built when it is first asked for. */
+interface DocumentScan {
+	readonly key: string;
+	readonly version: number;
+	fenced?: FencedBlock[];
+	typst?: TypstBlock[];
+}
+
+let held: DocumentScan | undefined;
+
+/**
+ * The entry of one document version, empty when nothing has read it yet.
+ *
+ * @param document - The document being read.
+ */
+function scanOf(document: vscode.TextDocument): DocumentScan {
+	const key = document.uri.toString();
+	if (held?.key === key && held.version === document.version) {
+		return held;
+	}
+	held = { key, version: document.version };
+	return held;
+}
+
+/**
+ * The fenced code block bodies of a document.
+ *
+ * The text is taken as a thunk, because a hit needs none of it. `getText()`
+ * copies the whole document, and the readers here run on every keystroke.
+ *
+ * @param document - The document being read.
+ * @param readText - The full text of that document.
+ * @returns The ranges of `getCodeBlockRanges`, which the caller must not write to.
+ */
+export function getDocumentCodeBlockRanges(document: vscode.TextDocument, readText: () => string): TextRange[] {
+	const scan = scanOf(document);
+	scan.fenced ??= findFencedBlocks(readText());
+	return scan.fenced;
+}
+
+/**
+ * The Typst blocks of a document.
+ *
+ * @param document - The document being read.
+ * @param readText - The full text of that document.
+ * @returns The blocks of `findTypstBlocks`, which the caller must not write to.
+ */
+export function getDocumentTypstBlocks(document: vscode.TextDocument, readText: () => string): TypstBlock[] {
+	const scan = scanOf(document);
+	scan.typst ??= findTypstBlocks(readText());
+	return scan.typst;
+}

--- a/src/utils/documentScan.ts
+++ b/src/utils/documentScan.ts
@@ -1,24 +1,31 @@
 /**
- * What the fence readers of one document version built, held once.
+ * What the fence readers of one document version built, held once per document.
  *
  * Several readers answer the same keystroke, and each one scanned the whole
  * document to do it: a completion, a hover and a diagnostic pass all ask what
  * the fenced blocks of the document are, and the Typst surfaces ask again by
- * their own rules. The scan is a function of the text alone, so the document
+ * their own rules. A scan is a function of the text alone, so the document
  * version is the whole key.
  *
- * One entry is enough, because the document being typed in is the one every
- * reader asks about. A second document asking forgets the first, which costs
- * that document one scan and keeps the cache a single object.
+ * One entry per document and not one entry in all. Two sweeps read every open
+ * document in turn, and two editors side by side alternate, so a single entry
+ * would be evicted by the next document and rebuilt for the one before it.
  *
- * The entry holds the two scans side by side. They read the same text by
+ * The key is the document itself and not its URI. The editor holds one document
+ * object per open document, so identity says what a URI cannot: an untitled name
+ * is handed out again once the document holding it is closed, and the document
+ * taking that name starts at version one with different text. A weak key also
+ * releases the entry with the document, which matters because a block body is a
+ * slice of the text and a slice keeps the string it was cut from.
+ *
+ * Each entry holds the two scans side by side. They read the same text by
  * different rules, so neither is derived from the other, and a reader asking
  * for one must not forget what another reader already built.
  *
- * **The arrays are shared, so no reader may write to one.** `getCodeBlockRanges`
- * narrows the blocks of `findFencedBlocks` rather than copying them, so the same
- * objects reach the offset readers and the Typst reader. A reader that needs a
- * list of its own builds one.
+ * **The arrays are shared, so no reader may write to one.** `findFencedBlocks`
+ * is narrowed to `TextRange[]` rather than copied, so the same objects reach the
+ * offset readers and the Typst reader. A reader that needs a list of its own
+ * builds one.
  */
 
 import type * as vscode from "vscode";
@@ -27,13 +34,12 @@ import { findFencedBlocks, type FencedBlock, type TextRange } from "./yamlPositi
 
 /** The scans of one document version, each built when it is first asked for. */
 interface DocumentScan {
-	readonly key: string;
-	readonly version: number;
+	version: number;
 	fenced?: FencedBlock[];
 	typst?: TypstBlock[];
 }
 
-let held: DocumentScan | undefined;
+const held = new WeakMap<vscode.TextDocument, DocumentScan>();
 
 /**
  * The entry of one document version, empty when nothing has read it yet.
@@ -41,32 +47,34 @@ let held: DocumentScan | undefined;
  * @param document - The document being read.
  */
 function scanOf(document: vscode.TextDocument): DocumentScan {
-	const key = document.uri.toString();
-	if (held?.key === key && held.version === document.version) {
-		return held;
+	const entry = held.get(document);
+	if (entry?.version === document.version) {
+		return entry;
 	}
-	held = { key, version: document.version };
-	return held;
+	const fresh: DocumentScan = { version: document.version };
+	held.set(document, fresh);
+	return fresh;
 }
 
 /**
  * The fenced code block bodies of a document.
  *
- * The text is taken as a thunk, because a hit needs none of it. `getText()`
- * copies the whole document, and the readers here run on every keystroke.
- *
  * @param document - The document being read.
- * @param readText - The full text of that document.
+ * @param text - The full text of that document.
  * @returns The ranges of `getCodeBlockRanges`, which the caller must not write to.
  */
-export function getDocumentCodeBlockRanges(document: vscode.TextDocument, readText: () => string): TextRange[] {
+export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: string): TextRange[] {
 	const scan = scanOf(document);
-	scan.fenced ??= findFencedBlocks(readText());
+	scan.fenced ??= findFencedBlocks(text);
 	return scan.fenced;
 }
 
 /**
  * The Typst blocks of a document.
+ *
+ * The text is taken as a thunk here and not there, because a surface asking on
+ * its hot path holds a document and no text, and `getText()` copies the whole
+ * document to answer from a list that was already built.
  *
  * @param document - The document being read.
  * @param readText - The full text of that document.

--- a/src/utils/documentScan.ts
+++ b/src/utils/documentScan.ts
@@ -22,10 +22,9 @@
  * different rules, so neither is derived from the other, and a reader asking
  * for one must not forget what another reader already built.
  *
- * **The arrays are shared, so no reader may write to one.** `findFencedBlocks`
- * is narrowed to `TextRange[]` rather than copied, so the same objects reach the
- * offset readers and the Typst reader. A reader that needs a list of its own
- * builds one.
+ * The arrays are shared and are handed out `readonly`, because `findFencedBlocks`
+ * is narrowed rather than copied and the same objects reach the offset readers
+ * and the Typst reader. A reader that needs a list of its own builds one.
  */
 
 import type * as vscode from "vscode";
@@ -35,8 +34,8 @@ import { findFencedBlocks, type FencedBlock, type TextRange } from "./yamlPositi
 /** The scans of one document version, each built when it is first asked for. */
 interface DocumentScan {
 	version: number;
-	fenced?: FencedBlock[];
-	typst?: TypstBlock[];
+	fenced?: readonly FencedBlock[];
+	typst?: readonly TypstBlock[];
 }
 
 const held = new WeakMap<vscode.TextDocument, DocumentScan>();
@@ -61,9 +60,9 @@ function scanOf(document: vscode.TextDocument): DocumentScan {
  *
  * @param document - The document being read.
  * @param text - The full text of that document.
- * @returns The ranges of `getCodeBlockRanges`, which the caller must not write to.
+ * @returns The ranges of `getCodeBlockRanges`.
  */
-export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: string): TextRange[] {
+export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: string): readonly TextRange[] {
 	const scan = scanOf(document);
 	scan.fenced ??= findFencedBlocks(text);
 	return scan.fenced;
@@ -78,9 +77,9 @@ export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: 
  *
  * @param document - The document being read.
  * @param readText - The full text of that document.
- * @returns The blocks of `findTypstBlocks`, which the caller must not write to.
+ * @returns The blocks of `findTypstBlocks`.
  */
-export function getDocumentTypstBlocks(document: vscode.TextDocument, readText: () => string): TypstBlock[] {
+export function getDocumentTypstBlocks(document: vscode.TextDocument, readText: () => string): readonly TypstBlock[] {
 	const scan = scanOf(document);
 	scan.typst ??= findTypstBlocks(readText());
 	return scan.typst;

--- a/src/utils/elementAttributeParser.ts
+++ b/src/utils/elementAttributeParser.ts
@@ -72,7 +72,7 @@ export interface AttributeBounds {
 export function getAttributeBounds(
 	text: string,
 	offset: number,
-	codeBlockRanges?: TextRange[],
+	codeBlockRanges?: readonly TextRange[],
 ): AttributeBounds | null {
 	// Search backwards for `{` that is not inside a string
 	let openBrace = -1;
@@ -254,7 +254,7 @@ function findClosingBrace(text: string, openBrace: number): number {
 export function parseAttributeAtPosition(
 	text: string,
 	offset: number,
-	codeBlockRanges?: TextRange[],
+	codeBlockRanges?: readonly TextRange[],
 ): ElementAttributeParseResult | null {
 	const bounds = getAttributeBounds(text, offset, codeBlockRanges);
 	if (!bounds) {

--- a/src/utils/shortcodeParser.ts
+++ b/src/utils/shortcodeParser.ts
@@ -53,7 +53,7 @@ export interface ShortcodeBounds {
 export function getShortcodeBounds(
 	text: string,
 	offset: number,
-	codeBlockRanges?: TextRange[],
+	codeBlockRanges?: readonly TextRange[],
 ): ShortcodeBounds | null {
 	// Search backwards for {{< from the cursor position.
 	// We need to find the nearest {{< that is not already closed before the offset.
@@ -152,7 +152,7 @@ export function isInsideShortcode(text: string, offset: number): boolean {
 export function parseShortcodeAtPosition(
 	text: string,
 	offset: number,
-	codeBlockRanges?: TextRange[],
+	codeBlockRanges?: readonly TextRange[],
 ): ShortcodeParseResult | null {
 	const bounds = getShortcodeBounds(text, offset, codeBlockRanges);
 	if (!bounds) {

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -267,7 +267,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
  * the blocks around the one under the cursor: a raw block compiles with the raw
  * blocks above it. Taking the text would scan the document a second time.
  */
-export function blockAtOffset(blocks: TypstBlock[], offset: number): TypstBlock | undefined {
+export function blockAtOffset(blocks: readonly TypstBlock[], offset: number): TypstBlock | undefined {
 	return blocks.find((block) => offset >= block.fenceStart && offset <= block.bodyEnd);
 }
 
@@ -279,7 +279,7 @@ export function blockAtOffset(blocks: TypstBlock[], offset: number): TypstBlock 
  * compiled to an image by the filter, and a plain block is never executed, so
  * neither can put a binding in scope.
  */
-export function precedingRawBlocks(blocks: TypstBlock[], target: TypstBlock): TypstBlock[] {
+export function precedingRawBlocks(blocks: readonly TypstBlock[], target: TypstBlock): TypstBlock[] {
 	return blocks.filter((block) => block.kind === "raw" && block.bodyStart < target.bodyStart);
 }
 

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -14,7 +14,7 @@
  */
 
 import { getYamlIndentLevel, getYamlKeyPath, stripBlockquoteMarkers, stripCarriageReturn } from "../yamlPosition";
-import { findTypstBlocks, OPTION_LINE, quotedValue, type TypstBlock } from "./typstBlocks";
+import { OPTION_LINE, quotedValue, type TypstBlock } from "./typstBlocks";
 import { TYPST_RENDER } from "./typstOptions";
 import { resolveQuartoPath } from "./typstPaths";
 
@@ -279,13 +279,13 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
  * @param languageId - The VS Code language identifier, which decides where the
  *   YAML of the document is and whether it holds cells at all.
  * @param readBlocks - The blocks of that text. Taken as a thunk, because a YAML
- *   file holds no cell and asks for none. Absent for a caller holding no scan,
- *   which reads the text again.
+ *   file holds no cell and asks for none, and this module cannot read the cache
+ *   that a caller holding a document reads.
  */
 export function findTypstPathOptions(
 	text: string,
 	languageId: string,
-	readBlocks: () => TypstBlock[] = () => findTypstBlocks(text),
+	readBlocks: () => TypstBlock[],
 ): TypstPathOption[] {
 	const cells = languageId === "yaml" ? [] : cellPathOptions(text, readBlocks());
 	const yamlOptions = yamlPathOptions(text, languageId);

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -14,7 +14,7 @@
  */
 
 import { getYamlIndentLevel, getYamlKeyPath, stripBlockquoteMarkers, stripCarriageReturn } from "../yamlPosition";
-import { findTypstBlocks, OPTION_LINE, quotedValue } from "./typstBlocks";
+import { findTypstBlocks, OPTION_LINE, quotedValue, type TypstBlock } from "./typstBlocks";
 import { TYPST_RENDER } from "./typstOptions";
 import { resolveQuartoPath } from "./typstPaths";
 
@@ -78,11 +78,14 @@ function quoteDepth(text: string, fenceStart: number): number {
  * The run is read from the document text rather than from `block.body`, which
  * is de-indented and stripped of its blockquote markers: an offset taken in
  * that body does not map back to a position in the document.
+ *
+ * @param blocks - The blocks of that text, which a caller holding them already
+ *   passes rather than paying for the scan a second time.
  */
-function cellPathOptions(text: string): TypstPathOption[] {
+function cellPathOptions(text: string, blocks: TypstBlock[]): TypstPathOption[] {
 	const found: TypstPathOption[] = [];
 
-	for (const block of findTypstBlocks(text)) {
+	for (const block of blocks) {
 		// Only a cell carries options. In the other two kinds a `//|` line is an
 		// ordinary Typst comment.
 		if (block.kind !== "cell") {
@@ -275,9 +278,16 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
  * @param text - The document text.
  * @param languageId - The VS Code language identifier, which decides where the
  *   YAML of the document is and whether it holds cells at all.
+ * @param readBlocks - The blocks of that text. Taken as a thunk, because a YAML
+ *   file holds no cell and asks for none. Absent for a caller holding no scan,
+ *   which reads the text again.
  */
-export function findTypstPathOptions(text: string, languageId: string): TypstPathOption[] {
-	const cells = languageId === "yaml" ? [] : cellPathOptions(text);
+export function findTypstPathOptions(
+	text: string,
+	languageId: string,
+	readBlocks: () => TypstBlock[] = () => findTypstBlocks(text),
+): TypstPathOption[] {
+	const cells = languageId === "yaml" ? [] : cellPathOptions(text, readBlocks());
 	const yamlOptions = yamlPathOptions(text, languageId);
 	return [...yamlOptions, ...cells].sort((left, right) => left.start - right.start);
 }

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -82,7 +82,7 @@ function quoteDepth(text: string, fenceStart: number): number {
  * @param blocks - The blocks of that text, which a caller holding them already
  *   passes rather than paying for the scan a second time.
  */
-function cellPathOptions(text: string, blocks: TypstBlock[]): TypstPathOption[] {
+function cellPathOptions(text: string, blocks: readonly TypstBlock[]): TypstPathOption[] {
 	const found: TypstPathOption[] = [];
 
 	for (const block of blocks) {
@@ -285,7 +285,7 @@ function yamlPathOptions(text: string, languageId: string): TypstPathOption[] {
 export function findTypstPathOptions(
 	text: string,
 	languageId: string,
-	readBlocks: () => TypstBlock[],
+	readBlocks: () => readonly TypstBlock[],
 ): TypstPathOption[] {
 	const cells = languageId === "yaml" ? [] : cellPathOptions(text, readBlocks());
 	const yamlOptions = yamlPathOptions(text, languageId);

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -73,7 +73,7 @@ export function buildPlainSource(block: TypstBlock, header: string): AssembledSo
  * directives that the preview has no way to apply, so a block relying on
  * template state diverges.
  */
-export function buildRawSource(blocks: TypstBlock[], target: TypstBlock, header: string): AssembledSource {
+export function buildRawSource(blocks: readonly TypstBlock[], target: TypstBlock, header: string): AssembledSource {
 	const context = precedingRawBlocks(blocks, target).map((block) => block.body);
 	return assemble([header, ...context], target.body);
 }

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -451,7 +451,7 @@ export function getCodeBlockRanges(text: string): TextRange[] {
  * @param fencedRanges - Pre-computed fenced code block ranges to skip.
  * @returns An array of ranges sorted by start offset.
  */
-export function getInlineCodeSpanRanges(text: string, fencedRanges: TextRange[]): TextRange[] {
+export function getInlineCodeSpanRanges(text: string, fencedRanges: readonly TextRange[]): TextRange[] {
 	const ranges: TextRange[] = [];
 	const len = text.length;
 	let i = 0;
@@ -506,7 +506,7 @@ export function getInlineCodeSpanRanges(text: string, fencedRanges: TextRange[])
 /**
  * Find the first range that contains the given offset, or undefined.
  */
-function findContainingRange(ranges: TextRange[], offset: number): TextRange | undefined {
+function findContainingRange(ranges: readonly TextRange[], offset: number): TextRange | undefined {
 	for (const range of ranges) {
 		if (offset >= range.start && offset < range.end) {
 			return range;
@@ -525,7 +525,7 @@ function findContainingRange(ranges: TextRange[], offset: number): TextRange | u
  * @param offset - The offset to test.
  * @returns True if the offset is inside a code block.
  */
-export function isInCodeBlockRange(ranges: TextRange[], offset: number): boolean {
+export function isInCodeBlockRange(ranges: readonly TextRange[], offset: number): boolean {
 	return findContainingRange(ranges, offset) !== undefined;
 }
 


### PR DESCRIPTION
Several readers answer the same keystroke, and each one scanned the whole document to do it. A completion, a hover, a diagnostic pass and a code action all ask what the fenced blocks of the document are, and the Typst surfaces ask again by their own rules.

`src/utils/documentScan.ts` now holds both scans per document version, and every reader that has a document goes through it. `TypstContextCache` keeps only what it reads from disk.

The key is the document object and not its URI. The editor hands out one object per open document, so identity says what a URI cannot: an untitled name is handed out again once the document holding it closes, and the document taking it starts at version one with different text. The block cache this replaces was keyed on the URI and the version, so it served that new document the blocks of the one before it, and the preview then answered from that document's image. A weak key also releases an entry with its document, which matters because a block body is a slice of the text and a slice keeps the string it was cut from.

The arrays are shared rather than copied, so they are handed out `readonly` and the compiler enforces it. No reader wrote to one.