### PR TITLE
fix: measure fence tab stops from the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - fix: Read a document again when it takes the name of an untitled document that closed. The new document was shown the Typst blocks of the one before it. (#407)
 - fix: Point a YAML diagnostic at the key or the value it is about, instead of at the whole line. An option written in flow style, such as `format: {html: {toc: 3}}`, is now checked as well. (#408)
-- fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#\<pull request\>)
+- fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#409)
 
 ## 3.3.0 (2026-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - fix: Read a document again when it takes the name of an untitled document that closed. The new document was shown the Typst blocks of the one before it. (#407)
 - fix: Point a YAML diagnostic at the key or the value it is about, instead of at the whole line. An option written in flow style, such as `format: {html: {toc: 3}}`, is now checked as well. (#408)
+- fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#\<pull request\>)
 
 ## 3.3.0 (2026-09-03)
 

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -101,6 +101,15 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(found[0].body, "> #x\n");
 		});
 
+		test("Should keep the indent of a tab-indented body line in a quote", () => {
+			// The fence carries two columns of indent, so two columns come off each
+			// body line. The body tab runs from column two to column four, and the
+			// four spaces of Typst indent that follow it survive whole.
+			const found = findTypstBlocks("> \t```typst\n> \t    #x\n> \t```\n");
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].body, "    #x\n");
+		});
+
 		test("Should read an unclosed block to the end of the text", () => {
 			const found = findTypstBlocks("```typst\n#let a = 1\n");
 			assert.strictEqual(found.length, 1);

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -110,6 +110,18 @@ suite("Typst Path Options Test Suite", () => {
 			assert.strictEqual(text.slice(option.start, option.end), "_plot.typ");
 		});
 
+		test("Should report the offset of a path option in a tab-quoted cell", () => {
+			// Passes as soon as it is written: a straddling tab pads `content` with
+			// synthetic spaces, so `prefix` in `cellPathOptions` can be negative, but
+			// the offset expression still collapses to `line.length -
+			// match[2].length`, which stays correct. This guards that invariant.
+			const text = ">\t```{typst}\n>\t//| file: x.typ\n>\t```\n";
+			const option = only(text);
+			const valueOffset = text.indexOf("x.typ");
+			assert.strictEqual(option.start, valueOffset);
+			assert.strictEqual(option.end, valueOffset + "x.typ".length);
+		});
+
 		test("Should report the offset of a cell below front matter", () => {
 			const text = "---\ntitle: One\n---\n\n```{typst}\n//| file: _plot.typ\n```\n";
 			const option = only(text);

--- a/src/test/suite/yamlPosition.test.ts
+++ b/src/test/suite/yamlPosition.test.ts
@@ -416,6 +416,30 @@ suite("YAML Position Utils Test Suite", () => {
 			assert.strictEqual(found[0].info, "python");
 		});
 
+		test("should read a tab-indented fence inside a blockquote", () => {
+			// The marker `> ` takes two columns, so the tab advances from column two
+			// to column four and gives the fence two columns of indent. Counting the
+			// tab from the start of the quoted content charges it four, which is one
+			// past the limit, and the block is lost.
+			const text = "> \t```{r}\n> \tx <- 1\n> \t```\n";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].indent, 2);
+			assert.strictEqual(found[0].info, "{r}");
+			assert.strictEqual(found[0].quoteDepth, 1);
+		});
+
+		test("should give the marker one column of a tab that follows it", () => {
+			// CommonMark grants the blockquote marker one column of the tab after
+			// `>`. The rest is content, so the fence carries two columns of indent
+			// here as well.
+			const text = ">\t```{r}\n>\tx <- 1\n>\t```\n";
+			const found = findFencedBlocks(text);
+			assert.strictEqual(found.length, 1);
+			assert.strictEqual(found[0].indent, 2);
+			assert.strictEqual(found[0].info, "{r}");
+		});
+
 		test("should report the fence line of an unclosed block that ends the text", () => {
 			const text = "before\n```typst";
 			const found = findFencedBlocks(text);

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -80,7 +80,10 @@ function blockBody(text: string, block: FencedBlock): string {
 	// At most the depth of the fence is removed. A marker beyond that is content:
 	// one quote deep, the line `> > #x` reaches Typst as the text `> #x`.
 	const depth = block.quoteDepth;
-	const unquote = depth > 0 ? (line: string) => stripBlockquoteMarkers(line, depth).content : (line: string) => line;
+	const unquote =
+		depth > 0
+			? (line: string) => stripBlockquoteMarkers(line, depth)
+			: (line: string) => ({ content: line, column: 0 });
 
 	// Cut at the start of the closing fence line rather than dropping that line
 	// after a split, which would take the newline of the line above with it and
@@ -89,14 +92,17 @@ function blockBody(text: string, block: FencedBlock): string {
 	const lastNewline = slice.lastIndexOf("\n");
 	const closing = closingFenceRegExp(block.fence);
 	const lastLine = stripCarriageReturn(slice.slice(lastNewline + 1));
-	const body = closing.test(unquote(lastLine)) ? slice.slice(0, lastNewline + 1) : slice;
+	const body = closing.test(unquote(lastLine).content) ? slice.slice(0, lastNewline + 1) : slice;
 
 	// The indent comes off by column, because the fence owns a number of columns
 	// and not a number of characters. A carriage return is part of the line
 	// ending on a CRLF document, and is left alone.
 	return body
 		.split("\n")
-		.map((line) => removeIndentColumns(unquote(line), block.indent))
+		.map((line) => {
+			const { content, column } = unquote(line);
+			return removeIndentColumns(content, block.indent, column);
+		})
 		.join("\n");
 }
 

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -53,12 +53,15 @@ export function hasUnquotedBacktick(infoString: string): boolean {
 const MAX_FENCE_INDENT = 3;
 
 /**
- * One blockquote marker: up to three spaces, a `>`, and one optional space.
+ * One blockquote marker: up to three spaces and a `>`.
  *
- * Matched one at a time rather than as a run, because a reader sometimes has to
- * remove a fixed number of them and leave the rest as content.
+ * The whitespace that follows is handled by the reader rather than by the
+ * pattern, because CommonMark grants the marker one column of it and a tab is
+ * worth up to four. Matched one at a time rather than as a run, because a
+ * reader sometimes has to remove a fixed number of them and leave the rest as
+ * content.
  */
-const BLOCKQUOTE_MARKER = /^ {0,3}>[ \t]?/;
+const BLOCKQUOTE_MARKER = /^ {0,3}>/;
 
 /**
  * A list item marker, which opens a container whose content is indented.
@@ -126,18 +129,24 @@ function firstNonWhitespace(content: string): number {
  *
  * A tab that straddles the boundary is replaced by the spaces it contributes
  * past it, which is how CommonMark splits one.
+ *
+ * @param startColumn - The column of the original line that `line` starts at.
+ *   A tab expands against the whole line, so a quoted body line de-indented
+ *   from column zero would lose columns of real indent that the tab already
+ *   spent on the markers above it.
  */
-export function removeIndentColumns(line: string, indent: number): string {
-	let column = 0;
+export function removeIndentColumns(line: string, indent: number, startColumn = 0): string {
+	const limit = startColumn + indent;
+	let column = startColumn;
 	let index = 0;
-	while (index < line.length && column < indent) {
+	while (index < line.length && column < limit) {
 		const code = line.charCodeAt(index);
 		if (code === SPACE) {
 			column++;
 		} else if (code === TAB) {
 			const advance = TAB_WIDTH - (column % TAB_WIDTH);
-			if (column + advance > indent) {
-				return " ".repeat(column + advance - indent) + line.slice(index + 1);
+			if (column + advance > limit) {
+				return " ".repeat(column + advance - limit) + line.slice(index + 1);
 			}
 			column += advance;
 		} else {
@@ -153,13 +162,18 @@ export function removeIndentColumns(line: string, indent: number): string {
  *
  * Indentation is compared in columns rather than characters, because one tab
  * and four spaces put the following text in the same place.
+ *
+ * @param startColumn - The column of the original line that `content` starts
+ *   at. A tab expands against the whole line, so quoted content read from
+ *   column zero charges a tab more columns than it takes. The result stays
+ *   relative to the start of `content`, which is what every caller compares.
  */
-function columnAt(content: string, index: number): number {
-	let column = 0;
+function columnAt(content: string, index: number, startColumn = 0): number {
+	let column = startColumn;
 	for (let i = 0; i < index; i++) {
 		column += content.charCodeAt(i) === TAB ? TAB_WIDTH - (column % TAB_WIDTH) : 1;
 	}
-	return column;
+	return column - startColumn;
 }
 
 /** Drop a trailing carriage return left by a CRLF document. */
@@ -183,6 +197,8 @@ export interface QuotedLine {
 	content: string;
 	/** How many markers were removed. */
 	depth: number;
+	/** The column of the original line that `content` starts at. */
+	column: number;
 }
 
 /**
@@ -198,19 +214,32 @@ export interface QuotedLine {
  */
 export function stripBlockquoteMarkers(line: string, limit = Number.POSITIVE_INFINITY): QuotedLine {
 	if (limit <= 0 || !mayBeQuoted(line)) {
-		return { content: line, depth: 0 };
+		return { content: line, depth: 0, column: 0 };
 	}
 	let content = line;
 	let depth = 0;
+	let column = 0;
 	while (depth < limit) {
 		const found = BLOCKQUOTE_MARKER.exec(content);
 		if (found === null) {
 			break;
 		}
 		content = content.slice(found[0].length);
+		column += found[0].length;
 		depth++;
+		// The marker takes one column of the whitespace after it. A tab advances to
+		// the next tab stop, and the marker owns one column of that, so the rest
+		// comes back as the spaces the tab stood for.
+		if (content.startsWith(" ")) {
+			content = content.slice(1);
+			column++;
+		} else if (content.startsWith("\t")) {
+			const advance = TAB_WIDTH - (column % TAB_WIDTH);
+			content = " ".repeat(advance - 1) + content.slice(1);
+			column++;
+		}
 	}
-	return { content, depth };
+	return { content, depth, column };
 }
 
 /** An opening fence, as read from one line. */
@@ -230,8 +259,11 @@ interface OpeningFence {
  * line sits in, which only a reader walking the whole document knows.
  *
  * @param content - One line, with its blockquote markers already removed.
+ * @param startColumn - The column of the original line that `content` starts
+ *   at, so a tab in the indent is measured from the line rather than from the
+ *   quoted content.
  */
-function parseOpeningFence(content: string): OpeningFence | undefined {
+function parseOpeningFence(content: string, startColumn: number): OpeningFence | undefined {
 	const found = OPENING_FENCE.exec(content);
 	if (found === null) {
 		return undefined;
@@ -242,7 +274,7 @@ function parseOpeningFence(content: string): OpeningFence | undefined {
 	if (found[2][0] === "`" && hasUnquotedBacktick(found[3])) {
 		return undefined;
 	}
-	return { indent: columnAt(found[1], found[1].length), fence: found[2], info: found[3] };
+	return { indent: columnAt(found[1], found[1].length, startColumn), fence: found[2], info: found[3] };
 }
 
 /**
@@ -315,11 +347,7 @@ export function findFencedBlocks(text: string): FencedBlock[] {
 	//
 	// This is an approximation of container parsing and not the real thing. It
 	// is lowered only by a line that both starts a block and dedents past it, so
-	// it errs towards accepting a fence rather than losing one. The known gap
-	// runs the other way: a tab stop is counted from the start of the quoted
-	// content rather than from the start of the line, so a tab-indented fence
-	// inside a blockquote is charged four columns instead of the two it takes,
-	// and is not read as a fence.
+	// it errs towards accepting a fence rather than losing one.
 	let containerIndent = 0;
 	// Whether the line above was blank, which is what makes the line below it
 	// the start of a block rather than a continuation of the one above.
@@ -333,7 +361,7 @@ export function findFencedBlocks(text: string): FencedBlock[] {
 		// Advance offset past the newline for the next iteration.
 		offset = lineEnd + (i < lines.length - 1 ? 1 : 0);
 
-		const { content, depth } = stripBlockquoteMarkers(line);
+		const { content, depth, column } = stripBlockquoteMarkers(line);
 
 		if (open) {
 			if (depth > open.quoteDepth) {
@@ -375,18 +403,18 @@ export function findFencedBlocks(text: string): FencedBlock[] {
 				// than after the whitespace that follows it.
 				const empty = item[0].length === content.length;
 				const markerEnd = item[1].length + item[2].length;
-				containerIndent = empty ? columnAt(content, markerEnd) + 1 : columnAt(content, item[0].length);
+				containerIndent = empty ? columnAt(content, markerEnd, column) + 1 : columnAt(content, item[0].length, column);
 			} else if (previousBlank) {
 				// Only a line that starts a block can close a container. A line that
 				// continues the paragraph of an open item is written at the margin as
 				// often as not, and lowering the allowance for it would lose a fence
 				// the item still holds open.
-				containerIndent = Math.min(containerIndent, columnAt(content, contentStart));
+				containerIndent = Math.min(containerIndent, columnAt(content, contentStart, column));
 			}
 		}
 		previousBlank = contentStart === content.length;
 
-		const opening = parseOpeningFence(content);
+		const opening = parseOpeningFence(content, column);
 		if (opening && opening.indent <= containerIndent + MAX_FENCE_INDENT) {
 			open = {
 				indent: opening.indent,

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -227,15 +227,10 @@ export function stripBlockquoteMarkers(line: string, limit = Number.POSITIVE_INF
 		content = content.slice(found[0].length);
 		column += found[0].length;
 		depth++;
-		// The marker takes one column of the whitespace after it. A tab advances to
-		// the next tab stop, and the marker owns one column of that, so the rest
-		// comes back as the spaces the tab stood for.
-		if (content.startsWith(" ")) {
-			content = content.slice(1);
-			column++;
-		} else if (content.startsWith("\t")) {
-			const advance = TAB_WIDTH - (column % TAB_WIDTH);
-			content = " ".repeat(advance - 1) + content.slice(1);
+		// The marker takes one column of the whitespace after it. A straddling tab
+		// comes back as the spaces it stood for.
+		if (content.startsWith(" ") || content.startsWith("\t")) {
+			content = removeIndentColumns(content, 1, column);
 			column++;
 		}
 	}


### PR DESCRIPTION
`stripBlockquoteMarkers` takes the markers off a line, and every column was then counted from column zero of what was left. CommonMark expands a tab against the whole line.

For a fence line written as a blockquote marker, a space, a tab and then the fence, the marker takes two columns, so the tab advances to column four and gives the fence two columns of indent. The scan charged the tab four columns, the fence failed the indent test, and a live block was lost.

Two offsets followed from the same cause. A quoted body line was de-indented from column zero, so a tab-indented line could lose up to three columns of real indent, which matters because Typst is whitespace sensitive. And the blockquote marker consumed a whole tab, where CommonMark grants it one column.

`QuotedLine` now reports the column its content starts at, and `columnAt`, `removeIndentColumns` and `parseOpeningFence` take that column. The result of each stays relative to the start of the content, so no caller changes meaning.

Two further commits follow from that change. `stripBlockquoteMarkers` takes the marker column off through `removeIndentColumns` rather than repeating the tab arithmetic, and one test pins the offset arithmetic in `cellPathOptions`, which now has to survive content that a straddling tab made longer than the characters it consumed.

Locally: lint clean, and the suite at 1181 passing.