### PR TITLE
fix: correct three checks in the Lua validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix: Read a document again when it takes the name of an untitled document that closed. The new document was shown the Typst blocks of the one before it. (#407)
 - fix: Point a YAML diagnostic at the key or the value it is about, instead of at the whole line. An option written in flow style, such as `format: {html: {toc: 3}}`, is now checked as well. (#408)
 - fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#409)
+- fix: Correct two checks in the Lua reference validator. A dependent that holds only a default no longer satisfies `dependentRequired`, and a shortcode `required` name is now read from the merged attributes when the entry declares an `attributes` block. (#\<pull request\>)
 
 ## 3.3.0 (2026-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - fix: Point a YAML diagnostic at the key or the value it is about, instead of at the whole line. An option written in flow style, such as `format: {html: {toc: 3}}`, is now checked as well. (#408)
 - fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#409)
 - fix: Correct two checks in the Lua reference validator. A dependent that holds only a default no longer satisfies `dependentRequired`, and a shortcode `required` name is now read from the merged attributes when the entry declares an `attributes` block. (#\<pull request\>)
-- fix: Accept a name written with an underscore where the schema declares it with a hyphen. The Lua reference validator raised an error instead of resolving the name, so the underscore spelling never worked. (#\<pull request\>)
+- fix: Accept a name written with a hyphen where the schema declares it with an underscore. The Lua reference validator raised an error instead of resolving the name, so that spelling never worked. (#\<pull request\>)
 
 ## 3.3.0 (2026-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix: Point a YAML diagnostic at the key or the value it is about, instead of at the whole line. An option written in flow style, such as `format: {html: {toc: 3}}`, is now checked as well. (#408)
 - fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#409)
 - fix: Correct two checks in the Lua reference validator. A dependent that holds only a default no longer satisfies `dependentRequired`, and a shortcode `required` name is now read from the merged attributes when the entry declares an `attributes` block. (#\<pull request\>)
+- fix: Accept a name written with an underscore where the schema declares it with a hyphen. The Lua reference validator raised an error instead of resolving the name, so the underscore spelling never worked. (#\<pull request\>)
 
 ## 3.3.0 (2026-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - fix: Read a document again when it takes the name of an untitled document that closed. The new document was shown the Typst blocks of the one before it. (#407)
 - fix: Point a YAML diagnostic at the key or the value it is about, instead of at the whole line. An option written in flow style, such as `format: {html: {toc: 3}}`, is now checked as well. (#408)
 - fix: Read a fenced block that a tab indents inside a blockquote. A tab is now measured from the start of the line, so the block is found and a body line keeps the indent the author wrote. (#409)
-- fix: Correct two checks in the Lua reference validator. A dependent that holds only a default no longer satisfies `dependentRequired`, and a shortcode `required` name is now read from the merged attributes when the entry declares an `attributes` block. (#\<pull request\>)
-- fix: Accept a name written with a hyphen where the schema declares it with an underscore. The Lua reference validator raised an error instead of resolving the name, so that spelling never worked. (#\<pull request\>)
+- fix: Correct two checks in the Lua reference validator. A dependent that holds only a default no longer satisfies `dependentRequired`, and a shortcode `required` name is now read from the merged attributes when the entry declares an `attributes` block. (#410)
+- fix: Accept a name written with a hyphen where the schema declares it with an underscore. The Lua reference validator raised an error instead of resolving the name, so that spelling never worked. (#410)
 
 ## 3.3.0 (2026-09-03)
 

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -153,7 +153,7 @@ local function _lookup(map, key)
   if underscored ~= key and map[underscored] ~= nil then
     return map[underscored], underscored
   end
-  local hyphenated = (key:gsub('_', '%-'))
+  local hyphenated = (key:gsub('_', '-'))
   if hyphenated ~= key and map[hyphenated] ~= nil then
     return map[hyphenated], hyphenated
   end
@@ -2255,7 +2255,8 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     end
   end
 
-  if type(entry.attributes) == 'table' then
+  local declared = type(entry.attributes) == 'table'
+  if declared then
     merged.attributes = _validate_map(kwargs or {}, entry.attributes, name, context, {
       unknown = options.unknown or 'warn',
     })
@@ -2265,24 +2266,29 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- `merged.attributes` is filled only when the entry declares `attributes`,
     -- and it is authoritative when it is: it keeps every unclaimed key and it
     -- drops a key that a deprecation cleared. The vocabulary allows `required`
-    -- on its own, so fall back to what the caller supplied only in that case,
-    -- rather than reporting every name as missing. A name that names an alias
-    -- is not missing either: `_validate_map` moves its value to the field
-    -- that declares the alias and clears the alias spelling, the same way it
-    -- clears a deprecated key, so look for the value under that field.
-    local declared = type(entry.attributes) == 'table'
-    local supplied = declared and {} or (kwargs or {})
-
-    local function _satisfied_by_alias(required)
+    -- on its own, so fall back to what the caller supplied only when the
+    -- entry declares no `attributes`. A name that names an alias is not
+    -- missing either: `_validate_map` moves its value to the field that
+    -- declares the alias and clears the alias spelling, the same way it
+    -- clears a deprecated key, so look for the value under that field. The
+    -- match goes through `_lookup`, the same as every other name comparison
+    -- in this module, so a hyphen in one spelling and an underscore in the
+    -- other still match.
+    local function _required_satisfied(required)
+      if _lookup(merged.attributes, required) ~= nil then
+        return true
+      end
       if not declared then
-        return false
+        return _lookup(kwargs or {}, required) ~= nil
       end
       for field, spec in pairs(entry.attributes) do
         if type(spec) == 'table' and type(spec.aliases) == 'table' then
+          local spellings = {}
           for _, alias in ipairs(spec.aliases) do
-            if alias == required then
-              return _lookup(merged.attributes, field) ~= nil
-            end
+            spellings[alias] = true
+          end
+          if _lookup(spellings, required) ~= nil and _lookup(merged.attributes, field) ~= nil then
+            return true
           end
         end
       end
@@ -2290,9 +2296,7 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     end
 
     for _, required in ipairs(entry.required) do
-      if _lookup(merged.attributes, required) == nil
-        and _lookup(supplied, required) == nil
-        and not _satisfied_by_alias(required) then
+      if not _required_satisfied(required) then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2274,6 +2274,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- match goes through `_lookup`, the same as every other name comparison
     -- in this module, so a hyphen in one spelling and an underscore in the
     -- other still match.
+    --
+    -- This asks what the shortcode receives, not what the author wrote, so
+    -- a `default` present in `merged.attributes` satisfies a name here.
+    -- That is the opposite of `dependentRequired` above, which asks what
+    -- the author wrote and treats a default as an annotation nobody
+    -- supplied. Neither reading is a bug: they answer different questions
+    -- about the same instance.
     local function _required_satisfied(required)
       if _lookup(merged.attributes, required) ~= nil then
         return true

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2266,12 +2266,33 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- and it is authoritative when it is: it keeps every unclaimed key and it
     -- drops a key that a deprecation cleared. The vocabulary allows `required`
     -- on its own, so fall back to what the caller supplied only in that case,
-    -- rather than reporting every name as missing.
+    -- rather than reporting every name as missing. A name that names an alias
+    -- is not missing either: `_validate_map` moves its value to the field
+    -- that declares the alias and clears the alias spelling, the same way it
+    -- clears a deprecated key, so look for the value under that field.
     local declared = type(entry.attributes) == 'table'
     local supplied = declared and {} or (kwargs or {})
+
+    local function _satisfied_by_alias(required)
+      if not declared then
+        return false
+      end
+      for field, spec in pairs(entry.attributes) do
+        if type(spec) == 'table' and type(spec.aliases) == 'table' then
+          for _, alias in ipairs(spec.aliases) do
+            if alias == required then
+              return _lookup(merged.attributes, field) ~= nil
+            end
+          end
+        end
+      end
+      return false
+    end
+
     for _, required in ipairs(entry.required) do
       if _lookup(merged.attributes, required) == nil
-        and _lookup(supplied, required) == nil then
+        and _lookup(supplied, required) == nil
+        and not _satisfied_by_alias(required) then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1824,13 +1824,15 @@ local function _check_object(value, spec, path, context)
   -- Runs after the properties block, which writes the resolved members back
   -- into `value`. Before that, a dependent supplied under an alias is not yet
   -- there to be found. A `default` is an annotation and does not change the
-  -- instance, so a key that only holds one never triggers a requirement.
+  -- instance, so a key that only holds one neither triggers a requirement nor
+  -- satisfies it.
   if type(spec.dependentRequired) == 'table' then
     for key, dependents in pairs(spec.dependentRequired) do
       local trigger, trigger_key = _lookup(value, key)
       if trigger ~= nil and not defaulted[trigger_key] and type(dependents) == 'table' then
         for _, dependent in ipairs(dependents) do
-          if _lookup(value, dependent) == nil then
+          local supplied, dependent_key = _lookup(value, dependent)
+          if supplied == nil or defaulted[dependent_key] then
             _report(context, 'error', path, 'dependentRequired', string.format(
               'requires "%s" when "%s" is present.', dependent, key
             ))
@@ -2260,10 +2262,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
   end
 
   if type(entry.required) == 'table' then
-    -- `merged.attributes` is filled only when the entry declares `attributes`.
-    -- The vocabulary allows `required` on its own, so fall back to what the
-    -- caller supplied rather than reporting every name as missing.
-    local supplied = kwargs or {}
+    -- `merged.attributes` is filled only when the entry declares `attributes`,
+    -- and it is authoritative when it is: it keeps every unclaimed key and it
+    -- drops a key that a deprecation cleared. The vocabulary allows `required`
+    -- on its own, so fall back to what the caller supplied only in that case,
+    -- rather than reporting every name as missing.
+    local declared = type(entry.attributes) == 'table'
+    local supplied = declared and {} or (kwargs or {})
     for _, required in ipairs(entry.required) do
       if _lookup(merged.attributes, required) == nil
         and _lookup(supplied, required) == nil then

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -153,7 +153,7 @@ local function _lookup(map, key)
   if underscored ~= key and map[underscored] ~= nil then
     return map[underscored], underscored
   end
-  local hyphenated = (key:gsub('_', '%-'))
+  local hyphenated = (key:gsub('_', '-'))
   if hyphenated ~= key and map[hyphenated] ~= nil then
     return map[hyphenated], hyphenated
   end
@@ -2255,7 +2255,8 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     end
   end
 
-  if type(entry.attributes) == 'table' then
+  local declared = type(entry.attributes) == 'table'
+  if declared then
     merged.attributes = _validate_map(kwargs or {}, entry.attributes, name, context, {
       unknown = options.unknown or 'warn',
     })
@@ -2265,24 +2266,29 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- `merged.attributes` is filled only when the entry declares `attributes`,
     -- and it is authoritative when it is: it keeps every unclaimed key and it
     -- drops a key that a deprecation cleared. The vocabulary allows `required`
-    -- on its own, so fall back to what the caller supplied only in that case,
-    -- rather than reporting every name as missing. A name that names an alias
-    -- is not missing either: `_validate_map` moves its value to the field
-    -- that declares the alias and clears the alias spelling, the same way it
-    -- clears a deprecated key, so look for the value under that field.
-    local declared = type(entry.attributes) == 'table'
-    local supplied = declared and {} or (kwargs or {})
-
-    local function _satisfied_by_alias(required)
+    -- on its own, so fall back to what the caller supplied only when the
+    -- entry declares no `attributes`. A name that names an alias is not
+    -- missing either: `_validate_map` moves its value to the field that
+    -- declares the alias and clears the alias spelling, the same way it
+    -- clears a deprecated key, so look for the value under that field. The
+    -- match goes through `_lookup`, the same as every other name comparison
+    -- in this module, so a hyphen in one spelling and an underscore in the
+    -- other still match.
+    local function _required_satisfied(required)
+      if _lookup(merged.attributes, required) ~= nil then
+        return true
+      end
       if not declared then
-        return false
+        return _lookup(kwargs or {}, required) ~= nil
       end
       for field, spec in pairs(entry.attributes) do
         if type(spec) == 'table' and type(spec.aliases) == 'table' then
+          local spellings = {}
           for _, alias in ipairs(spec.aliases) do
-            if alias == required then
-              return _lookup(merged.attributes, field) ~= nil
-            end
+            spellings[alias] = true
+          end
+          if _lookup(spellings, required) ~= nil and _lookup(merged.attributes, field) ~= nil then
+            return true
           end
         end
       end
@@ -2290,9 +2296,7 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     end
 
     for _, required in ipairs(entry.required) do
-      if _lookup(merged.attributes, required) == nil
-        and _lookup(supplied, required) == nil
-        and not _satisfied_by_alias(required) then
+      if not _required_satisfied(required) then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2274,6 +2274,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- match goes through `_lookup`, the same as every other name comparison
     -- in this module, so a hyphen in one spelling and an underscore in the
     -- other still match.
+    --
+    -- This asks what the shortcode receives, not what the author wrote, so
+    -- a `default` present in `merged.attributes` satisfies a name here.
+    -- That is the opposite of `dependentRequired` above, which asks what
+    -- the author wrote and treats a default as an annotation nobody
+    -- supplied. Neither reading is a bug: they answer different questions
+    -- about the same instance.
     local function _required_satisfied(required)
       if _lookup(merged.attributes, required) ~= nil then
         return true

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2266,12 +2266,33 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- and it is authoritative when it is: it keeps every unclaimed key and it
     -- drops a key that a deprecation cleared. The vocabulary allows `required`
     -- on its own, so fall back to what the caller supplied only in that case,
-    -- rather than reporting every name as missing.
+    -- rather than reporting every name as missing. A name that names an alias
+    -- is not missing either: `_validate_map` moves its value to the field
+    -- that declares the alias and clears the alias spelling, the same way it
+    -- clears a deprecated key, so look for the value under that field.
     local declared = type(entry.attributes) == 'table'
     local supplied = declared and {} or (kwargs or {})
+
+    local function _satisfied_by_alias(required)
+      if not declared then
+        return false
+      end
+      for field, spec in pairs(entry.attributes) do
+        if type(spec) == 'table' and type(spec.aliases) == 'table' then
+          for _, alias in ipairs(spec.aliases) do
+            if alias == required then
+              return _lookup(merged.attributes, field) ~= nil
+            end
+          end
+        end
+      end
+      return false
+    end
+
     for _, required in ipairs(entry.required) do
       if _lookup(merged.attributes, required) == nil
-        and _lookup(supplied, required) == nil then
+        and _lookup(supplied, required) == nil
+        and not _satisfied_by_alias(required) then
         _report(context, 'error', name .. '.' .. required, 'required',
           'is required but was not provided.')
       end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1824,13 +1824,15 @@ local function _check_object(value, spec, path, context)
   -- Runs after the properties block, which writes the resolved members back
   -- into `value`. Before that, a dependent supplied under an alias is not yet
   -- there to be found. A `default` is an annotation and does not change the
-  -- instance, so a key that only holds one never triggers a requirement.
+  -- instance, so a key that only holds one neither triggers a requirement nor
+  -- satisfies it.
   if type(spec.dependentRequired) == 'table' then
     for key, dependents in pairs(spec.dependentRequired) do
       local trigger, trigger_key = _lookup(value, key)
       if trigger ~= nil and not defaulted[trigger_key] and type(dependents) == 'table' then
         for _, dependent in ipairs(dependents) do
-          if _lookup(value, dependent) == nil then
+          local supplied, dependent_key = _lookup(value, dependent)
+          if supplied == nil or defaulted[dependent_key] then
             _report(context, 'error', path, 'dependentRequired', string.format(
               'requires "%s" when "%s" is present.', dependent, key
             ))
@@ -2260,10 +2262,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
   end
 
   if type(entry.required) == 'table' then
-    -- `merged.attributes` is filled only when the entry declares `attributes`.
-    -- The vocabulary allows `required` on its own, so fall back to what the
-    -- caller supplied rather than reporting every name as missing.
-    local supplied = kwargs or {}
+    -- `merged.attributes` is filled only when the entry declares `attributes`,
+    -- and it is authoritative when it is: it keeps every unclaimed key and it
+    -- drops a key that a deprecation cleared. The vocabulary allows `required`
+    -- on its own, so fall back to what the caller supplied only in that case,
+    -- rather than reporting every name as missing.
+    local declared = type(entry.attributes) == 'table'
+    local supplied = declared and {} or (kwargs or {})
     for _, required in ipairs(entry.required) do
       if _lookup(merged.attributes, required) == nil
         and _lookup(supplied, required) == nil then

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -991,6 +991,27 @@ shortcodes:
   assert_valid(valid, errors)
 end)
 
+test('shortcode required matches an alias under its other spelling too', function()
+  -- `required` is read from the schema author, and a caller's raw argument
+  -- carries its own spelling. The match between them has to go through
+  -- `_lookup`, the same way every other name comparison in this module does,
+  -- so a hyphen in one and an underscore in the other still match.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      new-name:
+        type: string
+        aliases:
+          - legacy-name
+    required:
+      - legacy_name
+]])
+  local valid, errors = schema.validate_shortcode(
+    'demo', {}, { ['legacy-name'] = 'carried' }, loaded.shortcodes.demo)
+  assert_valid(valid, errors)
+end)
+
 test('S7: validate_attributes checks declared keys and ignores the rest', function()
   local loaded = load_schema([[
 attributes:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -624,6 +624,26 @@ options:
   assert_contains(errors, 'password')
 end)
 
+test('a dependent filled only by its own default does not satisfy the requirement', function()
+  local loaded = load_schema([[
+options:
+  auth:
+    type: object
+    dependentRequired:
+      user:
+        - password
+    properties:
+      user:
+        type: string
+      password:
+        type: string
+        default: letmein
+]])
+  local valid, errors = schema.validate({ auth = { user = 'me' } }, loaded.options)
+  assert_false(valid, 'a dependent that holds only a default is not present')
+  assert_contains(errors, 'password')
+end)
+
 test('nested properties contribute defaults and coercion to merged', function()
   local loaded = load_schema([[
 options:
@@ -924,6 +944,30 @@ shortcodes:
   local valid, errors = schema.validate_shortcode('demo', {}, {}, loaded.shortcodes.demo)
   assert_false(valid, 'a missing required attribute should be reported')
   assert_contains(errors, 'icon')
+end)
+
+test('shortcode required reads the merged attributes when the entry declares them', function()
+  -- `replaceWith` forwards the value and clears the old key, so the old
+  -- spelling is genuinely absent once the attributes are merged. Reading the
+  -- caller's raw arguments instead let it satisfy the requirement.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      old-name:
+        type: string
+        deprecated:
+          since: "1.2.0"
+          replaceWith: new-name
+      new-name:
+        type: string
+    required:
+      - old-name
+]])
+  local valid, errors = schema.validate_shortcode(
+    'demo', {}, { ['old-name'] = 'carried' }, loaded.shortcodes.demo)
+  assert_false(valid, 'a key cleared by replaceWith no longer satisfies required')
+  assert_contains(errors, 'old-name')
 end)
 
 test('S7: validate_attributes checks declared keys and ignores the rest', function()

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -644,6 +644,26 @@ options:
   assert_contains(errors, 'password')
 end)
 
+test('a dependent the author supplied satisfies the requirement', function()
+  local loaded = load_schema([[
+options:
+  auth:
+    type: object
+    dependentRequired:
+      user:
+        - password
+    properties:
+      user:
+        type: string
+      password:
+        type: string
+        default: letmein
+]])
+  local valid, errors = schema.validate(
+    { auth = { user = 'me', password = 'secret' } }, loaded.options)
+  assert_valid(valid, errors)
+end)
+
 test('nested properties contribute defaults and coercion to merged', function()
   local loaded = load_schema([[
 options:
@@ -1026,6 +1046,26 @@ shortcodes:
   local valid, errors = schema.validate_shortcode(
     'demo', {}, { ['legacy-name'] = 'carried' }, loaded.shortcodes.demo)
   assert_valid(valid, errors)
+end)
+
+test('shortcode required still reports a missing alias name', function()
+  -- Matching the spelling is not enough: `_required_satisfied` also has to
+  -- confirm the canonical field actually holds a value, not merely that the
+  -- required name is one of its declared aliases.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      new-name:
+        type: string
+        aliases:
+          - legacy-name
+    required:
+      - legacy-name
+]])
+  local valid, errors = schema.validate_shortcode('demo', {}, {}, loaded.shortcodes.demo)
+  assert_false(valid, 'an alias name with no supplied value is still missing')
+  assert_contains(errors, 'legacy-name')
 end)
 
 test('S7: validate_attributes checks declared keys and ignores the rest', function()

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -970,6 +970,27 @@ shortcodes:
   assert_contains(errors, 'old-name')
 end)
 
+test('shortcode required accepts a value supplied under a declared alias', function()
+  -- An alias resolves to its canonical field and the alias spelling is
+  -- cleared from the merged attributes, the way `_validate_map` clears a
+  -- deprecated key. Unlike `replaceWith`, the value is still present, under
+  -- the canonical name, so `required` must find it there.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      new-name:
+        type: string
+        aliases:
+          - legacy-name
+    required:
+      - legacy-name
+]])
+  local valid, errors = schema.validate_shortcode(
+    'demo', {}, { ['legacy-name'] = 'carried' }, loaded.shortcodes.demo)
+  assert_valid(valid, errors)
+end)
+
 test('S7: validate_attributes checks declared keys and ignores the rest', function()
   local loaded = load_schema([[
 attributes:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -690,6 +690,22 @@ options:
   assert_eq(merged['typst_cache_max_age'], nil, 'the variant spelling is not left behind')
 end)
 
+test('a value given under the hyphen spelling of an underscore-declared name still merges', function()
+  -- `_lookup` only parses its underscore-to-hyphen replacement string once a
+  -- match is found, which only happens when the key it is given contains an
+  -- underscore. Before the fix that replacement string was invalid, so this
+  -- direction raised instead of returning nil.
+  local loaded = load_schema([[
+options:
+  typst_cache_max_age:
+    type: number
+]])
+  local valid, errors, _, merged = schema.validate({ ['typst-cache-max-age'] = '30' }, loaded.options)
+  assert_valid(valid, errors)
+  assert_eq(merged.typst_cache_max_age, 30, 'canonical key holds the value')
+  assert_eq(merged['typst-cache-max-age'], nil, 'the variant spelling is not left behind')
+end)
+
 test('a leading YAML document marker is accepted', function()
   local loaded = load_schema([[
 ---


### PR DESCRIPTION
Three defects in the Lua reference validator, all present in the module that release 3.3.0 published and that other repositories vendor a copy of.

A default satisfied a dependent. The `dependentRequired` block runs after the properties block has written resolved members back into the instance. The trigger key was already skipped when its value came from a default, because a default is an annotation and does not change the instance. The dependent side was not, so a dependent that held only a default counted as present. The comment above the block stated the rule that the code applied to one side only.

The raw arguments fallback applied when it should not. It exists for a shortcode entry that declares `required` without `attributes`, and it was consulted in every case. Where `attributes` is declared, the merged attributes are authoritative: they keep every unclaimed key and they drop a key that a deprecation cleared through `replaceWith`. The old spelling still sat in the raw arguments, so the `required` error was suppressed.

Closing that hole opened a smaller one, which is fixed here as well. A declared alias is resolved to its canonical field and the alias spelling is cleared from the merged attributes, so a `required` name written in an alias spelling would have been reported as missing even though the caller supplied it. One helper now answers whether a required name is satisfied, in the order the rule runs: present in the merged attributes, then the caller's raw arguments when the entry declares no `attributes`, then a declared alias whose field is present. It resolves a name through `_lookup`, so an alias accepts the same spellings every other name in the module accepts.

The third defect surfaced while testing that. `_lookup` wrote `%-` in a `gsub` replacement string, which Lua rejects, so the call raised instead of returning. The replacement string is only parsed when a match is replaced, so it was safe for a name with no underscore and raised for any name that has one. Reading the branches in order, every lookup of an underscore spelled name that was not found directly raised, which means the hyphen spelling of an underscore declared name has never worked in any released version. The correction is one character.

The two requirement checks now state opposite principles about a default, and the comment above the shortcode check says why. `dependentRequired` is about what the author wrote, because one key being present is what makes another necessary and nobody wrote a default. A shortcode `required` is about what the shortcode receives, and it does receive the default.

Locally: lint clean, the Lua suite at 105 passing with the conformance sweep clean over four schema files and 97 descriptors, the schema workspace at 235, and the root suite at 1177. `docs/assets/schema/v2/schema.lua` is rebuilt and is byte for byte the source.