### PR TITLE
ci: stop interpolating the pull request title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,10 @@ jobs:
 
       - name: Generate consolidated summary
         shell: bash
+        env:
+          # A pull request title is attacker controlled. Read through the
+          # environment so the shell never parses it as code.
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # `download-artifact` creates no directory when it matches nothing,
           # and this step runs under `-e -o pipefail`, so a `find` over a
@@ -312,7 +316,7 @@ jobs:
 
           # Add Pull Request link if triggered by PR event
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "**🔗 Pull Request**: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) - ${{ github.event.pull_request.title }}" >> ${GITHUB_STEP_SUMMARY}
+            echo "**🔗 Pull Request**: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) - ${PR_TITLE}" >> ${GITHUB_STEP_SUMMARY}
             echo "" >> ${GITHUB_STEP_SUMMARY}
           fi
 


### PR DESCRIPTION
The `Generate consolidated summary` step interpolated `github.event.pull_request.title` straight into its inline script. A pull request title is text a person writes, so the shell parsed it as code.

The value now travels through an `env:` entry on the step and is read as `${PR_TITLE}` inside a double quoted string, so the shell can neither split it nor run it.

`actionlint` reports 25 findings on this file before the change and 24 after it, and the one that is gone is the untrusted input report. The rest are SC2086, SC2129 and SC2162, which are style and are left alone.

The pull request title of this pull request is the check: the summary of its own run prints it whole.