### PR TITLE
test: allow for clock rounding in timeout bounds

### DIFF
--- a/src/test/suite/timeout.test.ts
+++ b/src/test/suite/timeout.test.ts
@@ -1,6 +1,16 @@
 import * as assert from "assert";
 import { checkInternetConnection } from "../../utils/network";
 
+/**
+ * How far below the timeout an elapsed reading may sit and still count.
+ *
+ * `Date.now()` has millisecond granularity and a timer can be measured firing
+ * a fraction early against it, so a 1000 ms timeout is reported as 999 ms often
+ * enough to fail a run. The tolerance is one millisecond, which covers the
+ * rounding and nothing else: a request that returned at once still fails.
+ */
+const CLOCK_TOLERANCE_MS = 1;
+
 suite("Timeout Handling Test Suite", () => {
 	test("checkInternetConnection should timeout with unreachable URL", async function () {
 		this.timeout(10000); // Allow up to 10 seconds for the test
@@ -12,7 +22,10 @@ suite("Timeout Handling Test Suite", () => {
 
 		// Should return false and complete within reasonable time of the timeout
 		assert.strictEqual(result, false);
-		assert.ok(elapsed >= 1000 && elapsed < 2000, `Expected timeout around 1000ms, got ${elapsed}ms`);
+		assert.ok(
+			elapsed >= 1000 - CLOCK_TOLERANCE_MS && elapsed < 2000,
+			`Expected timeout around 1000ms, got ${elapsed}ms`,
+		);
 	});
 
 	test("checkInternetConnection should succeed with valid URL and sufficient timeout", async function () {
@@ -39,7 +52,7 @@ suite("Timeout Handling Test Suite", () => {
 		// Should return false and respect the timeout
 		assert.strictEqual(result, false);
 		assert.ok(
-			elapsed >= shortTimeout && elapsed < shortTimeout * 2,
+			elapsed >= shortTimeout - CLOCK_TOLERANCE_MS && elapsed < shortTimeout * 2,
 			`Expected timeout around ${shortTimeout}ms, got ${elapsed}ms`,
 		);
 	});


### PR DESCRIPTION
Two assertions in `src/test/suite/timeout.test.ts` required that a timed out request took at least as long as the timeout it was given. `elapsed` is a difference of two `Date.now()` readings, which have millisecond granularity, and a timer can be measured firing a fraction early against that clock. The bound was therefore not safe and the tests failed at random.

The Ubuntu cell of pull request 411 failed with both of them one millisecond short, 999 against 1000 and 499 against 500. That branch changed one workflow file and no source, and the same range passed on Windows in the same run.

A named constant now allows one millisecond, which covers the rounding and nothing else. A request that returns at once still fails the check, so the bound still proves that the timeout it was given is the one that fired. The upper bound is unchanged.

This matters before a release. `release.yml` opens its own version pull request and merges it with `--auto --squash`, so a random failure there stalls a release for a reason that has nothing to do with the release.

Locally: lint clean, and the suite at 1181 passing.