### PR TITLE
ci: report that a draft defers the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,10 @@ jobs:
           retention-days: 1
 
   summary:
-    if: always() && github.event.pull_request.draft == false
+    # No draft condition, unlike the jobs above. This is the single required
+    # check, and a skipped required check does not block, so skipping here let
+    # a draft reach a mergeable state with nothing built.
+    if: always()
     needs:
       - changes
       - build
@@ -287,6 +290,23 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
+      - name: Report that a draft defers the build
+        # `changes`, `build` and `lua` are each guarded on the draft state, so a
+        # run on a draft skips all of them and there is nothing to report. A
+        # failure here states that, where a skip stated nothing and counted as
+        # satisfied. The guards above are what keep a draft off the runners; the
+        # cost of this step is one job that ends in seconds.
+        if: github.event.pull_request.draft == true
+        shell: bash
+        run: |
+          {
+            echo "# 🚧 Build deferred"
+            echo ""
+            echo "This pull request is a draft, so the build matrix did not run."
+            echo "Mark it ready for review to build it."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+
       - name: Download all job summaries
         # The summary now runs even when a needed job fails, so there may be no
         # artifact at all. The consolidated summary below falls back to the job


### PR DESCRIPTION
`changes`, `build`, `lua` and `summary` were each guarded on the draft state, so a run on a draft pull request skipped every one of them. `summary` is the single required context of the ruleset, and a skipped required check does not block, so a draft could report a mergeable and clean state with the matrix never having built its code.

That is not theoretical. Pull request 410 was pushed and marked ready in quick succession, no `ready_for_review` run was ever created, and it then reported `mergeable=MERGEABLE state=CLEAN` on the strength of a run that built nothing. It was cleared by converting it back to a draft and marking it ready again, which is a workaround that depends on a person noticing.

`summary` now runs on a draft as well, and its first step writes a short note and exits non-zero. The required check reports a failure while the work is a draft, where it used to report nothing at all. `changes`, `build` and `lua` keep their draft guard, so a draft still puts nothing on the build runners.

This is the same class of failure as the one found before the 3.3.0 release, where a matrix cell that was cancelled hid a Windows failure. A matrix that skips is not a matrix that passed.

This pull request proves itself in both directions. It is opened as a draft, where the required check must fail, and marked ready, where the matrix runs and it must pass.