### PR TITLE
refactor: report the spellings a merge consumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: Report a spelling that two attributes both declare in the Lua reference validator. One declaring it as its own name and the other as an alias leaves no way to say which accepts it, so the schema author is told instead of the validator choosing one and the choice changing between runs. (#\<pull request\>)
+
 ### Bug Fixes
 
 - fix: Read a document again when it takes the name of an untitled document that closed. The new document was shown the Typst blocks of the one before it. (#407)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- feat: Report a spelling that two attributes both declare in the Lua reference validator. One declaring it as its own name and the other as an alias leaves no way to say which accepts it, so the schema author is told instead of the validator choosing one and the choice changing between runs. (#\<pull request\>)
+- feat: Report a spelling that two attributes both declare in the Lua reference validator. One declaring it as its own name and the other as an alias leaves no way to say which accepts it, so the schema author is told instead of the validator choosing one and the choice changing between runs. (#415)
 
 ### Bug Fixes
 

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1953,6 +1953,10 @@ end
 --- @param options table|nil {unknown = 'warn'|'error'|'ignore', additional = descriptor}
 --- @return table merged Values with aliases, coercion and defaults applied
 --- @return table defaulted Set of field names whose value came from `default`
+--- @return table sources Map of every spelling the schema accepts to the
+---   declared name it resolves to. A reader that has to answer a question
+---   about a name the caller wrote asks this rather than walking the
+---   descriptors again, because the merge has already decided the answer.
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1964,6 +1968,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   local claimed = {}
   local defaulted = {}
+  local sources = {}
   local fields = {}
 
   -- Three passes, because `pairs` yields descriptors in no particular order.
@@ -1977,6 +1982,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
       path = base_path and (base_path .. '.' .. field) or field,
     }
     claimed[field] = true
+    sources[field] = field
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
@@ -1996,6 +2002,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
         claimed[alias] = true
+        sources[alias] = field
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
           claimed[alias_key] = true
@@ -2074,7 +2081,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     end
   end
 
-  return merged, defaulted
+  return merged, defaulted, sources
 end
 
 --- Start a validation run.
@@ -2256,10 +2263,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
   end
 
   local declared = type(entry.attributes) == 'table'
+  local spellings
   if declared then
-    merged.attributes = _validate_map(kwargs or {}, entry.attributes, name, context, {
+    local attributes, _, resolved = _validate_map(kwargs or {}, entry.attributes, name, context, {
       unknown = options.unknown or 'warn',
     })
+    merged.attributes = attributes
+    spellings = resolved
   end
 
   if type(entry.required) == 'table' then
@@ -2271,9 +2281,11 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- missing either: `_validate_map` moves its value to the field that
     -- declares the alias and clears the alias spelling, the same way it
     -- clears a deprecated key, so look for the value under that field. The
-    -- match goes through `_lookup`, the same as every other name comparison
-    -- in this module, so a hyphen in one spelling and an underscore in the
-    -- other still match.
+    -- merge reports which declared name each spelling resolves to, so that
+    -- is one lookup rather than a second walk over the descriptors. It goes
+    -- through `_lookup`, the same as every other name comparison in this
+    -- module, so a hyphen in one spelling and an underscore in the other
+    -- still match.
     --
     -- This asks what the shortcode receives, not what the author wrote, so
     -- a `default` present in `merged.attributes` satisfies a name here.
@@ -2282,22 +2294,18 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- supplied. Neither reading is a bug: they answer different questions
     -- about the same instance.
     local function _required_satisfied(required)
-      if _lookup(merged.attributes, required) ~= nil then
+      local field = required
+      if spellings then
+        local declared_name = _lookup(spellings, required)
+        if declared_name ~= nil then
+          field = declared_name
+        end
+      end
+      if _lookup(merged.attributes, field) ~= nil then
         return true
       end
       if not declared then
         return _lookup(kwargs or {}, required) ~= nil
-      end
-      for field, spec in pairs(entry.attributes) do
-        if type(spec) == 'table' and type(spec.aliases) == 'table' then
-          local spellings = {}
-          for _, alias in ipairs(spec.aliases) do
-            spellings[alias] = true
-          end
-          if _lookup(spellings, required) ~= nil and _lookup(merged.attributes, field) ~= nil then
-            return true
-          end
-        end
       end
       return false
     end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1960,15 +1960,22 @@ end
 --- @param base_path string|nil Path prefix for findings
 --- @param context table Validation context
 local function _declare_spelling(sources, spelling, field, base_path, context)
-  local owner = sources[spelling]
-  if owner == nil then
-    sources[spelling] = field
-  elseif owner ~= field then
+  -- The owner is read through `_lookup`, like every other name comparison in
+  -- this module, so a contest between the hyphen and the underscore spelling
+  -- of one name is found as well. Those sit under different keys but reach the
+  -- same document key at merge time, so they contest just as directly.
+  local owner = _lookup(sources, spelling)
+  if owner ~= nil and owner ~= field then
     _report(context, 'warning', base_path and (base_path .. '.' .. spelling) or spelling,
       'aliases', string.format(
         'is declared by both "%s" and "%s"; which one accepts it is not defined.',
         owner, field))
   end
+  -- Stored under the literal spelling either way. The map is also the set of
+  -- keys a descriptor claimed, and a contested spelling is still claimed: the
+  -- schema is ambiguous, which the warning says, and treating the key as
+  -- undeclared on top of that would report it as unknown as well.
+  sources[spelling] = sources[spelling] or field
 end
 
 

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1982,7 +1982,15 @@ _validate_map = function(values, descriptors, base_path, context, options)
       spec = spec,
       path = base_path and (base_path .. '.' .. field) or field,
     }
-    sources[field] = field
+    -- Two writes with different weight. Declaring a spelling fills an empty
+    -- slot only, while claiming the value under one overwrites whatever was
+    -- there. Two descriptors can name the same spelling, when one declares as
+    -- an alias what another declares as its own name, and `pairs` yields them
+    -- in no particular order. The value itself lands under whichever
+    -- descriptor claimed it, so the claim is what the map has to follow: a
+    -- declaration that outranked it would send a reader to a field the merge
+    -- has already emptied.
+    sources[field] = sources[field] or field
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
@@ -2001,7 +2009,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        sources[alias] = field
+        sources[alias] = sources[alias] or field
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
           sources[alias_key] = field

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1957,6 +1957,8 @@ end
 ---   declared name it resolves to. A reader that has to answer a question
 ---   about a name the caller wrote asks this rather than walking the
 ---   descriptors again, because the merge has already decided the answer.
+---   It doubles as the set of keys a descriptor claimed, which is what the
+---   unknown key pass below reads.
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1966,7 +1968,6 @@ _validate_map = function(values, descriptors, base_path, context, options)
     merged[key] = value
   end
 
-  local claimed = {}
   local defaulted = {}
   local sources = {}
   local fields = {}
@@ -1981,7 +1982,6 @@ _validate_map = function(values, descriptors, base_path, context, options)
       spec = spec,
       path = base_path and (base_path .. '.' .. field) or field,
     }
-    claimed[field] = true
     sources[field] = field
 
     -- A value found under an alias, or under the other spelling, moves to the
@@ -1992,7 +1992,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     local found, found_key = _lookup(merged, field)
     if found ~= nil then
       merged[field] = found
-      claimed[found_key] = true
+      sources[found_key] = field
       supplied_key = found_key
       if found_key ~= field then
         merged[found_key] = nil
@@ -2001,11 +2001,10 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        claimed[alias] = true
         sources[alias] = field
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
-          claimed[alias_key] = true
+          sources[alias_key] = field
           if merged[field] == nil then
             merged[field] = aliased
             supplied_key = alias_key
@@ -2064,7 +2063,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   if unknown_policy ~= 'ignore' or options.additional then
     for key, value in pairs(values) do
-      if not claimed[key] then
+      if sources[key] == nil then
         local path = base_path and (base_path .. '.' .. tostring(key)) or tostring(key)
         if options.additional then
           local coerced = _coerce(value, options.additional.type)
@@ -2294,13 +2293,7 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- supplied. Neither reading is a bug: they answer different questions
     -- about the same instance.
     local function _required_satisfied(required)
-      local field = required
-      if spellings then
-        local declared_name = _lookup(spellings, required)
-        if declared_name ~= nil then
-          field = declared_name
-        end
-      end
+      local field = (spellings and _lookup(spellings, required)) or required
       if _lookup(merged.attributes, field) ~= nil then
         return true
       end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -1945,6 +1945,33 @@ local function _apply_deprecation(field, spec, value, merged)
   return message, cleared
 end
 
+--- Record that a descriptor accepts a spelling, and report a contested one.
+---
+--- Two descriptors can name the same spelling, when one declares as an alias
+--- what another declares as its own name, or when two of them declare the same
+--- alias. `pairs` yields descriptors in no particular order, so which field a
+--- contested spelling resolves to is not decidable from the schema. It is
+--- reported rather than resolved in silence, because the schema is what is
+--- wrong and only its author can settle it.
+---
+--- @param sources table Map of spelling to declared name
+--- @param spelling string The spelling being declared
+--- @param field string The declared name that accepts it
+--- @param base_path string|nil Path prefix for findings
+--- @param context table Validation context
+local function _declare_spelling(sources, spelling, field, base_path, context)
+  local owner = sources[spelling]
+  if owner == nil then
+    sources[spelling] = field
+  elseif owner ~= field then
+    _report(context, 'warning', base_path and (base_path .. '.' .. spelling) or spelling,
+      'aliases', string.format(
+        'is declared by both "%s" and "%s"; which one accepts it is not defined.',
+        owner, field))
+  end
+end
+
+
 --- Validate a map of values against a map of field descriptors.
 --- @param values table Values to validate
 --- @param descriptors table Field descriptor map
@@ -1984,13 +2011,10 @@ _validate_map = function(values, descriptors, base_path, context, options)
     }
     -- Two writes with different weight. Declaring a spelling fills an empty
     -- slot only, while claiming the value under one overwrites whatever was
-    -- there. Two descriptors can name the same spelling, when one declares as
-    -- an alias what another declares as its own name, and `pairs` yields them
-    -- in no particular order. The value itself lands under whichever
-    -- descriptor claimed it, so the claim is what the map has to follow: a
-    -- declaration that outranked it would send a reader to a field the merge
-    -- has already emptied.
-    sources[field] = sources[field] or field
+    -- there. The value lands under whichever descriptor claimed it, so the
+    -- claim is what the map has to follow: a declaration that outranked it
+    -- would send a reader to a field the merge has already emptied.
+    _declare_spelling(sources, field, field, base_path, context)
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
@@ -2009,7 +2033,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        sources[alias] = sources[alias] or field
+        _declare_spelling(sources, alias, field, base_path, context)
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
           sources[alias_key] = field

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1953,6 +1953,10 @@ end
 --- @param options table|nil {unknown = 'warn'|'error'|'ignore', additional = descriptor}
 --- @return table merged Values with aliases, coercion and defaults applied
 --- @return table defaulted Set of field names whose value came from `default`
+--- @return table sources Map of every spelling the schema accepts to the
+---   declared name it resolves to. A reader that has to answer a question
+---   about a name the caller wrote asks this rather than walking the
+---   descriptors again, because the merge has already decided the answer.
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1964,6 +1968,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   local claimed = {}
   local defaulted = {}
+  local sources = {}
   local fields = {}
 
   -- Three passes, because `pairs` yields descriptors in no particular order.
@@ -1977,6 +1982,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
       path = base_path and (base_path .. '.' .. field) or field,
     }
     claimed[field] = true
+    sources[field] = field
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
@@ -1996,6 +2002,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
         claimed[alias] = true
+        sources[alias] = field
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
           claimed[alias_key] = true
@@ -2074,7 +2081,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     end
   end
 
-  return merged, defaulted
+  return merged, defaulted, sources
 end
 
 --- Start a validation run.
@@ -2256,10 +2263,13 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
   end
 
   local declared = type(entry.attributes) == 'table'
+  local spellings
   if declared then
-    merged.attributes = _validate_map(kwargs or {}, entry.attributes, name, context, {
+    local attributes, _, resolved = _validate_map(kwargs or {}, entry.attributes, name, context, {
       unknown = options.unknown or 'warn',
     })
+    merged.attributes = attributes
+    spellings = resolved
   end
 
   if type(entry.required) == 'table' then
@@ -2271,9 +2281,11 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- missing either: `_validate_map` moves its value to the field that
     -- declares the alias and clears the alias spelling, the same way it
     -- clears a deprecated key, so look for the value under that field. The
-    -- match goes through `_lookup`, the same as every other name comparison
-    -- in this module, so a hyphen in one spelling and an underscore in the
-    -- other still match.
+    -- merge reports which declared name each spelling resolves to, so that
+    -- is one lookup rather than a second walk over the descriptors. It goes
+    -- through `_lookup`, the same as every other name comparison in this
+    -- module, so a hyphen in one spelling and an underscore in the other
+    -- still match.
     --
     -- This asks what the shortcode receives, not what the author wrote, so
     -- a `default` present in `merged.attributes` satisfies a name here.
@@ -2282,22 +2294,18 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- supplied. Neither reading is a bug: they answer different questions
     -- about the same instance.
     local function _required_satisfied(required)
-      if _lookup(merged.attributes, required) ~= nil then
+      local field = required
+      if spellings then
+        local declared_name = _lookup(spellings, required)
+        if declared_name ~= nil then
+          field = declared_name
+        end
+      end
+      if _lookup(merged.attributes, field) ~= nil then
         return true
       end
       if not declared then
         return _lookup(kwargs or {}, required) ~= nil
-      end
-      for field, spec in pairs(entry.attributes) do
-        if type(spec) == 'table' and type(spec.aliases) == 'table' then
-          local spellings = {}
-          for _, alias in ipairs(spec.aliases) do
-            spellings[alias] = true
-          end
-          if _lookup(spellings, required) ~= nil and _lookup(merged.attributes, field) ~= nil then
-            return true
-          end
-        end
       end
       return false
     end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1960,15 +1960,22 @@ end
 --- @param base_path string|nil Path prefix for findings
 --- @param context table Validation context
 local function _declare_spelling(sources, spelling, field, base_path, context)
-  local owner = sources[spelling]
-  if owner == nil then
-    sources[spelling] = field
-  elseif owner ~= field then
+  -- The owner is read through `_lookup`, like every other name comparison in
+  -- this module, so a contest between the hyphen and the underscore spelling
+  -- of one name is found as well. Those sit under different keys but reach the
+  -- same document key at merge time, so they contest just as directly.
+  local owner = _lookup(sources, spelling)
+  if owner ~= nil and owner ~= field then
     _report(context, 'warning', base_path and (base_path .. '.' .. spelling) or spelling,
       'aliases', string.format(
         'is declared by both "%s" and "%s"; which one accepts it is not defined.',
         owner, field))
   end
+  -- Stored under the literal spelling either way. The map is also the set of
+  -- keys a descriptor claimed, and a contested spelling is still claimed: the
+  -- schema is ambiguous, which the warning says, and treating the key as
+  -- undeclared on top of that would report it as unknown as well.
+  sources[spelling] = sources[spelling] or field
 end
 
 

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1982,7 +1982,15 @@ _validate_map = function(values, descriptors, base_path, context, options)
       spec = spec,
       path = base_path and (base_path .. '.' .. field) or field,
     }
-    sources[field] = field
+    -- Two writes with different weight. Declaring a spelling fills an empty
+    -- slot only, while claiming the value under one overwrites whatever was
+    -- there. Two descriptors can name the same spelling, when one declares as
+    -- an alias what another declares as its own name, and `pairs` yields them
+    -- in no particular order. The value itself lands under whichever
+    -- descriptor claimed it, so the claim is what the map has to follow: a
+    -- declaration that outranked it would send a reader to a field the merge
+    -- has already emptied.
+    sources[field] = sources[field] or field
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
@@ -2001,7 +2009,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        sources[alias] = field
+        sources[alias] = sources[alias] or field
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
           sources[alias_key] = field

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1957,6 +1957,8 @@ end
 ---   declared name it resolves to. A reader that has to answer a question
 ---   about a name the caller wrote asks this rather than walking the
 ---   descriptors again, because the merge has already decided the answer.
+---   It doubles as the set of keys a descriptor claimed, which is what the
+---   unknown key pass below reads.
 _validate_map = function(values, descriptors, base_path, context, options)
   options = options or {}
   local unknown_policy = options.unknown or 'ignore'
@@ -1966,7 +1968,6 @@ _validate_map = function(values, descriptors, base_path, context, options)
     merged[key] = value
   end
 
-  local claimed = {}
   local defaulted = {}
   local sources = {}
   local fields = {}
@@ -1981,7 +1982,6 @@ _validate_map = function(values, descriptors, base_path, context, options)
       spec = spec,
       path = base_path and (base_path .. '.' .. field) or field,
     }
-    claimed[field] = true
     sources[field] = field
 
     -- A value found under an alias, or under the other spelling, moves to the
@@ -1992,7 +1992,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
     local found, found_key = _lookup(merged, field)
     if found ~= nil then
       merged[field] = found
-      claimed[found_key] = true
+      sources[found_key] = field
       supplied_key = found_key
       if found_key ~= field then
         merged[found_key] = nil
@@ -2001,11 +2001,10 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        claimed[alias] = true
         sources[alias] = field
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
-          claimed[alias_key] = true
+          sources[alias_key] = field
           if merged[field] == nil then
             merged[field] = aliased
             supplied_key = alias_key
@@ -2064,7 +2063,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
   if unknown_policy ~= 'ignore' or options.additional then
     for key, value in pairs(values) do
-      if not claimed[key] then
+      if sources[key] == nil then
         local path = base_path and (base_path .. '.' .. tostring(key)) or tostring(key)
         if options.additional then
           local coerced = _coerce(value, options.additional.type)
@@ -2294,13 +2293,7 @@ function M.validate_shortcode(name, args, kwargs, entry, options)
     -- supplied. Neither reading is a bug: they answer different questions
     -- about the same instance.
     local function _required_satisfied(required)
-      local field = required
-      if spellings then
-        local declared_name = _lookup(spellings, required)
-        if declared_name ~= nil then
-          field = declared_name
-        end
-      end
+      local field = (spellings and _lookup(spellings, required)) or required
       if _lookup(merged.attributes, field) ~= nil then
         return true
       end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -1945,6 +1945,33 @@ local function _apply_deprecation(field, spec, value, merged)
   return message, cleared
 end
 
+--- Record that a descriptor accepts a spelling, and report a contested one.
+---
+--- Two descriptors can name the same spelling, when one declares as an alias
+--- what another declares as its own name, or when two of them declare the same
+--- alias. `pairs` yields descriptors in no particular order, so which field a
+--- contested spelling resolves to is not decidable from the schema. It is
+--- reported rather than resolved in silence, because the schema is what is
+--- wrong and only its author can settle it.
+---
+--- @param sources table Map of spelling to declared name
+--- @param spelling string The spelling being declared
+--- @param field string The declared name that accepts it
+--- @param base_path string|nil Path prefix for findings
+--- @param context table Validation context
+local function _declare_spelling(sources, spelling, field, base_path, context)
+  local owner = sources[spelling]
+  if owner == nil then
+    sources[spelling] = field
+  elseif owner ~= field then
+    _report(context, 'warning', base_path and (base_path .. '.' .. spelling) or spelling,
+      'aliases', string.format(
+        'is declared by both "%s" and "%s"; which one accepts it is not defined.',
+        owner, field))
+  end
+end
+
+
 --- Validate a map of values against a map of field descriptors.
 --- @param values table Values to validate
 --- @param descriptors table Field descriptor map
@@ -1984,13 +2011,10 @@ _validate_map = function(values, descriptors, base_path, context, options)
     }
     -- Two writes with different weight. Declaring a spelling fills an empty
     -- slot only, while claiming the value under one overwrites whatever was
-    -- there. Two descriptors can name the same spelling, when one declares as
-    -- an alias what another declares as its own name, and `pairs` yields them
-    -- in no particular order. The value itself lands under whichever
-    -- descriptor claimed it, so the claim is what the map has to follow: a
-    -- declaration that outranked it would send a reader to a field the merge
-    -- has already emptied.
-    sources[field] = sources[field] or field
+    -- there. The value lands under whichever descriptor claimed it, so the
+    -- claim is what the map has to follow: a declaration that outranked it
+    -- would send a reader to a field the merge has already emptied.
+    _declare_spelling(sources, field, field, base_path, context)
 
     -- A value found under an alias, or under the other spelling, moves to the
     -- name the schema declares. The key it came from is removed, so `merged`
@@ -2009,7 +2033,7 @@ _validate_map = function(values, descriptors, base_path, context, options)
 
     if type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        sources[alias] = sources[alias] or field
+        _declare_spelling(sources, alias, field, base_path, context)
         local aliased, alias_key = _lookup(merged, alias)
         if aliased ~= nil then
           sources[alias_key] = field

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1116,6 +1116,26 @@ shortcodes:
   assert_contains(warnings, 'is declared by both')
 end)
 
+test('a contest between the two spellings of one name is reported', function()
+  -- `line_width` and `line-width` sit under different keys, so a raw index
+  -- would see no contest. They reach the same document key at merge time,
+  -- because every name in this module resolves through both spellings, so
+  -- they contest as directly as an exact match does.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      line_width:
+        type: string
+      stroke:
+        type: string
+        aliases:
+          - line-width
+]])
+  local _, _, warnings = schema.validate_shortcode('demo', {}, {}, loaded.shortcodes.demo)
+  assert_contains(warnings, 'is declared by both')
+end)
+
 test('S7: validate_attributes checks declared keys and ignores the rest', function()
   local loaded = load_schema([[
 attributes:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1068,6 +1068,31 @@ shortcodes:
   assert_contains(errors, 'legacy-name')
 end)
 
+test('a required name follows the value when another attribute claims it', function()
+  -- Two attributes name the same spelling: `colour` is declared, and `shade`
+  -- lists `colour` among its aliases. Whichever order `pairs` yields them in,
+  -- `shade` claims the supplied value and the merge empties `colour`, so a
+  -- required `colour` has to resolve to `shade` to find it. A spelling map
+  -- that let the declaration outrank the claim would send the check to the
+  -- field the merge had just emptied and report a supplied value as missing.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      colour:
+        type: string
+      shade:
+        type: string
+        aliases:
+          - colour
+    required:
+      - colour
+]])
+  local valid, errors = schema.validate_shortcode(
+    'demo', {}, { colour = 'red' }, loaded.shortcodes.demo)
+  assert_valid(valid, errors)
+end)
+
 test('S7: validate_attributes checks declared keys and ignores the rest', function()
   local loaded = load_schema([[
 attributes:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1088,9 +1088,32 @@ shortcodes:
     required:
       - colour
 ]])
-  local valid, errors = schema.validate_shortcode(
+  local valid, errors, warnings = schema.validate_shortcode(
     'demo', {}, { colour = 'red' }, loaded.shortcodes.demo)
   assert_valid(valid, errors)
+  -- The schema is what is wrong here, so the author is told. Which of the two
+  -- accepts the spelling is not decidable from the schema, and resolving it in
+  -- silence would hide that.
+  assert_contains(warnings, 'is declared by both')
+  assert_contains(warnings, 'colour')
+end)
+
+test('a spelling declared by two attributes with no value is reported', function()
+  -- The same contested schema with nothing supplied. The warning does not
+  -- depend on a value arriving, because the schema is ambiguous either way.
+  local loaded = load_schema([[
+shortcodes:
+  demo:
+    attributes:
+      colour:
+        type: string
+      shade:
+        type: string
+        aliases:
+          - colour
+]])
+  local _, _, warnings = schema.validate_shortcode('demo', {}, {}, loaded.shortcodes.demo)
+  assert_contains(warnings, 'is declared by both')
 end)
 
 test('S7: validate_attributes checks declared keys and ignores the rest', function()


### PR DESCRIPTION
`_validate_map` resolves a declared alias to the field that declares it and clears the alias spelling from the merged table. The shortcode `required` check then re-derived that mapping by walking the descriptors for each field's `aliases` list, which duplicated matching the merge already owned and gave two places to keep in step.

The merge now reports it. `_validate_map` returns a third value mapping every spelling the schema accepts to the declared name it resolves to, and `_required_satisfied` resolves through it in one lookup. The descriptor walk is gone. `_validate_map` is a local, so the wider return is invisible to its other four callers: Lua drops returns nobody captures, and nothing in the exported surface moves.

The same map replaces the `claimed` set, which recorded the same spellings for the unknown key pass, so the module carries one bookkeeping table rather than two.

Two corrections came out of building it, and both are behaviour a schema author can see.

A spelling resolves to the field that claimed the value, not to the field that declared the name. Where one attribute declares as an alias what another declares as its own name, the merge moves the value under the claiming field and empties the other, in either iteration order. A map that followed the declaration would have sent the check to the field the merge had just emptied and reported a supplied value as missing.

A spelling that two attributes both declare is now reported. Which of them accepts it is not decidable from the schema, and it was being settled by table iteration order. The author is told instead. The contest is detected through `_lookup`, so the hyphen and the underscore spelling of one name contest each other as directly as an exact match does.

Locally: the Lua suite at 108 passing with the conformance sweep clean over 4 schema files and 97 descriptors, the schema workspace at 235, the root suite at 1181, and `docs/assets/schema/v2/schema.lua` rebuilt and byte for byte the source.