### PR TITLE
build: attach the schema validator as a plain release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,10 @@ jobs:
           npm pack
           mv quarto-wizard-schema-*.tgz "${GITHUB_WORKSPACE}/"
 
+      - name: Copy schema validator asset
+        shell: bash
+        run: cp packages/schema/src/validation/schema.lua "${GITHUB_WORKSPACE}/schema.lua"
+
       - name: Package snippets library
         shell: bash
         run: |
@@ -265,6 +269,7 @@ jobs:
             ${{ github.workspace }}/quarto-wizard-core-${{ env.VERSION }}.tgz
             ${{ github.workspace }}/quarto-wizard-schema-${{ env.VERSION }}.tgz
             ${{ github.workspace }}/quarto-wizard-snippets-${{ env.VERSION }}.tgz
+            ${{ github.workspace }}/schema.lua
 
       - name: Upload release bundle
         uses: actions/upload-artifact@v7
@@ -275,6 +280,7 @@ jobs:
             quarto-wizard-core-${{ env.VERSION }}.tgz
             quarto-wizard-schema-${{ env.VERSION }}.tgz
             quarto-wizard-snippets-${{ env.VERSION }}.tgz
+            schema.lua
             CHANGELOG-${{ env.VERSION }}.md
           if-no-files-found: error
           retention-days: 30
@@ -316,6 +322,7 @@ jobs:
             "./quarto-wizard-core-${VERSION}.tgz#Quarto Wizard Core (tgz)"
             "./quarto-wizard-schema-${VERSION}.tgz#Quarto Wizard Schema (tgz)"
             "./quarto-wizard-snippets-${VERSION}.tgz#Quarto Wizard Snippets (tgz)"
+            "./schema.lua#Quarto Wizard Schema Validator (lua)"
           )
 
           if gh release view "${VERSION}" >/dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- feat: Attach the Lua reference validator to each release as a plain asset. An extension can now pin it to a release rather than to a repository path that a refactor can move. (#418)
+
 ## 3.4.0 (2026-09-04)
 
 ### New Features


### PR DESCRIPTION
The release already publishes a schema tarball.
This attaches `packages/schema/src/validation/schema.lua` beside it as a plain asset, so a consumer can fetch the Lua reference validator from a release rather than from a raw repository path.

The reason is durability rather than convenience.
A raw path depends on `packages/schema/src/validation/` staying where it is, which a refactor can move with no release note, and about forty extension manifests currently pin that path.
A release asset cannot move under them.

The file is copied in the same step that builds the other assets and is added to both the release file list and the upload artifact, so a release either carries all of them or fails.

Verified locally: `actionlint` reports the same seventeen findings on this branch as on `main`, all pre-existing and none in the seven lines added here.

The catalogue is not repointed in this branch.
An earlier attempt to point it at an asset that no published release carried broke `init` for every repository, so the catalogue moves only once a release exists that carries the file.
