### PR TITLE
feat: show the Typst preview on more than one surface

### DIFF
--- a/docs/getting-started/typst-preview.qmd
+++ b/docs/getting-started/typst-preview.qmd
@@ -7,20 +7,22 @@ The preview uses the Typst binary that ships inside Quarto, so it needs no other
 
 ## Where the Preview Appears
 
-`quartoWizard.typstPreview.surface` selects the surface.
+`quartoWizard.typstPreview.surface` is a list of surfaces.
+Name one or both to show them at the same time.
 
 - `panel` shows the image in a panel beside the editor.
   The panel follows the cursor while it is open, and it scrolls, so a tall image is never cut.
 - `hover` shows the image when the pointer rests on a block.
   A hover cannot scroll, so the image is scaled down to `quartoWizard.typstPreview.maxHeight`.
-- `off` shows no image, and offers no code lens.
+
+An empty list shows no image, and offers no code lens.
 
 There is no preview inside the text of the document.
 The editor gives an extension no way to make a line taller.
 An image drawn after a block covers the lines below it.
 
-**Quarto Wizard: Preview Typst Block** opens the panel whatever the surface is.
-The one exception is `off`, where the command names the setting instead of opening anything.
+**Quarto Wizard: Preview Typst Block** opens the panel whatever the list holds.
+The one exception is an empty list, where the command names the setting instead of opening anything.
 
 ## The Authoring Loop
 

--- a/docs/reference/configuration.qmd
+++ b/docs/reference/configuration.qmd
@@ -232,17 +232,16 @@ The greatest height of the image a hover shows, in the points Typst writes into 
 
 **Setting**: `quartoWizard.typstPreview.surface`
 
-Where the Typst block preview is shown. All three block kinds compile to an image, so every kind works on every surface. The **Quarto Wizard: Preview Typst Block** command opens the panel whatever the value, except `off`, which turns the whole feature off. There is no surface that draws the image inside the document, because the editor does not let an extension change the height of a line.
+Where the Typst block preview is shown. Name both surfaces to have both. An empty list turns the whole feature off. All three block kinds compile to an image, so every kind works on every surface. The **Quarto Wizard: Preview Typst Block** command opens the panel whatever the list holds, unless it is empty. There is no surface that draws the image inside the document, because the editor does not let an extension change the height of a line.
 
 | Value   | Description                                                                                       |
 | ------- | ------------------------------------------------------------------------------------------------- |
 | `panel` | Show the image in a panel beside the editor, which follows the cursor while it is open (default). |
 | `hover` | Show the image when the pointer rests on a block.                                                 |
-| `off`   | Show no image, and offer no code lens.                                                            |
 
 ```json
 {
-  "quartoWizard.typstPreview.surface": "panel"
+  "quartoWizard.typstPreview.surface": ["panel"]
 }
 ```
 
@@ -250,7 +249,7 @@ Where the Typst block preview is shown. All three block kinds compile to an imag
 
 **Setting**: `quartoWizard.typstPreview.codeLens`
 
-Show a code lens above every Typst block, offering to preview it. Turn it off to keep the editor clear: a document of many examples carries one lens per block. The lens is never shown when `#quartoWizard.typstPreview.surface#` is `off`.
+Show a code lens above every Typst block, offering to preview it. Turn it off to keep the editor clear: a document of many examples carries one lens per block. The lens is never shown when `#quartoWizard.typstPreview.surface#` is empty.
 
 | Property | Value   |
 | -------- | ------- |
@@ -291,7 +290,7 @@ Here is an example `settings.json` with all Quarto Wizard settings:
   "quartoWizard.typstPreview.timeoutMs": 20000,
   "quartoWizard.typstPreview.debounceMs": 300,
   "quartoWizard.typstPreview.maxHeight": 200,
-  "quartoWizard.typstPreview.surface": "panel",
+  "quartoWizard.typstPreview.surface": ["panel"],
   "quartoWizard.typstPreview.codeLens": true
 }
 ```

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -47,7 +47,7 @@ See [Configuration Reference](configuration.qmd) for all available options.
 | `quartoWizard.typstPreview.timeoutMs`  | `20000`                                    | Time limit for one preview compile.                   |
 | `quartoWizard.typstPreview.debounceMs` | `300`                                      | Delay between an edit and the next preview compile.   |
 | `quartoWizard.typstPreview.maxHeight`  | `200`                                      | Greatest image height for a hover.                    |
-| `quartoWizard.typstPreview.surface`    | `panel`                                    | Where a previewed block is shown.                     |
+| `quartoWizard.typstPreview.surface`    | `["panel"]`                                | Where a previewed block is shown.                     |
 | `quartoWizard.typstPreview.codeLens`   | `true`                                     | Offer a preview above every Typst block.              |
 
 ## Extension Schema

--- a/package.json
+++ b/package.json
@@ -834,19 +834,23 @@
 				"quartoWizard.typstPreview.surface": {
 					"order": 25,
 					"scope": "resource",
-					"type": "string",
-					"enum": [
-						"panel",
-						"hover",
-						"off"
+					"type": "array",
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"enum": [
+							"panel",
+							"hover"
+						],
+						"enumDescriptions": [
+							"Show the image in a panel beside the editor, which follows the cursor while it is open.",
+							"Show the image when the pointer rests on a block."
+						]
+					},
+					"default": [
+						"panel"
 					],
-					"enumDescriptions": [
-						"Show the image in a panel beside the editor, which follows the cursor while it is open.",
-						"Show the image when the pointer rests on a block.",
-						"Show no image, and offer no code lens."
-					],
-					"default": "panel",
-					"markdownDescription": "Where the Typst block preview is shown. All three block kinds compile to an image, so every kind works on every surface. The **Quarto Wizard: Preview Typst Block** command opens the panel whatever the value, except `off`, which turns the whole feature off. There is no surface that draws the image inside the document, because the editor does not let an extension change the height of a line.",
+					"markdownDescription": "Where the Typst block preview is shown. Name both surfaces to have both. An empty list turns the whole feature off. All three block kinds compile to an image, so every kind works on every surface. The **Quarto Wizard: Preview Typst Block** command opens the panel whatever the list holds, unless it is empty. There is no surface that draws the image inside the document, because the editor does not let an extension change the height of a line.",
 					"title": "Preview Surface",
 					"description": "Where a previewed block is shown."
 				},
@@ -855,7 +859,7 @@
 					"scope": "resource",
 					"type": "boolean",
 					"default": true,
-					"markdownDescription": "Show a code lens above every Typst block, offering to preview it. Turn it off to keep the editor clear: a document of many examples carries one lens per block. The lens is never shown when `#quartoWizard.typstPreview.surface#` is `off`.",
+					"markdownDescription": "Show a code lens above every Typst block, offering to preview it. Turn it off to keep the editor clear: a document of many examples carries one lens per block. The lens is never shown when `#quartoWizard.typstPreview.surface#` is empty.",
 					"title": "Preview Code Lens",
 					"description": "Offer a preview above every Typst block."
 				}

--- a/scripts/process-api-docs.mjs
+++ b/scripts/process-api-docs.mjs
@@ -709,12 +709,12 @@ function generateSettingQuickDesc(prop) {
 /**
  * Generate a description for an enum value.
  * @param {string|boolean} value - Enum value.
- * @param {string|boolean} defaultValue - Default value.
+ * @param {string|boolean|Array<string>} defaultValue - Default value, an array for an array-typed property.
  * @param {string} description - Description from enumDescriptions.
  * @returns {string} Description.
  */
 function generateEnumDescription(value, defaultValue, description) {
-	const isDefault = value === defaultValue;
+	const isDefault = Array.isArray(defaultValue) ? defaultValue.includes(value) : value === defaultValue;
 	const defaultSuffix = isDefault ? " (default)." : ".";
 	const text = description ? description.replace(/\.$/, "") : capitalise(String(value));
 	return text + defaultSuffix;
@@ -809,6 +809,14 @@ function generateConfigurationPage(pkg) {
 					sectionLines.push(`| \`${value}\` | ${valueDesc} |`);
 				}
 				sectionLines.push("");
+			} else if (prop.type === "array" && prop.items?.enum) {
+				sectionLines.push("| Value | Description |", "|-------|-------------|");
+				for (let i = 0; i < prop.items.enum.length; i++) {
+					const value = prop.items.enum[i];
+					const valueDesc = generateEnumDescription(value, prop.default, prop.items.enumDescriptions?.[i]);
+					sectionLines.push(`| \`${value}\` | ${valueDesc} |`);
+				}
+				sectionLines.push("");
 			} else if (prop.type === "number") {
 				sectionLines.push("| Property | Value |", "|----------|-------|");
 				sectionLines.push(`| Type | Number |`);
@@ -881,8 +889,12 @@ function generateReferenceIndex(pkg) {
 	const configLines = ["| Setting | Default | Description |", "|---------|---------|-------------|"];
 	const sortedProps = Object.entries(properties).sort(([, a], [, b]) => (a.order || 99) - (b.order || 99));
 	for (const [key, prop] of sortedProps) {
+		// An array default is rendered as JSON, so `["panel"]` reads as the list it
+		// is rather than as the bare word a template literal would flatten it to.
 		const defaultVal =
-			key === "quartoWizard.registry.url" ? "[see docs](configuration.qmd#registry-url)" : `\`${prop.default}\``;
+			key === "quartoWizard.registry.url"
+				? "[see docs](configuration.qmd#registry-url)"
+				: `\`${Array.isArray(prop.default) ? JSON.stringify(prop.default) : prop.default}\``;
 		configLines.push(`| \`${key}\` | ${defaultVal} | ${generateSettingQuickDesc(prop)} |`);
 	}
 

--- a/src/providers/typstPreview/typstPreviewCodeLens.ts
+++ b/src/providers/typstPreview/typstPreviewCodeLens.ts
@@ -83,7 +83,7 @@ export class TypstPreviewCodeLens implements vscode.CodeLensProvider, vscode.Dis
 	/** Whether this document asks for a lens above each of its Typst blocks. */
 	private wanted(document: vscode.TextDocument): boolean {
 		const settings = this.settingsOf(document);
-		return settings.surface !== "off" && settings.codeLens;
+		return settings.surfaces.size > 0 && settings.codeLens;
 	}
 
 	provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -14,7 +14,7 @@ import { commandKey, type TypstCommand } from "../../utils/typst/typstCli";
 import { EXTENSION_MANIFEST_GLOB } from "../../utils/quartoProjectDiscovery";
 import { buildCompileRequest, NO_BLOCK_MESSAGE, TypstContextCache, type CompileRequest } from "./typstContext";
 import { TypstCompiler, invalidateTypstBinary, resolveTypstBinary, type TypstCompileResult } from "./typstCompiler";
-import { compileSettings, documentDelayOf, surfaceOf } from "./typstPreviewSettings";
+import { compileSettings, documentDelayOf, surfacesOf } from "./typstPreviewSettings";
 
 /**
  * The one owner of the preview state.
@@ -607,7 +607,7 @@ export class TypstPreviewController implements vscode.Disposable {
 			return undefined;
 		}
 
-		if (surfaceOf(document) === "off") {
+		if (surfacesOf(document).size === 0) {
 			// Asked here rather than in each surface, because a surface that renders
 			// nothing is not the same as a document that wants nothing compiled: with
 			// the gate in the surfaces alone, an open panel went on spawning Typst for
@@ -615,7 +615,8 @@ export class TypstPreviewController implements vscode.Disposable {
 			//
 			// Naming the setting is what makes it recoverable, and only a reader who
 			// asked hears it: an edit in such a folder is not a question.
-			const message = "The Typst preview is off. Set `quartoWizard.typstPreview.surface` to show a preview.";
+			const message =
+				"The Typst preview is off. Add a surface to `quartoWizard.typstPreview.surface` to show a preview.";
 			logMessage(`Typst preview: ${message}`, "debug");
 			// A surface open when the setting changed would otherwise hold the last
 			// image for good: nothing recompiles it, and nothing said it had stopped

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -47,7 +47,7 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		token: vscode.CancellationToken,
 	): Promise<vscode.Hover | undefined> {
 		const settings = this.settingsOf(document);
-		if (settings.surface !== "hover" || token.isCancellationRequested) {
+		if (!settings.surfaces.has("hover") || token.isCancellationRequested) {
 			return undefined;
 		}
 		const blocks = this.controller.blocksOf(document);

--- a/src/providers/typstPreview/typstPreviewSettings.ts
+++ b/src/providers/typstPreview/typstPreviewSettings.ts
@@ -19,22 +19,24 @@ const SECTION = "quartoWizard.typstPreview";
 /**
  * Where a preview is shown.
  *
- * There is no surface that draws inside the document. An image after the block
+ * A list and not one value, because the panel and the hover answer different
+ * questions: the panel follows the cursor and stays, and the hover costs
+ * nothing until the pointer rests. A reader can want both at once.
+ *
+ * There is no surface that draws inside the document. An image after a fence
  * would have to grow the height of its line, and the editor takes line height
  * from `IModelDecorationOptions.lineHeight`, which the extension API does not
- * expose at any version. A decoration attachment is laid out inside a line of
- * fixed height, so a tall one paints over the lines below it rather than moving
- * them. The API that would do it is `createWebviewTextEditorInset`, proposed in
- * microsoft/vscode#85682, on the backlog since 2019 and refused to a published
- * extension at run time.
+ * expose at any version.
  */
-const SURFACES = ["panel", "hover", "off"] as const;
+const SURFACES = ["panel", "hover"] as const;
 
 /** Derived from the list, so the two cannot drift apart in silence. */
 export type TypstPreviewSurface = (typeof SURFACES)[number];
 
+/** The list `package.json` declares as its default. */
+const DEFAULT_SURFACES: readonly TypstPreviewSurface[] = ["panel"];
+
 /** The defaults and bounds `package.json` declares, which it cannot enforce. */
-const DEFAULT_SURFACE: TypstPreviewSurface = "panel";
 const DEFAULT_MAX_HEIGHT = 200;
 const MIN_MAX_HEIGHT = 20;
 const MAX_MAX_HEIGHT = 4000;
@@ -59,14 +61,36 @@ function boundedNumber(value: unknown, fallback: number, lowest: number, highest
 }
 
 /**
- * A usable surface, whatever the setting holds.
+ * A usable set of surfaces, whatever the setting holds.
  *
- * Exported for its tests. `package.json` declares the enum, a hand-edited
- * `settings.json` ignores it, and a settings file written against an older
- * version can still name a surface that no longer exists.
+ * Exported for its tests. An empty set is the value that turns the feature off,
+ * so it is a real answer and never a fallback.
+ *
+ * A string is read as well as a list. `package.json` declares an array, a
+ * hand-edited `settings.json` ignores that, and a settings file written against
+ * an older version of this extension holds one of the strings the setting used
+ * to take. `off` is the one that still means something, and it means the empty
+ * set.
  */
-export function previewSurface(value: unknown): TypstPreviewSurface {
-	return SURFACES.includes(value as TypstPreviewSurface) ? (value as TypstPreviewSurface) : DEFAULT_SURFACE;
+export function previewSurfaces(value: unknown): ReadonlySet<TypstPreviewSurface> {
+	if (typeof value === "string") {
+		return value === "off" ? new Set() : new Set(known([value]));
+	}
+	if (!Array.isArray(value)) {
+		return new Set(DEFAULT_SURFACES);
+	}
+	return new Set(known(value));
+}
+
+/** The members of a list this version knows, or the default when it knows none. */
+function known(value: readonly unknown[]): readonly TypstPreviewSurface[] {
+	const members = value.filter((entry): entry is TypstPreviewSurface =>
+		SURFACES.includes(entry as TypstPreviewSurface),
+	);
+	// An empty input is off, and an input of members this version does not know
+	// is a settings file from another version, which falls back rather than
+	// turning the feature off in silence.
+	return members.length === 0 && value.length > 0 ? DEFAULT_SURFACES : members;
 }
 
 /**
@@ -125,7 +149,7 @@ export function previewCodeLens(value: unknown): boolean {
 
 /** What a surface asks about the document it is rendering. */
 export interface TypstSurfaceSettings {
-	surface: TypstPreviewSurface;
+	surfaces: ReadonlySet<TypstPreviewSurface>;
 	maxHeight: number;
 	codeLens: boolean;
 }
@@ -140,20 +164,20 @@ export interface TypstSurfaceSettings {
 export function surfaceSettings(document: vscode.TextDocument): TypstSurfaceSettings {
 	const config = section(document);
 	return {
-		surface: previewSurface(config.get("surface")),
+		surfaces: previewSurfaces(config.get("surface")),
 		maxHeight: previewMaxHeight(config.get<number>("maxHeight", DEFAULT_MAX_HEIGHT)),
 		codeLens: previewCodeLens(config.get("codeLens")),
 	};
 }
 
 /**
- * The surface one document asks for.
+ * The surfaces one document asks for.
  *
  * Takes an optional document because the active editor is what decides whether
  * a hover is offered at all, and there may not be one.
  */
-export function surfaceOf(document: vscode.TextDocument | undefined): TypstPreviewSurface {
-	return previewSurface(section(document).get("surface"));
+export function surfacesOf(document: vscode.TextDocument | undefined): ReadonlySet<TypstPreviewSurface> {
+	return previewSurfaces(section(document).get("surface"));
 }
 
 /** What compiling one document needs. */

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -7,7 +7,7 @@ import { TypstPreviewHover } from "../../providers/typstPreview/typstPreviewHove
 import {
 	previewCodeLens,
 	previewMaxHeight,
-	previewSurface,
+	previewSurfaces,
 	type TypstPreviewSurface,
 	type TypstSurfaceSettings,
 } from "../../providers/typstPreview/typstPreviewSettings";
@@ -92,8 +92,12 @@ function nextResultFor(
 }
 
 /** Settings that answer the same way for every document. */
-function fixedSettings(surface: TypstPreviewSurface, maxHeight = 200, codeLens = true): () => TypstSurfaceSettings {
-	return () => ({ surface, maxHeight, codeLens });
+function fixedSettings(
+	surfaces: readonly TypstPreviewSurface[],
+	maxHeight = 200,
+	codeLens = true,
+): () => TypstSurfaceSettings {
+	return () => ({ surfaces: new Set(surfaces), maxHeight, codeLens });
 }
 
 const NO_CANCEL = new vscode.CancellationTokenSource().token;
@@ -111,13 +115,20 @@ function hoverText(hover: vscode.Hover | undefined): string {
 
 suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should hold a surface setting inside the values it declares", () => {
-		assert.strictEqual(previewSurface("hover"), "hover");
-		assert.strictEqual(previewSurface("off"), "off");
-		// `inline` was a value once and cannot render without an editor API that
-		// VS Code does not expose, so a settings file still holding it falls back.
-		assert.strictEqual(previewSurface("inline"), "panel");
-		assert.strictEqual(previewSurface("everywhere"), "panel");
-		assert.strictEqual(previewSurface(undefined), "panel");
+		assert.deepStrictEqual([...previewSurfaces(["panel", "hover"])], ["panel", "hover"]);
+		assert.deepStrictEqual([...previewSurfaces(["hover"])], ["hover"]);
+		// An empty list is the value that turns the feature off, and it replaces the
+		// enum value `off` that the setting held before.
+		assert.deepStrictEqual([...previewSurfaces([])], []);
+		// A member the extension does not know is dropped, and the rest is kept.
+		assert.deepStrictEqual([...previewSurfaces(["hover", "everywhere"])], ["hover"]);
+		// A settings file written against an older version holds a string.
+		assert.deepStrictEqual([...previewSurfaces("hover")], ["hover"]);
+		assert.deepStrictEqual([...previewSurfaces("off")], []);
+		// `inline` was a value once and never rendered anything, so it falls back.
+		assert.deepStrictEqual([...previewSurfaces("inline")], ["panel"]);
+		assert.deepStrictEqual([...previewSurfaces(undefined)], ["panel"]);
+		assert.deepStrictEqual([...previewSurfaces(7)], ["panel"]);
 		assert.strictEqual(previewMaxHeight(0), 20);
 		assert.strictEqual(previewMaxHeight("tall"), 200);
 		assert.strictEqual(previewMaxHeight(500), 500);
@@ -130,7 +141,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 
 	test("Should offer one code lens per block, on its opening fence line", async () => {
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
-		const lens = new TypstPreviewCodeLens(controller, fixedSettings("panel"));
+		const lens = new TypstPreviewCodeLens(controller, fixedSettings(["panel"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const lenses = lens.provideCodeLenses(document, NO_CANCEL);
@@ -148,7 +159,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// The three fences look nearly identical and behave differently, so a title
 		// that reads the same on all of them would hide the difference that matters.
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
-		const lens = new TypstPreviewCodeLens(controller, fixedSettings("panel"));
+		const lens = new TypstPreviewCodeLens(controller, fixedSettings(["panel"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const titles = lens.provideCodeLenses(document, NO_CANCEL).map((one) => one.command?.title);
@@ -161,7 +172,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should carry the block it means in the command arguments", async () => {
 		// A lens previews its own block and not the one the cursor happens to be in.
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
-		const lens = new TypstPreviewCodeLens(controller, fixedSettings("panel"));
+		const lens = new TypstPreviewCodeLens(controller, fixedSettings(["panel"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const [, raw] = lens.provideCodeLenses(document, NO_CANCEL);
@@ -176,8 +187,8 @@ suite("Typst Preview Surfaces Test Suite", () => {
 
 	test("Should offer no code lens when the setting turns it off", async () => {
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
-		const off = new TypstPreviewCodeLens(controller, fixedSettings("panel", 200, false));
-		const surfaceOff = new TypstPreviewCodeLens(controller, fixedSettings("off"));
+		const off = new TypstPreviewCodeLens(controller, fixedSettings(["panel"], 200, false));
+		const surfaceOff = new TypstPreviewCodeLens(controller, fixedSettings([]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		assert.deepStrictEqual(off.provideCodeLenses(document, NO_CANCEL), []);
@@ -194,7 +205,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// when a late result arrives, so the compile is awaited instead.
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const shown = await hover.provideHover(document, INSIDE_RAW, NO_CANCEL);
@@ -220,7 +231,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 			resolveBinary: () => Promise.resolve("/typst"),
 			createCompiler: () => compiler,
 		});
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
@@ -245,7 +256,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 			resolveBinary: () => Promise.resolve("/typst"),
 			createCompiler: () => compiler,
 		});
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
@@ -289,7 +300,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 			resolveBinary: () => Promise.resolve("/typst"),
 			createCompiler: () => compiler,
 		});
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const pending = hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
@@ -315,7 +326,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// written as text: rendering it as markdown would change what it says.
 		const stderr = "error: unknown variable: _x_\n  ┌─ <stdin>:3:1\n  │\n";
 		const controller = makeController(new StubCompiler({ stderr }));
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
@@ -334,7 +345,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// block the pointer touched, which is not a cursor move.
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 		const updates: string[] = [];
 		const subscription = controller.onDidChangeResult((update) => updates.push(update.reason));
@@ -349,7 +360,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should answer from the preview on screen without compiling again", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		await nextResultFor(controller, document, INSIDE_PLAIN);
@@ -363,7 +374,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should give up a hover the pointer has already left", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 		const cancelled = new vscode.CancellationTokenSource();
 		cancelled.cancel();
@@ -378,7 +389,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should point at the panel for an image too large to hover", async () => {
 		const huge = `<svg width="10pt" height="10pt">${"x".repeat(400_000)}</svg>`;
 		const controller = makeController(new StubCompiler({ svg: huge, stderr: "" }));
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
@@ -391,7 +402,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should offer no hover when the document asks for another surface", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
-		const hover = new TypstPreviewHover(controller, fixedSettings("panel"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["panel"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		await nextResultFor(controller, document, INSIDE_PLAIN);
@@ -402,10 +413,29 @@ suite("Typst Preview Surfaces Test Suite", () => {
 
 	test("Should offer no hover outside a Typst block", async () => {
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
-		const hover = new TypstPreviewHover(controller, fixedSettings("hover"));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		assert.strictEqual(await hover.provideHover(document, new vscode.Position(0, 0), NO_CANCEL), undefined);
+		controller.dispose();
+	});
+
+	test("Should keep the panel off the pointer while both surfaces are on", async () => {
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const controller = makeController(compiler);
+		const document = await quartoDocument(THREE_KINDS);
+		const hover = new TypstPreviewHover(controller, fixedSettings(["panel", "hover"]));
+
+		// The panel is following the plain block, which is what a cursor move does.
+		await nextResultFor(controller, document, INSIDE_PLAIN);
+		const followed = controller.shown();
+
+		// A pointer resting on another block compiles for the hover alone.
+		assert.ok(await hover.provideHover(document, INSIDE_RAW, NO_CANCEL));
+		await settle();
+
+		// `shown()` is what the panel renders, and it has not moved to the raw block.
+		assert.strictEqual(controller.shown()?.blockIndex, followed?.blockIndex);
 		controller.dispose();
 	});
 });

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -129,6 +129,11 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		assert.deepStrictEqual([...previewSurfaces("inline")], ["panel"]);
 		assert.deepStrictEqual([...previewSurfaces(undefined)], ["panel"]);
 		assert.deepStrictEqual([...previewSurfaces(7)], ["panel"]);
+		// A non-string member is filtered out the same way an unknown one is, and
+		// the fallback applies once that leaves nothing, because the input itself
+		// was not empty.
+		assert.deepStrictEqual([...previewSurfaces([7])], ["panel"]);
+		assert.deepStrictEqual([...previewSurfaces([null])], ["panel"]);
 		assert.strictEqual(previewMaxHeight(0), 20);
 		assert.strictEqual(previewMaxHeight("tall"), 200);
 		assert.strictEqual(previewMaxHeight(500), 500);


### PR DESCRIPTION
Bottom of a five layer stack that adds inline Typst preview.

`quartoWizard.typstPreview.surface` held a single enum value, so a reader could have the panel or the hover and never both.
The setting is now an array of `panel` and `hover`.
An empty array turns the feature off, and it replaces the `off` value the enum carried.

`previewSurfaces` still reads a bare string, because a settings file written against an older version of the extension holds one.
`off` maps to the empty set, and a string this version does not know falls back to the default.

The controller needed no coordination work.
`hasSurface` asks whether a panel is open rather than what the setting holds, `render` drops an update whose reason is a surface, and `publish` keeps the last compile apart from the last rendered result.
The single value was the only thing that prevented both surfaces at once.

The generated configuration reference is committed and the release site renders it, so `scripts/process-api-docs.mjs` gained a branch for an array typed setting and both pages were regenerated.
Without it the published reference documented a value the extension no longer declares.

Verified with `npm run test`, `npm run lint` and `npm run format:check`.