### PR TITLE
refactor: name the Typst scan unit and give it an end

### DIFF
--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as semver from "semver";
-import { blockAtOffset, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { blockAtOffset, type TypstUnit } from "../../utils/typst/typstBlocks";
 import {
 	buildPlainSource,
 	buildRawSource,
@@ -54,7 +54,7 @@ export const NO_BLOCK_MESSAGE = "Put the cursor inside a Typst block to preview 
 /** Everything the compiler and the panel need for one block. */
 export interface CompileRequest {
 	/** The block under the cursor. */
-	block: TypstBlock;
+	block: TypstUnit;
 	/**
 	 * Where the block sits in the document, counted from the top.
 	 *

--- a/src/providers/typstPreview/typstPreviewCodeLens.ts
+++ b/src/providers/typstPreview/typstPreviewCodeLens.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { debounce, type DebouncedFunction } from "../../utils/debounce";
-import type { TypstBlockKind } from "../../utils/typst/typstBlocks";
+import type { TypstUnitKind } from "../../utils/typst/typstBlocks";
 import type { TypstPreviewController } from "./typstPreviewController";
 import { surfaceSettings, type TypstSurfaceSettings } from "./typstPreviewSettings";
 
@@ -22,7 +22,7 @@ const CHANGE_DEBOUNCE_MS = 300;
  * executable cell are spelled almost the same way and behave differently, and
  * one title on all three would hide the difference that matters most.
  */
-const TITLES: Record<TypstBlockKind, string> = {
+const TITLES: Record<TypstUnitKind, string> = {
 	plain: "Preview Typst block",
 	raw: "Preview raw Typst block",
 	cell: "Preview Typst cell",

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { getErrorMessage } from "@quarto-wizard/core";
-import { blockAtOffset, invalidatesPreview, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { blockAtOffset, invalidatesPreview, type TypstUnit } from "../../utils/typst/typstBlocks";
 import { isUnavailable, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 import { parseTypstStderr, typstMessages } from "../../utils/typst/typstDiagnostics";
 import { debounce, type DebouncedFunction } from "../../utils/debounce";
@@ -88,7 +88,7 @@ export interface TypstPreviewResult {
 	/** The document the block belongs to. */
 	uri: vscode.Uri;
 	/** The block that was previewed. */
-	block: TypstBlock;
+	block: TypstUnit;
 	/** Where that block sits in the document, which is its identity across an edit. */
 	blockIndex: number;
 	/**
@@ -402,7 +402,7 @@ export class TypstPreviewController implements vscode.Disposable {
 	}
 
 	/** The Typst blocks of a document, which is the list a compile was built from. */
-	blocksOf(document: vscode.TextDocument): readonly TypstBlock[] {
+	blocksOf(document: vscode.TextDocument): readonly TypstUnit[] {
 		return getDocumentTypstBlocks(document, () => document.getText());
 	}
 

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -1059,7 +1059,7 @@ export class TypstPreviewController implements vscode.Disposable {
 			return true;
 		}
 		const offset = event.textEditor.document.offsetAt(event.selections[0].active);
-		return offset < shown.block.fenceStart || offset > shown.block.bodyEnd;
+		return offset < shown.block.fenceStart || offset > shown.block.unitEnd;
 	}
 
 	private handleDocumentChange(event: vscode.TextDocumentChangeEvent): void {

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -56,7 +56,7 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 			return undefined;
 		}
 		// The whole block, so the hover stays up while the pointer moves inside it.
-		const range = new vscode.Range(document.positionAt(block.fenceStart), document.positionAt(block.bodyEnd));
+		const range = new vscode.Range(document.positionAt(block.fenceStart), document.positionAt(block.unitEnd));
 
 		const blockIndex = blocks.indexOf(block);
 		// The version is part of the identity, not decoration. Nothing recompiles in

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -445,5 +445,13 @@ suite("Typst Blocks Test Suite", () => {
 				true,
 			);
 		});
+
+		test("Should pin the region at the unit end, not only the body end", () => {
+			// A fence carries no attribute, so `unitEnd` is `bodyEnd` here, and this
+			// pins the exact offset the check reads against a regression that stops
+			// at `bodyEnd` again, which an inline unit would need past its body.
+			assert.strictEqual(invalidatesPreview(plain, insertion(plain.unitEnd)), true);
+			assert.strictEqual(invalidatesPreview(plain, insertion(plain.unitEnd + 1)), false);
+		});
 	});
 });

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import {
-	findTypstBlocks,
+	findTypstUnits,
 	blockAtOffset,
 	precedingRawBlocks,
 	hasLateOptionLine,
@@ -13,7 +13,7 @@ function fence(info: string): string {
 }
 
 suite("Typst Blocks Test Suite", () => {
-	suite("findTypstBlocks classification", () => {
+	suite("findTypstUnits classification", () => {
 		// The three kinds behave differently and must never be conflated, so
 		// every accepted spelling and every rejected one has its own case.
 		const cases: [string, string | undefined][] = [
@@ -29,7 +29,7 @@ suite("Typst Blocks Test Suite", () => {
 
 		for (const [info, kind] of cases) {
 			test(`Should classify \`${info}\` as ${kind ?? "excluded"}`, () => {
-				const found = findTypstBlocks(fence(info));
+				const found = findTypstUnits(fence(info));
 				assert.strictEqual(found[0]?.kind, kind);
 			});
 		}
@@ -37,15 +37,15 @@ suite("Typst Blocks Test Suite", () => {
 
 	// Each case below is one the module inherits from `getCodeBlockRanges`, and
 	// one a second fence scanner would have had to earn again.
-	suite("findTypstBlocks body derivation", () => {
+	suite("findTypstUnits body derivation", () => {
 		test("Should read a body written with CRLF line endings", () => {
-			const found = findTypstBlocks("```typst\r\n#let a = 1\r\n#a\r\n```\r\n");
+			const found = findTypstUnits("```typst\r\n#let a = 1\r\n#a\r\n```\r\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "#let a = 1\r\n#a\r\n");
 		});
 
 		test("Should remove the fence indent from every body line", () => {
-			const found = findTypstBlocks("- item\n\n  ```typst\n  #let a = 1\n  #a\n  ```\n");
+			const found = findTypstUnits("- item\n\n  ```typst\n  #let a = 1\n  #a\n  ```\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].indent, 2);
 			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
@@ -56,13 +56,13 @@ suite("Typst Blocks Test Suite", () => {
 			// documented example of a Typst block and not one. Compiling it would
 			// run source the author wrote to be read.
 			const text = "before\n\n    ```typst\n    #a\n    ```\n";
-			assert.deepStrictEqual(findTypstBlocks(text), []);
+			assert.deepStrictEqual(findTypstUnits(text), []);
 		});
 
 		test("Should remove the blockquote marker from every body line", () => {
 			// Typst is whitespace sensitive and knows nothing about Markdown, so a
 			// marker left on a body line is a syntax error in the compiled source.
-			const found = findTypstBlocks("> ```typst\n> #let a = 1\n> #a\n> ```\n");
+			const found = findTypstUnits("> ```typst\n> #let a = 1\n> #a\n> ```\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "#let a = 1\n#a\n");
 		});
@@ -72,7 +72,7 @@ suite("Typst Blocks Test Suite", () => {
 			// indented by a tab keeps whatever follows it, so four spaces of Typst
 			// indent survive. Counting characters instead would eat the tab and
 			// three of those spaces.
-			const found = findTypstBlocks("1. Step\n\n\t```typst\n\t    #x\n\t```\n");
+			const found = findTypstUnits("1. Step\n\n\t```typst\n\t    #x\n\t```\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "    #x\n");
 		});
@@ -80,14 +80,14 @@ suite("Typst Blocks Test Suite", () => {
 		test("Should read a blockquoted cell with its options", () => {
 			// The option reader sees the body after the markers are removed, which is
 			// the one path where the two rules meet.
-			const found = findTypstBlocks("> ```{typst}\n> //| width: 3\n> #x\n> ```\n");
+			const found = findTypstUnits("> ```{typst}\n> //| width: 3\n> #x\n> ```\n");
 			assert.strictEqual(found.length, 1);
 			assert.deepStrictEqual(found[0].options, { width: "3" });
 			assert.strictEqual(found[0].code, "#x\n");
 		});
 
 		test("Should keep CRLF line endings in a blockquoted block", () => {
-			const found = findTypstBlocks("> ```typst\r\n> #a\r\n> ```\r\n");
+			const found = findTypstUnits("> ```typst\r\n> #a\r\n> ```\r\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "#a\r\n");
 		});
@@ -96,7 +96,7 @@ suite("Typst Blocks Test Suite", () => {
 			// The fence sits one quote deep, so Pandoc hands Typst the body with one
 			// marker removed and the second one intact. Removing both would delete a
 			// character the author wrote.
-			const found = findTypstBlocks("> ```typst\n> > #x\n> ```\n");
+			const found = findTypstUnits("> ```typst\n> > #x\n> ```\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "> #x\n");
 		});
@@ -105,26 +105,26 @@ suite("Typst Blocks Test Suite", () => {
 			// The fence carries two columns of indent, so two columns come off each
 			// body line. The body tab runs from column two to column four, and the
 			// four spaces of Typst indent that follow it survive whole.
-			const found = findTypstBlocks("> \t```typst\n> \t    #x\n> \t```\n");
+			const found = findTypstUnits("> \t```typst\n> \t    #x\n> \t```\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "    #x\n");
 		});
 
 		test("Should read an unclosed block to the end of the text", () => {
-			const found = findTypstBlocks("```typst\n#let a = 1\n");
+			const found = findTypstUnits("```typst\n#let a = 1\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "#let a = 1\n");
 		});
 
 		test("Should read an unclosed block whose fence is the last line", () => {
-			const found = findTypstBlocks("text\n\n```typst");
+			const found = findTypstUnits("text\n\n```typst");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].kind, "plain");
 			assert.strictEqual(found[0].body, "");
 		});
 
 		test("Should read a fence that starts at offset zero", () => {
-			const found = findTypstBlocks("```typst\n#a\n```\n");
+			const found = findTypstUnits("```typst\n#a\n```\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].fenceLine, 0);
 			assert.strictEqual(found[0].body, "#a\n");
@@ -132,12 +132,12 @@ suite("Typst Blocks Test Suite", () => {
 
 		test("Should ignore a Typst fence nested in a demonstration block", () => {
 			const text = "````markdown\n```{typst}\n#a\n```\n````\n";
-			assert.deepStrictEqual(findTypstBlocks(text), []);
+			assert.deepStrictEqual(findTypstUnits(text), []);
 		});
 
 		test("Should ignore a fence inside the YAML front matter", () => {
 			const text = '---\ntitle: "```typst"\n---\n\n```typst\n#a\n```\n';
-			const found = findTypstBlocks(text);
+			const found = findTypstUnits(text);
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].body, "#a\n");
 		});
@@ -148,7 +148,7 @@ suite("Typst Blocks Test Suite", () => {
 			// only closes on a bare fence line it swallows the opening fence of the
 			// real block below, which then goes unreported.
 			const text = "---\ndescription: |\n  text\n```\n---\n\n```typst\n#a\n```\n";
-			const found = findTypstBlocks(text);
+			const found = findTypstUnits(text);
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].kind, "plain");
 			assert.strictEqual(found[0].body, "#a\n");
@@ -159,7 +159,7 @@ suite("Typst Blocks Test Suite", () => {
 			// `---` lines are thematic breaks. Reading them as delimiters started the
 			// scan below the second one and hid the block between them.
 			const text = "---\n\n```typst\n#a\n```\n\n---\n";
-			const found = findTypstBlocks(text);
+			const found = findTypstUnits(text);
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].kind, "plain");
 			assert.strictEqual(found[0].body, "#a\n");
@@ -167,7 +167,7 @@ suite("Typst Blocks Test Suite", () => {
 
 		test("Should report offsets and line numbers past the front matter", () => {
 			const text = "---\ntitle: t\n---\n\n```typst\n#a\n```\n";
-			const found = findTypstBlocks(text);
+			const found = findTypstUnits(text);
 			assert.strictEqual(found[0].fenceLine, 4);
 			assert.strictEqual(text.slice(found[0].fenceStart, found[0].fenceStart + 8), "```typst");
 			assert.strictEqual(text.slice(found[0].bodyStart, found[0].bodyEnd), "#a\n```");
@@ -176,7 +176,7 @@ suite("Typst Blocks Test Suite", () => {
 		test("Should read a tilde fence and keep a backtick line in its body", () => {
 			// A tilde block closes only on tildes, so a backtick line inside it is
 			// content. The bare-backtick rule does not apply to a tilde fence either.
-			const found = findTypstBlocks("~~~typst\n#a\n```\n#b\n~~~\n");
+			const found = findTypstUnits("~~~typst\n#a\n```\n#b\n~~~\n");
 			assert.strictEqual(found.length, 1);
 			assert.strictEqual(found[0].kind, "plain");
 			assert.strictEqual(found[0].body, "#a\n```\n#b\n");
@@ -185,12 +185,12 @@ suite("Typst Blocks Test Suite", () => {
 		test("Should keep the line endings of a CRLF cell in its code", () => {
 			// `body` and `code` describe the same text, so one must not be
 			// normalised while the other is not.
-			const block = findTypstBlocks("```{typst}\r\n//| a: 1\r\n#x\r\n#y\r\n```\r\n")[0];
+			const block = findTypstUnits("```{typst}\r\n//| a: 1\r\n#x\r\n#y\r\n```\r\n")[0];
 			assert.strictEqual(block.code, "#x\r\n#y\r\n");
 		});
 
 		test("Should report the fence line of each block", () => {
-			const found = findTypstBlocks("intro\n\n```typst\n#a\n```\n\n```{=typst}\n#b\n```\n");
+			const found = findTypstUnits("intro\n\n```typst\n#a\n```\n\n```{=typst}\n#b\n```\n");
 			assert.deepStrictEqual(
 				found.map((block) => [block.kind, block.fenceLine]),
 				[
@@ -204,59 +204,59 @@ suite("Typst Blocks Test Suite", () => {
 	// A bug-compatible port of `_modules/code-cell.lua:84-122`. Each quirk is a
 	// quirk of that pattern, so each test names the behaviour and cites the line
 	// it ports. An upstream fix to any of them is a breaking change here.
-	suite("findTypstBlocks comment-pipe options", () => {
+	suite("findTypstUnits comment-pipe options", () => {
 		/** One cell block wrapping the given body. */
 		function cell(body: string): string {
 			return "```{typst}\n" + body + "\n```\n";
 		}
 
 		test("Should read a hyphenated key, which the key pattern allows (:89)", () => {
-			assert.deepStrictEqual(findTypstBlocks(cell("//| fig-width: 3\n#a"))[0].options, { "fig-width": "3" });
+			assert.deepStrictEqual(findTypstUnits(cell("//| fig-width: 3\n#a"))[0].options, { "fig-width": "3" });
 		});
 
 		test("Should end the run at an underscore key, which the key pattern rejects (:89)", () => {
-			const block = findTypstBlocks(cell("//| my_key: v\n//| dpi: 300\n#a"))[0];
+			const block = findTypstUnits(cell("//| my_key: v\n//| dpi: 300\n#a"))[0];
 			assert.deepStrictEqual(block.options, {});
 			assert.strictEqual(block.code, "//| my_key: v\n//| dpi: 300\n#a\n");
 		});
 
 		test("Should end the run at an empty value, which needs one character (:89)", () => {
-			const block = findTypstBlocks(cell("//| dpi:\n//| width: 3\n#a"))[0];
+			const block = findTypstUnits(cell("//| dpi:\n//| width: 3\n#a"))[0];
 			assert.deepStrictEqual(block.options, {});
 		});
 
 		test("Should read an empty value when a space follows the colon (:89)", () => {
 			// The pattern backtracks, so the trailing space alone decides whether
 			// the line parses. Verified against the Lua pattern itself.
-			assert.deepStrictEqual(findTypstBlocks(cell("//| dpi: \n#a"))[0].options, { dpi: "" });
+			assert.deepStrictEqual(findTypstUnits(cell("//| dpi: \n#a"))[0].options, { dpi: "" });
 		});
 
 		test("Should count only the leading run and keep a later option as code (:105-118)", () => {
-			const block = findTypstBlocks(cell("//| dpi: 300\n#a\n//| width: 3"))[0];
+			const block = findTypstUnits(cell("//| dpi: 300\n#a\n//| width: 3"))[0];
 			assert.deepStrictEqual(block.options, { dpi: "300" });
 			assert.strictEqual(block.code, "#a\n//| width: 3\n");
 		});
 
 		test("Should read true and false as booleans (:95-98)", () => {
-			assert.deepStrictEqual(findTypstBlocks(cell("//| a: true\n//| b: false\n#a"))[0].options, {
+			assert.deepStrictEqual(findTypstUnits(cell("//| a: true\n//| b: false\n#a"))[0].options, {
 				a: true,
 				b: false,
 			});
 		});
 
 		test("Should strip one layer of matching quotes, either style (:100-101)", () => {
-			assert.deepStrictEqual(findTypstBlocks(cell("//| a: \"q\"\n//| b: 'q'\n#a"))[0].options, { a: "q", b: "q" });
+			assert.deepStrictEqual(findTypstUnits(cell("//| a: \"q\"\n//| b: 'q'\n#a"))[0].options, { a: "q", b: "q" });
 		});
 
 		test("Should keep every other value as a trimmed string (:102)", () => {
-			assert.deepStrictEqual(findTypstBlocks(cell("//| dpi: 300\n//| k:   spaced   \n#a"))[0].options, {
+			assert.deepStrictEqual(findTypstUnits(cell("//| dpi: 300\n//| k:   spaced   \n#a"))[0].options, {
 				dpi: "300",
 				k: "spaced",
 			});
 		});
 
 		test("Should allow whitespace around the prefix (:89)", () => {
-			assert.deepStrictEqual(findTypstBlocks(cell("  //| a: 1\n//|b: 2\n#a"))[0].options, { a: "1", b: "2" });
+			assert.deepStrictEqual(findTypstUnits(cell("  //| a: 1\n//|b: 2\n#a"))[0].options, { a: "1", b: "2" });
 		});
 
 		test("Should read every option of a block written with CRLF", () => {
@@ -265,20 +265,20 @@ suite("Typst Blocks Test Suite", () => {
 			// first option. That is unreachable in a render, because Pandoc does
 			// not recognise a fenced block in a CRLF document at all, so matching
 			// it here would only break the preview of a file an author can write.
-			assert.deepStrictEqual(findTypstBlocks("```{typst}\r\n//| a: 1\r\n//| b: 2\r\n#x\r\n```\r\n")[0].options, {
+			assert.deepStrictEqual(findTypstUnits("```{typst}\r\n//| a: 1\r\n//| b: 2\r\n#x\r\n```\r\n")[0].options, {
 				a: "1",
 				b: "2",
 			});
 		});
 
 		test("Should parse no options for a plain block and keep the lines verbatim", () => {
-			const block = findTypstBlocks("```typst\n//| dpi: 300\n#a\n```\n")[0];
+			const block = findTypstUnits("```typst\n//| dpi: 300\n#a\n```\n")[0];
 			assert.deepStrictEqual(block.options, {});
 			assert.strictEqual(block.code, "//| dpi: 300\n#a\n");
 		});
 
 		test("Should parse no options for a raw block and keep the lines verbatim", () => {
-			const block = findTypstBlocks("```{=typst}\n//| dpi: 300\n#a\n```\n")[0];
+			const block = findTypstUnits("```{=typst}\n//| dpi: 300\n#a\n```\n")[0];
 			assert.deepStrictEqual(block.options, {});
 			assert.strictEqual(block.code, "//| dpi: 300\n#a\n");
 		});
@@ -286,12 +286,12 @@ suite("Typst Blocks Test Suite", () => {
 
 	suite("hasLateOptionLine", () => {
 		test("Should report a cell whose option line comes after the code", () => {
-			const block = findTypstBlocks("```{typst}\n#a\n//| dpi: 300\n```\n")[0];
+			const block = findTypstUnits("```{typst}\n#a\n//| dpi: 300\n```\n")[0];
 			assert.strictEqual(hasLateOptionLine(block), true);
 		});
 
 		test("Should not report a cell whose options are all in the leading run", () => {
-			const block = findTypstBlocks("```{typst}\n//| dpi: 300\n#a\n```\n")[0];
+			const block = findTypstUnits("```{typst}\n//| dpi: 300\n#a\n```\n")[0];
 			assert.strictEqual(hasLateOptionLine(block), false);
 		});
 
@@ -299,7 +299,7 @@ suite("Typst Blocks Test Suite", () => {
 			// A comment-pipe line is an ordinary Typst comment in both, so there is
 			// nothing to warn about.
 			const text = "```typst\n#a\n//| dpi: 300\n```\n\n```{=typst}\n#b\n//| dpi: 300\n```\n";
-			for (const block of findTypstBlocks(text)) {
+			for (const block of findTypstUnits(text)) {
 				assert.strictEqual(hasLateOptionLine(block), false, block.kind);
 			}
 		});
@@ -308,14 +308,14 @@ suite("Typst Blocks Test Suite", () => {
 			// The Lua guard at `:110` ends with a colon and one whitespace, while
 			// the key pattern at `:89` does not, so upstream passes over this line
 			// in silence. The port keeps that difference.
-			const block = findTypstBlocks("```{typst}\n#a\n//| dpi:300\n```\n")[0];
+			const block = findTypstUnits("```{typst}\n#a\n//| dpi:300\n```\n")[0];
 			assert.strictEqual(hasLateOptionLine(block), false);
 		});
 	});
 
 	suite("blockAtOffset", () => {
 		const text = "intro\n\n```typst\n#a\n```\n\ntext\n\n```{=typst}\n#b\n```\n";
-		const blocks = findTypstBlocks(text);
+		const blocks = findTypstUnits(text);
 
 		test("Should find the block holding an offset inside a body", () => {
 			assert.strictEqual(blockAtOffset(blocks, text.indexOf("#a"))?.kind, "plain");
@@ -332,12 +332,22 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(blockAtOffset(blocks, 0), undefined);
 			assert.strictEqual(blockAtOffset(blocks, text.indexOf("text")), undefined);
 		});
+
+		test("Should end a fenced unit at its body", () => {
+			const text = ["```typst", "#circle()", "```", ""].join("\n");
+			const [unit] = findTypstUnits(text);
+			assert.strictEqual(unit.scope, "block");
+			// A fence carries no attribute, so the two ends are the same place, and
+			// `blockAtOffset` reads `unitEnd` alone from here on.
+			assert.strictEqual(unit.unitEnd, unit.bodyEnd);
+			assert.strictEqual(blockAtOffset([unit], unit.unitEnd), unit);
+		});
 	});
 
 	suite("precedingRawBlocks", () => {
 		test("Should return every earlier raw block in document order", () => {
 			const text = "```{=typst}\n#let a = 1\n```\n\n```{=typst}\n#let b = 2\n```\n\n```{=typst}\n#a\n```\n";
-			const blocks = findTypstBlocks(text);
+			const blocks = findTypstUnits(text);
 			assert.deepStrictEqual(
 				precedingRawBlocks(blocks, blocks[2]).map((block) => block.code),
 				["#let a = 1\n", "#let b = 2\n"],
@@ -348,7 +358,7 @@ suite("Typst Blocks Test Suite", () => {
 			// Only a raw block reaches the Typst output, so only a raw block can
 			// put a binding in scope for a later one.
 			const text = "```{=typst}\n#let a = 1\n```\n\n```{typst}\n#x\n```\n\n```typst\n#y\n```\n\n```{=typst}\n#a\n```\n";
-			const blocks = findTypstBlocks(text);
+			const blocks = findTypstUnits(text);
 			const target = blocks[blocks.length - 1];
 			assert.deepStrictEqual(
 				precedingRawBlocks(blocks, target).map((block) => block.code),
@@ -357,7 +367,7 @@ suite("Typst Blocks Test Suite", () => {
 		});
 
 		test("Should return nothing when the target is the first raw block", () => {
-			const blocks = findTypstBlocks("```{=typst}\n#a\n```\n");
+			const blocks = findTypstUnits("```{=typst}\n#a\n```\n");
 			assert.deepStrictEqual(precedingRawBlocks(blocks, blocks[0]), []);
 		});
 	});
@@ -381,7 +391,7 @@ suite("Typst Blocks Test Suite", () => {
 			"```",
 			"",
 		].join("\n");
-		const [firstRaw, plain, secondRaw] = findTypstBlocks(text);
+		const [firstRaw, plain, secondRaw] = findTypstUnits(text);
 
 		/** A one character insertion at an offset. */
 		function insertion(offset: number): { rangeOffset: number; rangeLength: number } {

--- a/src/test/suite/typstFixtures.test.ts
+++ b/src/test/suite/typstFixtures.test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as yaml from "js-yaml";
-import { blockAtOffset, findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { blockAtOffset, findTypstUnits, type TypstUnit } from "../../utils/typst/typstBlocks";
 import { BRAND_CANDIDATES, splitBrand, EMPTY_BRAND, type Brand } from "../../utils/typst/typstBrand";
 import { extensionLevel, type TypstBrandMode, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
 import { parseFrontMatter } from "../../utils/yamlPosition";
@@ -66,8 +66,8 @@ function brandOf(directory: string): Brand {
 }
 
 /** The one cell of a fixture document. */
-function cellOf(text: string): TypstBlock {
-	const blocks = findTypstBlocks(text);
+function cellOf(text: string): TypstUnit {
+	const blocks = findTypstUnits(text);
 	const block = blockAtOffset(blocks, blocks[0].bodyStart);
 	assert.ok(block !== undefined && block.kind === "cell", "the fixture must hold one executable cell");
 	return block;

--- a/src/test/suite/typstOptions.test.ts
+++ b/src/test/suite/typstOptions.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { findTypstUnits, type TypstUnit } from "../../utils/typst/typstBlocks";
 import { EMPTY_BRAND, brandColourReader } from "../../utils/typst/typstBrand";
 import {
 	TYPST_DEFAULTS,
@@ -16,9 +16,9 @@ import {
 } from "../../utils/typst/typstOptions";
 
 /** The one cell of a document written as an option run over one line of code. */
-function cell(options: string[]): TypstBlock {
+function cell(options: string[]): TypstUnit {
 	const body = [...options.map((option) => `//| ${option}`), "#circle()"].join("\n");
-	return findTypstBlocks(`\`\`\`{typst}\n${body}\n\`\`\`\n`)[0];
+	return findTypstUnits(`\`\`\`{typst}\n${body}\n\`\`\`\n`)[0];
 }
 
 /** A document with no brand at all, which is what every candidate path missing means. */

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as path from "node:path";
-import { findTypstBlocks } from "../../utils/typst/typstBlocks";
+import { findTypstUnits } from "../../utils/typst/typstBlocks";
 import { findTypstPathOptions, resolveTypstPathOption, type TypstPathOption } from "../../utils/typst/typstPathOptions";
 import { annotateYaml, yamlRegionOf } from "../../utils/yamlAnnotated";
 
@@ -15,7 +15,7 @@ function covered(text: string, languageId = "quarto"): string[] {
 	return findTypstPathOptions(
 		text,
 		languageId,
-		() => findTypstBlocks(text),
+		() => findTypstUnits(text),
 		() => readYaml(text, languageId),
 	).map((option) => text.slice(option.start, option.end));
 }
@@ -25,7 +25,7 @@ function only(text: string, languageId = "quarto"): TypstPathOption {
 	const found = findTypstPathOptions(
 		text,
 		languageId,
-		() => findTypstBlocks(text),
+		() => findTypstUnits(text),
 		() => readYaml(text, languageId),
 	);
 	assert.strictEqual(found.length, 1, `expected one occurrence, found ${found.length}`);

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as vscode from "vscode";
-import { findTypstBlocks, type TypstBlock } from "../../utils/typst/typstBlocks";
+import { findTypstUnits, type TypstUnit } from "../../utils/typst/typstBlocks";
 import { EMPTY_BRAND, brandColourReader, splitBrand } from "../../utils/typst/typstBrand";
 import { mergeGlobalConfigs, resolveTypstOptions, type TypstGlobalLevel } from "../../utils/typst/typstOptions";
 import { buildCell, cellNotes, isUnavailable, resolvePreamble } from "../../utils/typst/typstSource";
@@ -21,9 +21,9 @@ import { parseFrontMatter } from "../../utils/yamlPosition";
 import { makeFolder, makeRoot } from "./projectFixtures";
 
 /** The one cell of a document written as an option run over one line of code. */
-function cell(options: string[], code = "#circle()"): TypstBlock {
+function cell(options: string[], code = "#circle()"): TypstUnit {
 	const body = [...options.map((option) => `//| ${option}`), code].join("\n");
-	return findTypstBlocks(`\`\`\`{typst}\n${body}\n\`\`\`\n`)[0];
+	return findTypstUnits(`\`\`\`{typst}\n${body}\n\`\`\`\n`)[0];
 }
 
 /** A read that answers from a table rather than from disk. */

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { findTypstBlocks } from "../../utils/typst/typstBlocks";
+import { findTypstUnits } from "../../utils/typst/typstBlocks";
 import { buildPlainSource, buildRawSource, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
 
 /** The page setup a preview injects above every block. */
@@ -33,7 +33,7 @@ const CHAIN = [
 suite("Typst Source Test Suite", () => {
 	suite("buildPlainSource", () => {
 		test("Should put the header above the body", () => {
-			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
+			const blocks = findTypstUnits("```typst\n#circle()\n```\n");
 			assert.deepStrictEqual(buildPlainSource(blocks[0], HEADER), {
 				source: `${HEADER}\n#circle()\n`,
 				injectedLines: 1,
@@ -43,7 +43,7 @@ suite("Typst Source Test Suite", () => {
 		test("Should inject nothing when the header is empty", () => {
 			// An empty header must not push the body down by a line, or every
 			// diagnostic would point one line too far.
-			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
+			const blocks = findTypstUnits("```typst\n#circle()\n```\n");
 			assert.deepStrictEqual(buildPlainSource(blocks[0], ""), { source: "#circle()\n", injectedLines: 0 });
 		});
 	});
@@ -53,7 +53,7 @@ suite("Typst Source Test Suite", () => {
 			// A raw block is passed through into the document's Typst context, so a
 			// name bound by an earlier one is in scope for a later one. Compiled
 			// alone, the target below fails on an unknown variable.
-			const blocks = findTypstBlocks(CHAIN);
+			const blocks = findTypstUnits(CHAIN);
 			assert.strictEqual(
 				buildRawSource(blocks, blocks[2], HEADER).source,
 				`${HEADER}\n#let accent = red\n#text(fill: accent)[Hello]\n`,
@@ -63,19 +63,19 @@ suite("Typst Source Test Suite", () => {
 		test("Should leave a cell sitting between two raw blocks out of the source", () => {
 			// The filter compiles a cell to an image of its own, so nothing it
 			// contains reaches the Typst context of the raw blocks around it.
-			const blocks = findTypstBlocks(CHAIN);
+			const blocks = findTypstUnits(CHAIN);
 			assert.ok(!buildRawSource(blocks, blocks[2], HEADER).source.includes("#square()"));
 		});
 
 		test("Should count the header and every prepended body as injected lines", () => {
 			// A diagnostic reports a position in the assembled source, so the count
 			// is what maps it back to a line of the target block.
-			const blocks = findTypstBlocks(CHAIN);
+			const blocks = findTypstUnits(CHAIN);
 			assert.strictEqual(buildRawSource(blocks, blocks[2], HEADER).injectedLines, 2);
 		});
 
 		test("Should compile the first raw block of a document on its own", () => {
-			const blocks = findTypstBlocks(CHAIN);
+			const blocks = findTypstUnits(CHAIN);
 			assert.deepStrictEqual(buildRawSource(blocks, blocks[0], HEADER), {
 				source: `${HEADER}\n#let accent = red\n`,
 				injectedLines: 1,
@@ -86,7 +86,7 @@ suite("Typst Source Test Suite", () => {
 			// Only a cell carries options. In a raw block the same spelling is an
 			// ordinary Typst comment, and dropping it would change the source.
 			const text = "```{=typst}\n//| width: 10cm\n#circle()\n```\n";
-			const blocks = findTypstBlocks(text);
+			const blocks = findTypstUnits(text);
 			assert.strictEqual(buildRawSource(blocks, blocks[0], HEADER).source, `${HEADER}\n//| width: 10cm\n#circle()\n`);
 		});
 
@@ -94,7 +94,7 @@ suite("Typst Source Test Suite", () => {
 			// An empty body has no line to contribute, so counting it would push
 			// every diagnostic of the target down by one.
 			const text = "```{=typst}\n```\n\n```{=typst}\n#circle()\n```\n";
-			const blocks = findTypstBlocks(text);
+			const blocks = findTypstUnits(text);
 			assert.deepStrictEqual(buildRawSource(blocks, blocks[1], HEADER), {
 				source: `${HEADER}\n#circle()\n`,
 				injectedLines: 1,
@@ -106,7 +106,7 @@ suite("Typst Source Test Suite", () => {
 			// line has no line ending of its own and would otherwise be glued to the
 			// first line of the target.
 			const text = "```{=typst}\n#let a = 1\n```\n\n```{=typst}\n#a";
-			const blocks = findTypstBlocks(text);
+			const blocks = findTypstUnits(text);
 			assert.strictEqual(buildRawSource(blocks, blocks[1], "").source, "#let a = 1\n#a");
 		});
 	});
@@ -184,7 +184,7 @@ suite("Typst Source Test Suite", () => {
 		test("Should count both header lines as injected lines", () => {
 			// A diagnostic reports a position in the assembled source, so a header
 			// that grows by a line and does not say so moves every reported line.
-			const blocks = findTypstBlocks("```typst\n#circle()\n```\n");
+			const blocks = findTypstUnits("```typst\n#circle()\n```\n");
 			const { header } = themeHeader("dark", "auto", "auto");
 			assert.strictEqual(buildPlainSource(blocks[0], header).injectedLines, 2);
 		});

--- a/src/utils/documentScan.ts
+++ b/src/utils/documentScan.ts
@@ -28,7 +28,7 @@
  */
 
 import type * as vscode from "vscode";
-import { findTypstBlocks, type TypstBlock } from "./typst/typstBlocks";
+import { findTypstUnits, type TypstUnit } from "./typst/typstBlocks";
 import { annotateYaml, yamlRegionOf, type AnnotatedYaml } from "./yamlAnnotated";
 import { findFencedBlocks, type FencedBlock, type TextRange } from "./yamlPosition";
 
@@ -36,7 +36,7 @@ import { findFencedBlocks, type FencedBlock, type TextRange } from "./yamlPositi
 interface DocumentScan {
 	version: number;
 	fenced?: readonly FencedBlock[];
-	typst?: readonly TypstBlock[];
+	typst?: readonly TypstUnit[];
 	/**
 	 * The annotated parse, which is undefined for a document that is not YAML and
 	 * for one that does not parse.
@@ -88,11 +88,11 @@ export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: 
  *
  * @param document - The document being read.
  * @param readText - The full text of that document.
- * @returns The blocks of `findTypstBlocks`.
+ * @returns The blocks of `findTypstUnits`.
  */
-export function getDocumentTypstBlocks(document: vscode.TextDocument, readText: () => string): readonly TypstBlock[] {
+export function getDocumentTypstBlocks(document: vscode.TextDocument, readText: () => string): readonly TypstUnit[] {
 	const scan = scanOf(document);
-	scan.typst ??= findTypstBlocks(readText());
+	scan.typst ??= findTypstUnits(readText());
 	return scan.typst;
 }
 

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -21,12 +21,14 @@ import {
  * - `cell` is a ```` ```{typst} ```` block, an executable cell owned by the
  *   `typst-render` extension. Only this kind carries options.
  */
-export type TypstBlockKind = "plain" | "raw" | "cell";
+export type TypstUnitKind = "plain" | "raw" | "cell";
 
-/** One Typst block found in a document. */
-export interface TypstBlock {
+/** One Typst unit found in a document. */
+export interface TypstUnit {
 	/** Which of the three fence kinds this is. */
-	kind: TypstBlockKind;
+	kind: TypstUnitKind;
+	/** Whether this is a fenced block or an inline code span. */
+	scope: "block" | "inline";
 	/** The block body, without the fences, de-indented to column zero. */
 	body: string;
 	/**
@@ -42,6 +44,15 @@ export interface TypstBlock {
 	bodyStart: number;
 	/** Offset one past the last character of the body. */
 	bodyEnd: number;
+	/**
+	 * Offset one past the last character that belongs to this unit.
+	 *
+	 * The same place as `bodyEnd` for a fence. An inline body ends before the
+	 * closing backtick run, and the attribute that names the kind sits after that
+	 * run, so a reader that stopped at `bodyEnd` would find no unit under a cursor
+	 * resting on either.
+	 */
+	unitEnd: number;
 	/** Offset of the first character of the opening fence line. */
 	fenceStart: number;
 	/** Zero-based line number of the opening fence. */
@@ -51,7 +62,7 @@ export interface TypstBlock {
 }
 
 /** The kind an info string declares, or undefined when it is not Typst. */
-function classifyInfoString(info: string): TypstBlockKind | undefined {
+function classifyInfoString(info: string): TypstUnitKind | undefined {
 	const trimmed = info.trim();
 	if (trimmed === "{=typst}") {
 		return "raw";
@@ -203,7 +214,7 @@ function parseOptions(body: string): { options: Record<string, string | boolean>
 }
 
 /** Whether a body carries an option line after its code, which Lua warns about. */
-export function hasLateOptionLine(block: TypstBlock): boolean {
+export function hasLateOptionLine(block: TypstUnit): boolean {
 	return block.kind === "cell" && block.code.split(/\r?\n/).some((line) => LATE_OPTION_LINE.test(line));
 }
 
@@ -216,7 +227,7 @@ export function hasLateOptionLine(block: TypstBlock): boolean {
  * nested inside a longer fence, as in a Markdown demonstration block, is part of
  * that outer block and is never reported here.
  */
-export function findTypstBlocks(text: string): TypstBlock[] {
+export function findTypstUnits(text: string): TypstUnit[] {
 	// Scan below the front matter rather than dropping its blocks afterwards. A
 	// block scalar can hold a line that looks like a fence, and that opens a
 	// block which only closes on a bare fence line, so it swallows the opening
@@ -234,7 +245,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 		}
 	}
 
-	const blocks: TypstBlock[] = [];
+	const blocks: TypstUnit[] = [];
 	for (const found of findFencedBlocks(source)) {
 		const kind = classifyInfoString(found.info);
 		if (kind === undefined) {
@@ -247,6 +258,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 		const parsed = kind === "cell" ? parseOptions(body) : { options: {}, code: body };
 
 		blocks.push({
+			scope: "block",
 			kind,
 			body,
 			code: parsed.code,
@@ -254,6 +266,7 @@ export function findTypstBlocks(text: string): TypstBlock[] {
 			// Offsets are reported against the document, not against the slice.
 			bodyStart: found.start + from,
 			bodyEnd: found.end + from,
+			unitEnd: found.end + from,
 			fenceStart: found.fenceStart + from,
 			fenceLine: found.fenceLine + firstLine,
 			indent: found.indent,
@@ -273,8 +286,8 @@ export function findTypstBlocks(text: string): TypstBlock[] {
  * the blocks around the one under the cursor: a raw block compiles with the raw
  * blocks above it. Taking the text would scan the document a second time.
  */
-export function blockAtOffset(blocks: readonly TypstBlock[], offset: number): TypstBlock | undefined {
-	return blocks.find((block) => offset >= block.fenceStart && offset <= block.bodyEnd);
+export function blockAtOffset(blocks: readonly TypstUnit[], offset: number): TypstUnit | undefined {
+	return blocks.find((block) => offset >= block.fenceStart && offset <= block.unitEnd);
 }
 
 /**
@@ -285,7 +298,7 @@ export function blockAtOffset(blocks: readonly TypstBlock[], offset: number): Ty
  * compiled to an image by the filter, and a plain block is never executed, so
  * neither can put a binding in scope.
  */
-export function precedingRawBlocks(blocks: readonly TypstBlock[], target: TypstBlock): TypstBlock[] {
+export function precedingRawBlocks(blocks: readonly TypstUnit[], target: TypstUnit): TypstUnit[] {
 	return blocks.filter((block) => block.kind === "raw" && block.bodyStart < target.bodyStart);
 }
 
@@ -313,7 +326,7 @@ export interface DocumentChange {
  * kind, and so is the closing fence, because removing it changes where the body
  * ends.
  */
-export function invalidatesPreview(block: TypstBlock, change: DocumentChange): boolean {
+export function invalidatesPreview(block: TypstUnit, change: DocumentChange): boolean {
 	const from = block.kind === "raw" ? 0 : block.fenceStart;
 	return change.rangeOffset <= block.bodyEnd && change.rangeOffset + change.rangeLength >= from;
 }

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -325,8 +325,13 @@ export interface DocumentChange {
  * The opening fence is inside that region, because the info string decides the
  * kind, and so is the closing fence, because removing it changes where the body
  * ends.
+ *
+ * The region reaches the end of the unit and not only the end of the body, for
+ * the same reason. An inline unit names its kind in the attribute that follows
+ * the closing backtick run, so an edit there changes what the unit compiles as
+ * without touching its body at all, and must invalidate the preview all the same.
  */
 export function invalidatesPreview(block: TypstUnit, change: DocumentChange): boolean {
 	const from = block.kind === "raw" ? 0 : block.fenceStart;
-	return change.rangeOffset <= block.bodyEnd && change.rangeOffset + change.rangeLength >= from;
+	return change.rangeOffset <= block.unitEnd && change.rangeOffset + change.rangeLength >= from;
 }

--- a/src/utils/typst/typstOptions.ts
+++ b/src/utils/typst/typstOptions.ts
@@ -12,7 +12,7 @@
  * that corrects the filter shows an image the render does not produce.
  */
 
-import type { TypstBlock } from "./typstBlocks";
+import type { TypstUnit } from "./typstBlocks";
 
 /** Which side of a light and dark pair a colour is read from. */
 export type TypstBrandMode = "light" | "dark";
@@ -474,7 +474,7 @@ export function mergeGlobalConfigs(
  * Typst expression, and wrapping `rgb("#faf6ee")` a second time does not compile.
  */
 export function resolveTypstOptions(
-	block: TypstBlock,
+	block: TypstUnit,
 	global: ResolvedTypstOptions,
 	brand: BrandColourReader,
 ): ResolvedTypstOptions {

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -15,7 +15,7 @@
 
 import type { AnnotatedNode, AnnotatedYaml, YamlPathSegment } from "../yamlAnnotated";
 import { stripBlockquoteMarkers, stripCarriageReturn } from "../yamlPosition";
-import { OPTION_LINE, quotedValue, type TypstBlock } from "./typstBlocks";
+import { OPTION_LINE, quotedValue, type TypstUnit } from "./typstBlocks";
 import { TYPST_RENDER } from "./typstOptions";
 import { resolveQuartoPath } from "./typstPaths";
 
@@ -83,7 +83,7 @@ function quoteDepth(text: string, fenceStart: number): number {
  * @param blocks - The blocks of that text, which a caller holding them already
  *   passes rather than paying for the scan a second time.
  */
-function cellPathOptions(text: string, blocks: readonly TypstBlock[]): TypstPathOption[] {
+function cellPathOptions(text: string, blocks: readonly TypstUnit[]): TypstPathOption[] {
 	const found: TypstPathOption[] = [];
 
 	for (const block of blocks) {
@@ -210,7 +210,7 @@ function yamlPathOptions(text: string, annotated: AnnotatedYaml): TypstPathOptio
 export function findTypstPathOptions(
 	text: string,
 	languageId: string,
-	readBlocks: () => readonly TypstBlock[],
+	readBlocks: () => readonly TypstUnit[],
 	readYaml: () => AnnotatedYaml | undefined,
 ): TypstPathOption[] {
 	const cells = languageId === "yaml" ? [] : cellPathOptions(text, readBlocks());

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -1,4 +1,4 @@
-import { hasLateOptionLine, precedingRawBlocks, type TypstBlock } from "./typstBlocks";
+import { hasLateOptionLine, precedingRawBlocks, type TypstUnit } from "./typstBlocks";
 import { brandColourReader, brandDictionary, type Brand } from "./typstBrand";
 import { buildTypstCommand, type TypstCommand } from "./typstCli";
 import type { TypstPaths } from "./typstPaths";
@@ -56,7 +56,7 @@ function assemble(above: string[], body: string): AssembledSource {
  * A plain block is never executed by Quarto and reaches no Typst output, so it
  * carries no context and compiles on its own.
  */
-export function buildPlainSource(block: TypstBlock, header: string): AssembledSource {
+export function buildPlainSource(block: TypstUnit, header: string): AssembledSource {
 	return assemble([header], block.body);
 }
 
@@ -73,7 +73,7 @@ export function buildPlainSource(block: TypstBlock, header: string): AssembledSo
  * directives that the preview has no way to apply, so a block relying on
  * template state diverges.
  */
-export function buildRawSource(blocks: readonly TypstBlock[], target: TypstBlock, header: string): AssembledSource {
+export function buildRawSource(blocks: readonly TypstUnit[], target: TypstUnit, header: string): AssembledSource {
 	const context = precedingRawBlocks(blocks, target).map((block) => block.body);
 	return assemble([header, ...context], target.body);
 }
@@ -227,7 +227,7 @@ function cellBody(body: string): string {
  * render. A cell that reads it is out of scope for the first version, which
  * `docs/getting-started/typst-preview.qmd` states.
  */
-function buildCellSource(block: TypstBlock, options: CellSourceOptions): AssembledSource {
+function buildCellSource(block: TypstUnit, options: CellSourceOptions): AssembledSource {
 	const above = [
 		`#let _typst_render_background = ${options.background}`,
 		`#let _typst_render_foreground = ${options.foreground ?? "none"}`,
@@ -395,7 +395,7 @@ function textOption(value: unknown, name: string, dropped: string[]): string | r
 	return undefined;
 }
 
-export async function buildCell(block: TypstBlock, context: CellContext): Promise<AssembledCell | Unavailable> {
+export async function buildCell(block: TypstUnit, context: CellContext): Promise<AssembledCell | Unavailable> {
 	const brand = brandColourReader(context.brand);
 	const global = mergeGlobalConfigs(context.levels, brand);
 	const options = resolveTypstOptions(block, global, brand);


### PR DESCRIPTION
Second layer of the inline Typst preview stack. No behaviour change.

`TypstBlock` becomes `TypstUnit` and gains two fields.
`scope` says whether a unit came from a fence or an inline span, and is `block` everywhere in this layer.
`unitEnd` is where a unit ends, which is `bodyEnd` for a fence.

`unitEnd` exists because an inline body ends before the closing backtick run, and the attribute that decides the kind sits after it.
Four readers that pair `fenceStart` with the end of a unit now read it: `blockAtOffset`, the hover range, `movedBlock` and `invalidatesPreview`.
The last two were found by review rather than by the plan, and both are behaviour neutral while every unit is a fence.

`findTypstBlocks` becomes `findTypstUnits`. No alias is kept.
`blockAtOffset`, `precedingRawBlocks`, `invalidatesPreview`, `hasLateOptionLine` and `getDocumentTypstBlocks` keep their names and take the new type.

Verified with `npm run test`, `npm run lint` and `npm run format:check`.