### PR TITLE
feat: read inline Typst spans into the document scan

### DIFF
--- a/src/providers/typstPreview/typstPreviewCodeLens.ts
+++ b/src/providers/typstPreview/typstPreviewCodeLens.ts
@@ -92,6 +92,11 @@ export class TypstPreviewCodeLens implements vscode.CodeLensProvider, vscode.Dis
 		}
 		const lenses: vscode.CodeLens[] = [];
 		for (const block of this.controller.blocksOf(document)) {
+			// A lens sits above a line of its own, and an inline span shares its line
+			// with prose, so there is no line a lens could take.
+			if (block.scope !== "block") {
+				continue;
+			}
 			if (token.isCancellationRequested) {
 				// A newer version of the document is being scanned already, and half a
 				// list is worse than none: it would take the lenses off the blocks it

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -454,4 +454,23 @@ suite("Typst Blocks Test Suite", () => {
 			assert.strictEqual(invalidatesPreview(plain, insertion(plain.unitEnd + 1)), false);
 		});
 	});
+
+	suite("invalidatesPreview for an inline unit", () => {
+		// The attribute sits between `bodyEnd` and `unitEnd`, so a check pinned at
+		// `bodyEnd` again would miss an edit here, because the edit never touches
+		// the body.
+		const text = "A circle: `#circle()`{.typst}.\n";
+		const [unit] = findTypstUnits(text);
+
+		test("Should invalidate an inline unit when an edit rewrites its attribute", () => {
+			// Rewriting `{.typst}` to `{.python}` changes the kind, so the preview
+			// must be treated as out of date.
+			const start = text.indexOf(".typst");
+			assert.strictEqual(invalidatesPreview(unit, { rangeOffset: start, rangeLength: "typst".length }), true);
+		});
+
+		test("Should leave an inline unit alone when the edit sits past its end", () => {
+			assert.strictEqual(invalidatesPreview(unit, { rangeOffset: unit.unitEnd + 1, rangeLength: 0 }), false);
+		});
+	});
 });

--- a/src/test/suite/typstBlocks.test.ts
+++ b/src/test/suite/typstBlocks.test.ts
@@ -311,6 +311,15 @@ suite("Typst Blocks Test Suite", () => {
 			const block = findTypstUnits("```{typst}\n#a\n//| dpi:300\n```\n")[0];
 			assert.strictEqual(hasLateOptionLine(block), false);
 		});
+
+		test("Should not report an inline unit, which has no option run at all", () => {
+			// An inline unit carries no `//|` run, so a line that looks like one is
+			// code. The guard is `block.scope === "block"` and nothing else, so this
+			// holds even when the code itself reads like a late option line.
+			const [unit] = findTypstUnits("Value: `{typst} //| dpi: 300`.\n");
+			assert.strictEqual(unit.scope, "inline");
+			assert.strictEqual(hasLateOptionLine(unit), false);
+		});
 	});
 
 	suite("blockAtOffset", () => {

--- a/src/test/suite/typstInline.test.ts
+++ b/src/test/suite/typstInline.test.ts
@@ -1,0 +1,91 @@
+import * as assert from "assert";
+import { findTypstInlines } from "../../utils/typst/typstInline";
+import { blockAtOffset, findTypstUnits } from "../../utils/typst/typstBlocks";
+
+suite("Typst Inline Test Suite", () => {
+	test("Should read the prefix form as a cell", () => {
+		const text = "The value is `{typst} #calc.pi` today.\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.scope, "inline");
+		assert.strictEqual(unit.kind, "cell");
+		assert.strictEqual(unit.body, "#calc.pi");
+		assert.strictEqual(unit.code, "#calc.pi");
+		assert.strictEqual(text.slice(unit.bodyStart, unit.bodyEnd), "#calc.pi");
+		assert.strictEqual(unit.fenceStart, text.indexOf("`"));
+		assert.strictEqual(unit.unitEnd, text.indexOf("` today") + 1);
+	});
+
+	test("Should read the class form as a cell, because the filter executes it", () => {
+		const text = "A circle: `#circle()`{.typst}.\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.kind, "cell");
+		assert.strictEqual(unit.body, "#circle()");
+		// The attribute belongs to the unit, so a cursor inside it finds the unit.
+		assert.strictEqual(unit.unitEnd, text.indexOf("}") + 1);
+	});
+
+	test("Should read the raw form as raw", () => {
+		const text = "Bound here: `#let a = 1`{=typst}.\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.kind, "raw");
+		assert.strictEqual(unit.body, "#let a = 1");
+	});
+
+	test("Should keep a class beside other classes", () => {
+		const text = "A circle: `#circle()`{.typst .extra}.\n";
+		assert.strictEqual(findTypstInlines(text)[0]?.kind, "cell");
+	});
+
+	test("Should read a span written with a longer backtick run", () => {
+		const text = 'Code: ``{typst} #raw("`")``.\n';
+		assert.strictEqual(findTypstInlines(text)[0]?.body, '#raw("`")');
+	});
+
+	test("Should remove one space from each end, as CommonMark does", () => {
+		const text = "Value: `` {typst} #calc.pi ``.\n";
+		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc.pi");
+	});
+
+	test("Should read no span that is not Typst", () => {
+		const text = "Plain `#circle()` and `x`{.python} and `y`{=html}.\n";
+		assert.deepStrictEqual(findTypstInlines(text), []);
+	});
+
+	test("Should read no span inside a fenced block", () => {
+		const text = ["```markdown", "`{typst} #circle()`", "```", ""].join("\n");
+		assert.deepStrictEqual(findTypstInlines(text), []);
+	});
+
+	test("Should read no span inside the front matter", () => {
+		const text = ["---", 'title: "`{typst} #circle()`"', "---", "", "Prose.", ""].join("\n");
+		assert.deepStrictEqual(findTypstInlines(text), []);
+	});
+
+	test("Should read a span that runs across a line ending", () => {
+		const text = "Value: `{typst} #calc\n.pi`.\n";
+		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc\n.pi");
+	});
+
+	test("Should read a span in a CRLF document", () => {
+		const text = "Value: `{typst} #calc.pi`.\r\nMore prose.\r\n";
+		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc.pi");
+	});
+
+	test("Should merge spans and fences in document order", () => {
+		const text = ["Value: `{typst} #calc.pi`.", "", "```typst", "#circle()", "```", ""].join("\n");
+		const units = findTypstUnits(text);
+		assert.deepStrictEqual(
+			units.map((unit) => unit.scope),
+			["inline", "block"],
+		);
+	});
+
+	test("Should find the unit under a cursor on the closing run or in the attribute", () => {
+		const text = "A circle: `#circle()`{.typst}.\n";
+		const units = findTypstUnits(text);
+		const closing = text.indexOf("`{.typst}");
+		const attribute = text.indexOf(".typst");
+		assert.strictEqual(blockAtOffset(units, closing), units[0]);
+		assert.strictEqual(blockAtOffset(units, attribute), units[0]);
+	});
+});

--- a/src/test/suite/typstInline.test.ts
+++ b/src/test/suite/typstInline.test.ts
@@ -112,6 +112,28 @@ suite("Typst Inline Test Suite", () => {
 		assert.deepStrictEqual(findTypstInlines(text), []);
 	});
 
+	test("Should read no span whose attribute merely contains the class inside a quoted value", () => {
+		// A quoted attribute value can hold the text `.typst` bounded by whitespace
+		// or a brace, which would otherwise read as the class.
+		const text = 'Code: `#circle()`{alt="see .typst here"}.\n';
+		assert.deepStrictEqual(findTypstInlines(text), []);
+	});
+
+	test("Should read a real class beside another attribute", () => {
+		const text = 'A circle: `#circle()`{alt="see here" .typst}.\n';
+		assert.strictEqual(findTypstInlines(text)[0]?.kind, "cell");
+	});
+
+	test("Should read no phantom span between two fences of equal run length", () => {
+		// A body-only fenced range leaves the opening backtick run unguarded, and
+		// two fences of the same length let that run pair with the next fence's
+		// opening run, reading the prose between them as one span. `findTypstInlines`
+		// rebuilds the ranges from `fenceStart` to guard against exactly this.
+		const text = ["```typst", "#a", "```", "", "Prose in between.", "", "```{=typst}", "#b", "```", ""].join("\n");
+		assert.deepStrictEqual(findTypstInlines(text), []);
+		assert.ok(findTypstUnits(text).every((unit) => unit.scope === "block"));
+	});
+
 	test("Should merge spans and fences in document order", () => {
 		const text = ["Value: `{typst} #calc.pi`.", "", "```typst", "#circle()", "```", ""].join("\n");
 		const units = findTypstUnits(text);

--- a/src/test/suite/typstInline.test.ts
+++ b/src/test/suite/typstInline.test.ts
@@ -78,6 +78,27 @@ suite("Typst Inline Test Suite", () => {
 		assert.strictEqual(text.slice(unit.bodyStart, unit.bodyEnd), "#calc\r\n.pi");
 	});
 
+	test("Should measure the prefix separator in document units when it is a CRLF", () => {
+		// The `\r\n` between `{typst}` and the code is two document characters but
+		// one converted character, so a prefix length read from the converted text
+		// would land `bodyStart` one character early, inside the line ending
+		// rather than on the code that follows it.
+		const text = "Value: `{typst}\r\n#calc.pi`.\r\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.body, "#calc.pi");
+		assert.strictEqual(text.slice(unit.bodyStart, unit.bodyEnd), "#calc.pi");
+	});
+
+	test("Should measure the prefix separator in document units when it is a bare newline", () => {
+		// A bare `\n` is one document character and one converted character, so
+		// this was already correct before the CRLF fix above. Pinned here so the
+		// fix does not shift it.
+		const text = "Value: `{typst}\n#calc.pi`.\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.body, "#calc.pi");
+		assert.strictEqual(text.slice(unit.bodyStart, unit.bodyEnd), "#calc.pi");
+	});
+
 	test("Should read a span in a CRLF document", () => {
 		const text = "Value: `{typst} #calc.pi`.\r\nMore prose.\r\n";
 		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc.pi");

--- a/src/test/suite/typstInline.test.ts
+++ b/src/test/suite/typstInline.test.ts
@@ -62,13 +62,33 @@ suite("Typst Inline Test Suite", () => {
 	});
 
 	test("Should read a span that runs across a line ending", () => {
+		// CommonMark converts every line ending inside a span to one space before
+		// the span's content exists at all, so Pandoc hands the filter one line.
 		const text = "Value: `{typst} #calc\n.pi`.\n";
-		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc\n.pi");
+		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc .pi");
+	});
+
+	test("Should convert an embedded CRLF to one space and keep bodyEnd on the document", () => {
+		// A converted `\r\n` is one character shorter than the two document
+		// characters it replaced, so this pins `bodyEnd` against the raw text
+		// rather than against `body.length`.
+		const text = "Value: `{typst} #calc\r\n.pi`.\r\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.body, "#calc .pi");
+		assert.strictEqual(text.slice(unit.bodyStart, unit.bodyEnd), "#calc\r\n.pi");
 	});
 
 	test("Should read a span in a CRLF document", () => {
 		const text = "Value: `{typst} #calc.pi`.\r\nMore prose.\r\n";
 		assert.strictEqual(findTypstInlines(text)[0]?.body, "#calc.pi");
+	});
+
+	test("Should read no span whose attribute merely contains the raw text, unquoted key=value", () => {
+		// Pandoc's bracketed attribute syntax allows an unquoted `key=value` pair,
+		// so `{lang=typst-preview}` holds the substring `=typst` without being the
+		// raw-passthrough form `{=typst}`.
+		const text = "Code: `#circle()`{lang=typst-preview}.\n";
+		assert.deepStrictEqual(findTypstInlines(text), []);
 	});
 
 	test("Should merge spans and fences in document order", () => {

--- a/src/test/suite/typstPathOptions.test.ts
+++ b/src/test/suite/typstPathOptions.test.ts
@@ -98,6 +98,14 @@ suite("Typst Path Options Test Suite", () => {
 			assert.deepStrictEqual(covered(text), []);
 		});
 
+		test("Should ignore an inline cell, which has no option run at all", () => {
+			// An inline cell carries no `//|` run, so a line that looks like one
+			// inside it is code, and `cellPathOptions` skips a unit whose scope is
+			// not `block` before it ever reads a line.
+			const text = "Value: `{typst} //| file: a.typ`.\n";
+			assert.deepStrictEqual(covered(text), []);
+		});
+
 		test("Should report the offset of an indented cell", () => {
 			const text = "- item\n\n  ```{typst}\n  //| file: _plot.typ\n  ```\n";
 			const option = only(text);

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -190,6 +190,22 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should offer no code lens above an inline span", async () => {
+		// A lens sits above a line of its own, and an inline span shares its line
+		// with prose, so there is no line a lens could take. The document holds the
+		// three fences the lens already covers, plus one inline cell, and the lens
+		// list must not grow past the three.
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
+		const lens = new TypstPreviewCodeLens(controller, fixedSettings(["panel"]));
+		const document = await quartoDocument(THREE_KINDS + "\nValue: `{typst} #calc.pi`.\n");
+
+		const lenses = lens.provideCodeLenses(document, NO_CANCEL);
+
+		assert.strictEqual(lenses.length, 3);
+		lens.dispose();
+		controller.dispose();
+	});
+
 	test("Should offer no code lens when the setting turns it off", async () => {
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
 		const off = new TypstPreviewCodeLens(controller, fixedSettings(["panel"], 200, false));

--- a/src/utils/typst/typstBlocks.ts
+++ b/src/utils/typst/typstBlocks.ts
@@ -7,6 +7,7 @@ import {
 	removeIndentColumns,
 	type FencedBlock,
 } from "../yamlPosition";
+import { findTypstInlines } from "./typstInline";
 
 /**
  * The three fence kinds that carry Typst source in a Quarto document.
@@ -215,7 +216,12 @@ function parseOptions(body: string): { options: Record<string, string | boolean>
 
 /** Whether a body carries an option line after its code, which Lua warns about. */
 export function hasLateOptionLine(block: TypstUnit): boolean {
-	return block.kind === "cell" && block.code.split(/\r?\n/).some((line) => LATE_OPTION_LINE.test(line));
+	// A span has no option run at all, so a `//|` line inside one is code.
+	return (
+		block.scope === "block" &&
+		block.kind === "cell" &&
+		block.code.split(/\r?\n/).some((line) => LATE_OPTION_LINE.test(line))
+	);
 }
 
 /**
@@ -273,7 +279,11 @@ export function findTypstUnits(text: string): TypstUnit[] {
 		});
 	}
 
-	return blocks;
+	// One list, in document order. A raw span and a raw fence both reach the Typst
+	// output through Pandoc in the order they are written, so the accumulation
+	// chain of `precedingRawBlocks` reads them together and needs no rule of its
+	// own.
+	return [...blocks, ...findTypstInlines(text)].sort((left, right) => left.fenceStart - right.fenceStart);
 }
 
 /**

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -36,9 +36,17 @@ const PREFIX_RAW = /^\{typst\}(?:[ \t]|\r\n|\r|\n)?/;
 /** The raw-passthrough form, whitespace inside the braces aside. */
 const RAW_ATTRIBUTE = /^\{\s*=typst\s*\}$/;
 
-/** Whether an attribute carries the class the filter matches on. */
+/**
+ * Whether an attribute carries the class the filter matches on.
+ *
+ * A quoted value can hold the text `.typst` bounded by whitespace or a brace,
+ * for example `{alt="see .typst here"}`, which would otherwise read as the
+ * class. Quoted values are stripped before the scan, so only an actual class
+ * token can match.
+ */
 function hasTypstClass(attribute: string): boolean {
-	return /(^|[\s{])\.typst(?=[\s}])/.test(attribute);
+	const withoutQuotedValues = attribute.replace(/"[^"]*"|'[^']*'/g, "");
+	return /(^|[\s{])\.typst(?=[\s}])/.test(withoutQuotedValues);
 }
 
 /**
@@ -100,18 +108,22 @@ export function findTypstInlines(text: string): TypstUnit[] {
 	const fences = findFencedBlocks(source).map((block) => ({ start: block.fenceStart, end: block.end }));
 
 	const units: TypstUnit[] = [];
+	// The spans arrive sorted, so the line of each one is counted onward from the
+	// last one read rather than from the start of the source every time.
+	let lastIndex = 0;
+	let lastLine = firstLine;
 	for (const span of getInlineCodeSpanRanges(source, fences)) {
 		const run = /^`+/.exec(source.slice(span.start, span.end))?.[0].length ?? 0;
 		const raw = source.slice(span.start + run, span.end - run);
 		const attributeMatch = ATTRIBUTE.exec(source.slice(span.end));
 		const attribute = attributeMatch?.[0] ?? "";
 
-		const kind = classify(raw, attribute);
+		const content = spanContent(raw);
+		const kind = classify(content.text, attribute);
 		if (kind === undefined) {
 			continue;
 		}
 
-		const content = spanContent(raw);
 		const prefix = attribute === "" ? (PREFIX.exec(content.text)?.[0].length ?? 0) : 0;
 		const body = content.text.slice(prefix);
 
@@ -128,12 +140,13 @@ export function findTypstInlines(text: string): TypstUnit[] {
 		const bodyStart = span.start + run + content.leading + rawPrefix + from;
 		const bodyEnd = span.end - run - content.trailing + from;
 
-		let line = firstLine;
-		for (let index = 0; index < span.start; index++) {
+		for (let index = lastIndex; index < span.start; index++) {
 			if (source[index] === "\n") {
-				line++;
+				lastLine++;
 			}
 		}
+		lastIndex = span.start;
+		const line = lastLine;
 
 		units.push({
 			scope: "inline",
@@ -157,8 +170,23 @@ export function findTypstInlines(text: string): TypstUnit[] {
 	return units;
 }
 
-/** The kind a span declares, or undefined when it is not Typst. */
-function classify(raw: string, attribute: string): TypstUnitKind | undefined {
+/**
+ * The kind a span declares, or undefined when it is not Typst.
+ *
+ * Upstream, `cell.is_inline_code` tests the class first and reaches the text
+ * prefix only when that test fails, so `` `{typst} #x`{.python} `` is read as
+ * not an inline cell even though its text carries the prefix: the class test
+ * alone decides it, because it is reached first and an element carrying
+ * `.python` fails it. This module follows that order, an attribute before a
+ * prefix, so the same span is skipped here too. The reasoning is a reading of
+ * the filter and not a recorded render, and the direction it commits to on
+ * that uncertainty is the safe one: show nothing rather than an image the
+ * render does not produce.
+ *
+ * @param text - The span's content, converted the way `spanContent` reads it,
+ *   so a prefix that runs across a line ending is still found.
+ */
+function classify(text: string, attribute: string): TypstUnitKind | undefined {
 	if (attribute !== "") {
 		// Anchored on the whole attribute, the way the block classifier reads
 		// `{=typst}`. Pandoc's bracketed attribute syntax allows an unquoted
@@ -169,5 +197,5 @@ function classify(raw: string, attribute: string): TypstUnitKind | undefined {
 		}
 		return hasTypstClass(attribute) ? "cell" : undefined;
 	}
-	return PREFIX.test(spanContent(raw).text) ? "cell" : undefined;
+	return PREFIX.test(text) ? "cell" : undefined;
 }

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -22,24 +22,41 @@ const ATTRIBUTE = /^\{[^}\n]*\}/;
 /** The prefix form, whose info sits inside the span, `cell.inline_code_text`. */
 const PREFIX = /^\{typst\}[ \t]?/;
 
+/** The raw-passthrough form, whitespace inside the braces aside. */
+const RAW_ATTRIBUTE = /^\{\s*=typst\s*\}$/;
+
 /** Whether an attribute carries the class the filter matches on. */
 function hasTypstClass(attribute: string): boolean {
 	return /(^|[\s{])\.typst(?=[\s}])/.test(attribute);
 }
 
 /**
- * The content of a span, without the rule CommonMark applies to its ends.
+ * The content of a span, converted the way Pandoc hands it to the filter.
  *
- * One space comes off each end when both ends have one and the content is not
- * only spaces. The offset of the first kept character comes back beside the
- * text, because every offset this module reports is a document offset.
+ * CommonMark converts every line ending inside a code span to one space
+ * before the span's content exists at all, so a body written across two
+ * lines compiles as one line, and `code` has to match what actually renders.
+ * Only then does one leading and one trailing literal space come off, and
+ * only a space: a tab was never a line ending and survives, because the
+ * conversion above has already spent every line ending by the time this rule
+ * runs.
+ *
+ * The raw document length consumed at each end comes back beside the text,
+ * because a converted `\r\n` is one character shorter than the two document
+ * characters it replaced, and every offset this module reports has to stay a
+ * document offset regardless of what the conversion did to the text.
  */
-function spanContent(raw: string): { text: string; offset: number } {
-	const stripped = /^[ \t\r\n](.*)[ \t\r\n]$/s.exec(raw);
-	if (stripped === null || raw.trim() === "") {
-		return { text: raw, offset: 0 };
+function spanContent(raw: string): { text: string; leading: number; trailing: number } {
+	const normalised = raw.replace(/\r\n|\r|\n/g, " ");
+	const strip = normalised[0] === " " && normalised[normalised.length - 1] === " " && normalised.trim() !== "";
+	if (!strip) {
+		return { text: normalised, leading: 0, trailing: 0 };
 	}
-	return { text: stripped[1], offset: 1 };
+	return {
+		text: normalised.slice(1, -1),
+		leading: raw.startsWith("\r\n") ? 2 : 1,
+		trailing: raw.endsWith("\r\n") ? 2 : 1,
+	};
 }
 
 /**
@@ -86,7 +103,8 @@ export function findTypstInlines(text: string): TypstUnit[] {
 		const content = spanContent(raw);
 		const prefix = attribute === "" ? (PREFIX.exec(content.text)?.[0].length ?? 0) : 0;
 		const body = content.text.slice(prefix);
-		const bodyStart = span.start + run + content.offset + prefix + from;
+		const bodyStart = span.start + run + content.leading + prefix + from;
+		const bodyEnd = span.end - run - content.trailing + from;
 
 		let line = firstLine;
 		for (let index = 0; index < span.start; index++) {
@@ -103,7 +121,10 @@ export function findTypstInlines(text: string): TypstUnit[] {
 			code: body,
 			options: {},
 			bodyStart,
-			bodyEnd: bodyStart + body.length,
+			// Not `bodyStart + body.length`: an embedded CRLF converts to one space
+			// in `body` and so is one character shorter than the document text it
+			// replaced, and this offset has to stay a document offset regardless.
+			bodyEnd,
 			unitEnd: span.end + attribute.length + from,
 			fenceStart: span.start + from,
 			fenceLine: line,
@@ -117,7 +138,11 @@ export function findTypstInlines(text: string): TypstUnit[] {
 /** The kind a span declares, or undefined when it is not Typst. */
 function classify(raw: string, attribute: string): TypstUnitKind | undefined {
 	if (attribute !== "") {
-		if (attribute.includes("=typst")) {
+		// Anchored on the whole attribute, the way the block classifier reads
+		// `{=typst}`. Pandoc's bracketed attribute syntax allows an unquoted
+		// `key=value` pair, so a substring test would misread `{lang=typst-preview}`
+		// as the same raw-passthrough form.
+		if (RAW_ATTRIBUTE.test(attribute)) {
 			return "raw";
 		}
 		return hasTypstClass(attribute) ? "cell" : undefined;

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -22,6 +22,17 @@ const ATTRIBUTE = /^\{[^}\n]*\}/;
 /** The prefix form, whose info sits inside the span, `cell.inline_code_text`. */
 const PREFIX = /^\{typst\}[ \t]?/;
 
+/**
+ * The prefix form matched against raw document text rather than the
+ * line-ending-converted text `PREFIX` reads.
+ *
+ * The separator after `{typst}` is one document unit: a space, a tab, or one
+ * line ending, and a `\r\n` is two document characters read as that one unit.
+ * `\r\n` has to come before the lone `\r` alternative, or the alternation
+ * would take the `\r` on its own and leave the `\n` to be read as code.
+ */
+const PREFIX_RAW = /^\{typst\}(?:[ \t]|\r\n|\r|\n)?/;
+
 /** The raw-passthrough form, whitespace inside the braces aside. */
 const RAW_ATTRIBUTE = /^\{\s*=typst\s*\}$/;
 
@@ -103,7 +114,18 @@ export function findTypstInlines(text: string): TypstUnit[] {
 		const content = spanContent(raw);
 		const prefix = attribute === "" ? (PREFIX.exec(content.text)?.[0].length ?? 0) : 0;
 		const body = content.text.slice(prefix);
-		const bodyStart = span.start + run + content.leading + prefix + from;
+
+		// Every offset this module reports counts document characters, and `body`
+		// counts the characters the filter reads, so the two lengths differ by
+		// every line ending the conversion collapsed. `prefix` is in the second
+		// unit, right for slicing `body` out of `content.text`, wrong for adding to
+		// a document offset. Matched again here, against the raw text with the
+		// CommonMark ends already removed, so the length is in document units and
+		// needs no further correction.
+		const rawContent = raw.slice(content.leading, raw.length - content.trailing);
+		const rawPrefix = attribute === "" ? (PREFIX_RAW.exec(rawContent)?.[0].length ?? 0) : 0;
+
+		const bodyStart = span.start + run + content.leading + rawPrefix + from;
 		const bodyEnd = span.end - run - content.trailing + from;
 
 		let line = firstLine;

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -1,0 +1,126 @@
+import { findFencedBlocks, getInlineCodeSpanRanges, getYamlFrontMatterRange } from "../yamlPosition";
+import type { TypstUnit, TypstUnitKind } from "./typstBlocks";
+
+/**
+ * The Typst carried by an inline code span.
+ *
+ * The `typst-render` filter walks Pandoc `Code` inlines beside `CodeBlock`
+ * elements, so an inline cell renders to an image and the editor has to say so.
+ *
+ * The rule is the filter's own, at `cell.is_inline_code`: the class `typst` and
+ * the text prefix `{typst}` are the same executable cell. That is not the block
+ * rule, where a `.typst` fence is a plain block Quarto only highlights, and the
+ * difference is deliberate upstream.
+ *
+ * There is no inline `plain` kind for that reason. An inline span is a cell or
+ * a raw passthrough, and nothing else.
+ */
+
+/** An attribute that follows the closing backtick run, on the same line. */
+const ATTRIBUTE = /^\{[^}\n]*\}/;
+
+/** The prefix form, whose info sits inside the span, `cell.inline_code_text`. */
+const PREFIX = /^\{typst\}[ \t]?/;
+
+/** Whether an attribute carries the class the filter matches on. */
+function hasTypstClass(attribute: string): boolean {
+	return /(^|[\s{])\.typst(?=[\s}])/.test(attribute);
+}
+
+/**
+ * The content of a span, without the rule CommonMark applies to its ends.
+ *
+ * One space comes off each end when both ends have one and the content is not
+ * only spaces. The offset of the first kept character comes back beside the
+ * text, because every offset this module reports is a document offset.
+ */
+function spanContent(raw: string): { text: string; offset: number } {
+	const stripped = /^[ \t\r\n](.*)[ \t\r\n]$/s.exec(raw);
+	if (stripped === null || raw.trim() === "") {
+		return { text: raw, offset: 0 };
+	}
+	return { text: stripped[1], offset: 1 };
+}
+
+/**
+ * Every inline Typst unit of a document, in document order.
+ *
+ * The spans come from `getInlineCodeSpanRanges`, which follows the CommonMark
+ * rule for a code span, skips the fenced regions it is given, and ends its range
+ * at the closing backtick run. The attribute is outside that range on purpose,
+ * which is what lets this read it.
+ */
+export function findTypstInlines(text: string): TypstUnit[] {
+	// Scan below the front matter, as the fence scan does. A block scalar can hold
+	// a line that looks like a span, and a title holding backticks is common.
+	const frontMatter = getYamlFrontMatterRange(text);
+	const from = frontMatter?.end ?? 0;
+	const source = from === 0 ? text : text.slice(from);
+
+	let firstLine = 0;
+	for (let index = 0; index < from; index++) {
+		if (text[index] === "\n") {
+			firstLine++;
+		}
+	}
+
+	// `findFencedBlocks` reports the body range, which starts after the opening
+	// fence line so a reader of the info string finds it outside the range. That
+	// leaves the opening backtick run itself unguarded, and two fences of the
+	// same length let that run pair with the next fence's opening run, so the
+	// range given here has to reach back to `fenceStart` instead.
+	const fences = findFencedBlocks(source).map((block) => ({ start: block.fenceStart, end: block.end }));
+
+	const units: TypstUnit[] = [];
+	for (const span of getInlineCodeSpanRanges(source, fences)) {
+		const run = /^`+/.exec(source.slice(span.start, span.end))?.[0].length ?? 0;
+		const raw = source.slice(span.start + run, span.end - run);
+		const attributeMatch = ATTRIBUTE.exec(source.slice(span.end));
+		const attribute = attributeMatch?.[0] ?? "";
+
+		const kind = classify(raw, attribute);
+		if (kind === undefined) {
+			continue;
+		}
+
+		const content = spanContent(raw);
+		const prefix = attribute === "" ? (PREFIX.exec(content.text)?.[0].length ?? 0) : 0;
+		const body = content.text.slice(prefix);
+		const bodyStart = span.start + run + content.offset + prefix + from;
+
+		let line = firstLine;
+		for (let index = 0; index < span.start; index++) {
+			if (source[index] === "\n") {
+				line++;
+			}
+		}
+
+		units.push({
+			scope: "inline",
+			kind,
+			body,
+			// A span carries no option run, so the two are the same text.
+			code: body,
+			options: {},
+			bodyStart,
+			bodyEnd: bodyStart + body.length,
+			unitEnd: span.end + attribute.length + from,
+			fenceStart: span.start + from,
+			fenceLine: line,
+			indent: 0,
+		});
+	}
+
+	return units;
+}
+
+/** The kind a span declares, or undefined when it is not Typst. */
+function classify(raw: string, attribute: string): TypstUnitKind | undefined {
+	if (attribute !== "") {
+		if (attribute.includes("=typst")) {
+			return "raw";
+		}
+		return hasTypstClass(attribute) ? "cell" : undefined;
+	}
+	return PREFIX.test(spanContent(raw).text) ? "cell" : undefined;
+}

--- a/src/utils/typst/typstPathOptions.ts
+++ b/src/utils/typst/typstPathOptions.ts
@@ -87,9 +87,9 @@ function cellPathOptions(text: string, blocks: readonly TypstUnit[]): TypstPathO
 	const found: TypstPathOption[] = [];
 
 	for (const block of blocks) {
-		// Only a cell carries options. In the other two kinds a `//|` line is an
-		// ordinary Typst comment.
-		if (block.kind !== "cell") {
+		// Only a fenced cell carries options. In the other two kinds a `//|` line is
+		// an ordinary Typst comment, and an inline cell has no option run at all.
+		if (block.scope !== "block" || block.kind !== "cell") {
 			continue;
 		}
 


### PR DESCRIPTION
Third layer of the inline Typst preview stack.

The `typst-render` filter walks Pandoc `Code` inlines beside `CodeBlock` elements, so an author writes `` `{typst} #calc.pi` `` and gets an image in the render, and the editor showed nothing.

`src/utils/typst/typstInline.ts` classifies the spans that `getInlineCodeSpanRanges` already finds, and `findTypstUnits` merges them with the fences in document order.
The classification is the filter own rule: the class `typst` and the text prefix `{typst}` are the same executable cell, which inverts the block rule where a `.typst` fence is only highlighted, and `=typst` is a raw passthrough.
There is no inline `plain` kind for that reason.

Three readers act on fenced units only, and each is guarded and tested: the code lens, the cell path options reader and `hasLateOptionLine`.

Four defects were found while building this and each carries its own commit and test:

- `findFencedBlocks` reports a body range that starts after the opening fence line, so the opening backtick run was unguarded and two fences of equal run length paired into a phantom span covering both fences and the prose between them.
- `=typst` was matched as a substring, so `{lang=typst-preview}` read as a passthrough.
- CommonMark converts a line ending inside a code span to one space before the span content exists, so the filter reads a space and the preview would have compiled a newline.
- A line ending inside the `{typst}` separator is one converted character and up to two document characters, so `bodyStart` landed one character early on a CRLF document.
- A quoted attribute value holding `.typst` classified the span as a cell.

Verified with `npm run test`, `npm run lint` and `npm run format:check`.