### PR TITLE
feat: compile an inline Typst cell as the filter does

### DIFF
--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -5,6 +5,7 @@ import {
 	buildPlainSource,
 	buildRawSource,
 	buildCell,
+	buildInlineCell,
 	isUnavailable,
 	type Unavailable,
 } from "../../utils/typst/typstSource";
@@ -289,8 +290,13 @@ export async function buildCompileRequest(
 		const assembled = block.kind === "raw" ? buildRawSource(blocks, block, header) : buildPlainSource(block, header);
 		// A raw block reaches Typst through the document template, which contributes
 		// imports, show rules and set directives the preview cannot apply. Saying so
-		// beside the image is what stops a divergence being read as a defect.
+		// beside the image is what stops a divergence being read as a defect. An
+		// inline passthrough sits inside a paragraph as well, whose prose reaches
+		// the output around it and is not compiled here.
 		const notes = block.kind === "raw" ? ["the document template is not applied to a raw passthrough"] : [];
+		if (block.kind === "raw" && block.scope === "inline") {
+			notes.push("the prose around an inline passthrough is not compiled");
+		}
 		// Neither kind reaches the filter, so neither carries an option of it. The
 		// directory of the document is the whole answer, and finding it costs no
 		// read, which is what keeps these two off the disk entirely.
@@ -316,7 +322,8 @@ export async function buildCompileRequest(
 	// this preview, asked while looking at it.
 	const mode = brandMode ?? documentBrandMode(chain.metadata) ?? themeBrandMode();
 
-	const built = await buildCell(block, {
+	const build = block.scope === "inline" ? buildInlineCell : buildCell;
+	const built = await build(block, {
 		levels: chain.levels,
 		brand,
 		mode,

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -241,6 +241,12 @@ export function errorText(stderr: string, place: ErrorPlace): string {
 /** What the surface says about the block it is displaying. */
 export function headerText(document: vscode.TextDocument, request: CompileRequest): string {
 	const parts = [`${path.basename(document.fileName)} · line ${request.block.fenceLine + 1}`];
+	if (request.block.scope === "inline") {
+		// An inline unit is cropped to its glyphs by a page directive the filter
+		// fixes, so its image is a different shape from every fenced one, and the
+		// reader is told which they are looking at.
+		parts.push(request.block.kind === "raw" ? "inline passthrough" : "inline cell");
+	}
 	if (request.brandMode !== undefined) {
 		// A cell resolves its `auto` colours against one side of the brand, and
 		// which side it took is not visible in the image when the two are close.

--- a/src/test/suite/typstPreviewContext.test.ts
+++ b/src/test/suite/typstPreviewContext.test.ts
@@ -557,6 +557,15 @@ suite("Typst Preview Context Test Suite", () => {
 			assert.strictEqual(request.source, `${HEADER}\n#let a = red\n#text(fill: a)[Hi]\n`);
 			assert.strictEqual(request.injectedLines, 2);
 		});
+
+		test("Should compile an inline passthrough with the raw blocks above it", async () => {
+			const text = ["```{=typst}", "#let a = 1", "```", "", "Value: `#a`{=typst}.", ""].join("\n");
+			const document = await documentOf(text);
+			const request = await buildCompileRequest(document, new vscode.Position(4, 8), HEADER, new TypstContextCache());
+			assert.ok(!isUnavailable(request));
+			assert.ok(request.source.includes("#let a = 1"));
+			assert.ok(request.notes.includes("the prose around an inline passthrough is not compiled"));
+		});
 	});
 
 	suite("readMetadataChain and readBrand", () => {

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -1,6 +1,9 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { errorText, themeKindOf } from "../../providers/typstPreview/typstPreviewController";
+import { errorText, headerText, themeKindOf } from "../../providers/typstPreview/typstPreviewController";
+import type { CompileRequest } from "../../providers/typstPreview/typstContext";
+import { findTypstUnits, type TypstUnit } from "../../utils/typst/typstBlocks";
+import { findTypstInlines } from "../../utils/typst/typstInline";
 import {
 	DEFAULT_DEBOUNCE_MS,
 	previewColour,
@@ -91,6 +94,43 @@ suite("Typst Preview Messages Test Suite", () => {
 
 		test("Should say so when the compiler reported nothing at all", () => {
 			assert.strictEqual(errorText("", { injectedLines: 1 }), "Typst produced no image and reported nothing.");
+		});
+	});
+
+	suite("headerText", () => {
+		/** A document named only by its file name, which is all `headerText` reads of it. */
+		function document(fileName: string): vscode.TextDocument {
+			return { fileName } as vscode.TextDocument;
+		}
+
+		/** A request naming the given block, with every other field at its plainest. */
+		function requestOf(block: TypstUnit): CompileRequest {
+			return {
+				block,
+				blockIndex: 0,
+				source: "",
+				command: { argv: [] },
+				injectedLines: 0,
+				bodyLineOffset: 0,
+				notes: [],
+			};
+		}
+
+		test("Should say nothing about scope for a fenced cell", () => {
+			const [block] = findTypstUnits("```{typst}\n#circle()\n```\n");
+			assert.strictEqual(headerText(document("doc.qmd"), requestOf(block)), "doc.qmd · line 1");
+		});
+
+		test("Should name an inline cell", () => {
+			// The image is cropped to its glyphs, a different shape from every fenced
+			// one, so the reader is told which kind they are looking at.
+			const [block] = findTypstInlines("Value: `{typst} #calc.pi`.\n");
+			assert.strictEqual(headerText(document("doc.qmd"), requestOf(block)), "doc.qmd · line 1 · inline cell");
+		});
+
+		test("Should name an inline passthrough", () => {
+			const [block] = findTypstInlines("Value: `#a`{=typst}.\n");
+			assert.strictEqual(headerText(document("doc.qmd"), requestOf(block)), "doc.qmd · line 1 · inline passthrough");
 		});
 	});
 

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -1,6 +1,15 @@
 import * as assert from "assert";
 import { findTypstUnits } from "../../utils/typst/typstBlocks";
-import { buildPlainSource, buildRawSource, themeHeader, type TypstThemeKind } from "../../utils/typst/typstSource";
+import { EMPTY_BRAND } from "../../utils/typst/typstBrand";
+import { findTypstInlines } from "../../utils/typst/typstInline";
+import {
+	buildInlineCell,
+	buildPlainSource,
+	buildRawSource,
+	isUnavailable,
+	themeHeader,
+	type TypstThemeKind,
+} from "../../utils/typst/typstSource";
 
 /** The page setup a preview injects above every block. */
 const HEADER = "#set page(width: auto, height: auto, margin: 0.5em)";
@@ -187,6 +196,29 @@ suite("Typst Source Test Suite", () => {
 			const blocks = findTypstUnits("```typst\n#circle()\n```\n");
 			const { header } = themeHeader("dark", "auto", "auto");
 			assert.strictEqual(buildPlainSource(blocks[0], header).injectedLines, 2);
+		});
+	});
+
+	suite("buildInlineCell", () => {
+		test("Should build an inline cell with the page directive of the filter", async () => {
+			const [unit] = findTypstInlines("Value: `{typst} #calc.pi`.\n");
+			const built = await buildInlineCell(unit, {
+				levels: [],
+				brand: EMPTY_BRAND,
+				mode: "light",
+				// A fixture drives the assembly from strings alone, so it names no place
+				// on disk, and the command it builds carries no root.
+				paths: {},
+				readFile: () => Promise.resolve(undefined),
+			});
+			assert.ok(!isUnavailable(built));
+			assert.match(
+				built.source,
+				/#set page\(width: auto, height: auto, margin: \(x: 0\.5pt, top: 0\.5pt, bottom: 0\.25em\), fill: none\)/,
+			);
+			assert.ok(built.source.endsWith("#calc.pi"));
+			// A span carries no option run, so nothing of the body sits above the code.
+			assert.strictEqual(built.bodyLineOffset, 0);
 		});
 	});
 });

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -473,3 +473,65 @@ export async function buildCell(block: TypstUnit, context: CellContext): Promise
 	}
 	return { ...assembled, command, notes, bodyLineOffset, externalFile };
 }
+
+/**
+ * The page settings `process_inline_code` applies, and which no option changes.
+ *
+ * The filter hardcodes all three for an inline cell, so a global `width:` or
+ * `margin:` reaches a fenced cell and never reaches a span. The image is meant
+ * to sit on a line of text, and these are what crop it to the glyphs.
+ */
+const INLINE_PAGE = Object.freeze({
+	width: "auto",
+	height: "auto",
+	margin: "(x: 0.5pt, top: 0.5pt, bottom: 0.25em)",
+});
+
+/**
+ * The source of one inline Typst cell.
+ *
+ * A port of `process_inline_code`, which shares `build_typst_source` with the
+ * fenced path and differs in three ways: the page geometry above is fixed, no
+ * `//|` option run is parsed, and no block-only option is available. The global
+ * options still apply, so the colours, the preamble and the brand are resolved
+ * exactly as a fenced cell resolves them.
+ */
+export async function buildInlineCell(unit: TypstUnit, context: CellContext): Promise<AssembledCell | Unavailable> {
+	const brand = brandColourReader(context.brand);
+	const global = mergeGlobalConfigs(context.levels, brand);
+	// The unit carries no options, so the merge is the global level alone. It is
+	// still run through the resolver, because that is what turns a brand alias
+	// into a colour and a global `background:` into a Typst expression.
+	const options = resolveTypstOptions(unit, global, brand);
+
+	const droppedOptions: string[] = [];
+	const preambleOption = textOption(options.preamble, "preamble", droppedOptions);
+	const preamble = await resolvePreamble(preambleOption, context.readFile);
+
+	const background = resolveColourValue(options.background, context.mode) ?? String(TYPST_DEFAULTS.background);
+	const foreground = resolveColourValue(options.foreground, context.mode);
+
+	const assembled = buildCellSource(unit, {
+		background,
+		foreground,
+		width: INLINE_PAGE.width,
+		height: INLINE_PAGE.height,
+		margin: INLINE_PAGE.margin,
+		brand: brandDictionary(context.brand, context.mode),
+		preamble,
+	});
+
+	const command = buildTypstCommand({
+		global,
+		background,
+		foreground,
+		paths: context.paths,
+	});
+	const notes = cellNotes(options);
+	for (const name of droppedOptions) {
+		notes.push(`the \`${name}\` option is not text and was ignored`);
+	}
+	// The whole span is the code, so nothing of it sits above the first compiled
+	// line, and there is no `file:` option to replace it.
+	return { ...assembled, command, notes, bodyLineOffset: 0 };
+}


### PR DESCRIPTION
Fourth layer of the inline Typst preview stack.

`buildInlineCell` compiles an inline unit the way `process_inline_code` does upstream.
The page directive is fixed at `width: auto`, `height: auto` and `margin: (x: 0.5pt, top: 0.5pt, bottom: 0.25em)`, which is what crops the image to the glyphs so it sits on a line of text.
No option changes those three, and no option run is parsed, because an inline cell carries none.
The global options still apply, so the colours, the preamble and the brand resolve exactly as they do for a fenced cell.

An inline passthrough compiles through `buildRawSource` with the raw units above it, since the merged unit list already holds the document order.
The panel header names an inline unit, so a reader can see why the margins differ from a fence.

The prose around an inline passthrough reaches the Typst output in a render and is not compiled here.
That is the approximation a raw block already carries, and the panel says so beside the image.

Verified with `npm run test`, `npm run lint` and `npm run format:check`.