### PR TITLE
ci: gate the version bump merge on the required check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,6 @@ jobs:
       COMMIT: "ci: bump version for release :rocket:"
       BUMP_VERSION: ${{ inputs.version }}
 
-    outputs:
-      version: ${{ steps.bump-version.outputs.version }}
-      release_title: ${{ steps.bump-version.outputs.release_title }}
-      summary: ${{ steps.bump-version.outputs.summary }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -109,6 +104,7 @@ jobs:
         run: npm install -g @vscode/vsce
 
       - name: Bump Version / Commit / Push CHANGELOG.md
+        id: bump-pull-request
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -152,10 +148,52 @@ jobs:
           git status
 
           sleep 5
-          gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:"
-          sleep 5
-          gh pr merge --auto --squash --delete-branch
-          sleep 5
+          PR_URL=$(gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:" | tail -n 1)
+          if [ -z "${PR_URL}" ]; then
+            echo "::error::Failed to create the version bump pull request."
+            exit 1
+          fi
+          echo "number=${PR_URL##*/}" >> "${GITHUB_OUTPUT}"
+
+      # `gh pr merge --auto` does not hold the pull request here. The token that
+      # opens it can bypass the ruleset, so the automatic merge flag merges at
+      # once instead of queueing behind the required check. The release then
+      # packages a commit that nothing built. This step is the gate instead.
+      - name: Wait for the required checks to pass
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
+          APPEARANCE_TIMEOUT_SECONDS: "300"
+          POLL_INTERVAL_SECONDS: "15"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # `gh pr checks --watch` fails outright when no check has registered
+          # yet, and a pull request seconds old is exactly that state. Wait for
+          # a required context to appear before watching it.
+          deadline=$((SECONDS + APPEARANCE_TIMEOUT_SECONDS))
+          until [ "$(gh pr checks "${PR_NUMBER}" --required --json state --jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; do
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::No required check reported on pull request ${PR_NUMBER} after ${APPEARANCE_TIMEOUT_SECONDS} seconds."
+              exit 1
+            fi
+            sleep "${POLL_INTERVAL_SECONDS}"
+          done
+
+          gh pr checks "${PR_NUMBER}" --required --watch --fail-fast --interval "${POLL_INTERVAL_SECONDS}"
+
+      - name: Merge the version bump pull request
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch
 
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,19 @@ jobs:
           git status
 
           sleep 5
-          PR_URL=$(gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:" | tail -n 1)
-          PR_NUMBER="${PR_URL##*/}"
+          # A release that stops at the check gate leaves this branch and its
+          # pull request open. The force push above updates that pull request,
+          # so reuse it. `gh pr create` refuses a second one and would end the
+          # re-run here, before the gate it exists to reach.
+          PR_NUMBER=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+          if [ -z "${PR_NUMBER}" ]; then
+            PR_URL=$(gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:" | tail -n 1)
+            PR_NUMBER="${PR_URL##*/}"
+          else
+            echo "::notice::Reusing the open version bump pull request ${PR_NUMBER}."
+          fi
           if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Failed to create the version bump pull request. Read a pull request number from: ${PR_URL}"
+            echo "::error::Failed to open the version bump pull request. Read a pull request number from: ${PR_NUMBER}"
             exit 1
           fi
           echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
@@ -190,7 +199,15 @@ jobs:
           # yet, and a pull request seconds old is exactly that state. Wait for
           # a required context to appear before watching it.
           deadline=$((SECONDS + APPEARANCE_TIMEOUT_SECONDS))
-          until [ "$(gh pr checks "${PR_NUMBER}" --required --json state --jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; do
+          while true; do
+            # `gh pr checks` prints a count and still exits non-zero while the
+            # checks are pending, so read the count and judge it here rather
+            # than let the exit code stand for the answer.
+            count=$(gh pr checks "${PR_NUMBER}" --required --json state --jq 'length' 2>/dev/null || true)
+            count=${count##*$'\n'}
+            if [[ "${count}" =~ ^[1-9][0-9]*$ ]]; then
+              break
+            fi
             if [ "${SECONDS}" -ge "${deadline}" ]; then
               # The loop hides every failure, so a bad token looks the same as a
               # check that has not started. Run once more without the muzzle, so
@@ -204,10 +221,22 @@ jobs:
 
           gh pr checks "${PR_NUMBER}" --required --watch --fail-fast --interval "${POLL_INTERVAL_SECONDS}"
 
+      # The token minted at the top of the job lasts an hour. The bump renders
+      # the documentation and the gate then waits for the matrix, so that hour
+      # can run out here, after the checks have passed and with the merge left
+      # undone. Mint a fresh one for the merge itself.
+      - name: Create GitHub App token for the merge
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
+        uses: actions/create-github-app-token@v3
+        id: merge-token
+        with:
+          client-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+
       - name: Merge the version bump pull request
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.merge-token.outputs.token }}
           PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,20 @@ jobs:
       BUMP_VERSION: ${{ inputs.version }}
 
     steps:
+      # The bump pull request targets the branch the release was dispatched
+      # from. `build.yml` runs on pull requests against `main` alone, so a
+      # dispatch from anywhere else opens a pull request that no required check
+      # ever reports on, and the gate below would then time out for a reason it
+      # cannot name. The `package` job checks out `main` as well.
+      - name: Check the release runs from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::The release runs from main only. It was dispatched from ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
@@ -150,8 +164,8 @@ jobs:
           sleep 5
           PR_URL=$(gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:" | tail -n 1)
           PR_NUMBER="${PR_URL##*/}"
-          if [ -z "${PR_NUMBER}" ]; then
-            echo "::error::Failed to create the version bump pull request."
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Failed to create the version bump pull request. Read a pull request number from: ${PR_URL}"
             exit 1
           fi
           echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
@@ -178,7 +192,11 @@ jobs:
           deadline=$((SECONDS + APPEARANCE_TIMEOUT_SECONDS))
           until [ "$(gh pr checks "${PR_NUMBER}" --required --json state --jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; do
             if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "::error::No required check reported on pull request ${PR_NUMBER} after ${APPEARANCE_TIMEOUT_SECONDS} seconds."
+              # The loop hides every failure, so a bad token looks the same as a
+              # check that has not started. Run once more without the muzzle, so
+              # the log carries the real reason next to the timeout.
+              echo "::error::No required check reported on pull request ${PR_NUMBER} after ${APPEARANCE_TIMEOUT_SECONDS} seconds. The last attempt reported:"
+              gh pr checks "${PR_NUMBER}" --required --json state || true
               exit 1
             fi
             sleep "${POLL_INTERVAL_SECONDS}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,12 +126,10 @@ jobs:
           DATE: ${{ github.event.inputs.date }}
         shell: bash
         run: |
-          if git show-ref --quiet refs/heads/${BRANCH}; then
-            echo "Branch ${BRANCH} already exists."
-            git branch -D "${BRANCH}"
-            git push origin --delete "${BRANCH}"
-          fi
-          git checkout -b "${BRANCH}"
+          # `-B` and not `-b`. The checkout above fetches the triggering ref
+          # alone, so this branch is normally absent, but a re-run must not end
+          # here if it is present.
+          git checkout -B "${BRANCH}"
           if [ "${DATE}" = "today" ]; then
             DATE=$(date +%Y-%m-%d)
           else
@@ -179,6 +177,18 @@ jobs:
           fi
           echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
+      # The token minted at the top of the job lasts an hour. The bump renders
+      # the documentation, and the gate below then waits for the matrix, so
+      # that hour can run out part way through the wait or before the merge.
+      # Both steps take a token minted here instead.
+      - name: Create GitHub App token for the gate
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
+        uses: actions/create-github-app-token@v3
+        id: gate-token
+        with:
+          client-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+
       # `gh pr merge --auto` does not hold the pull request here. The token that
       # opens it can bypass the ruleset, so the automatic merge flag merges at
       # once instead of queueing behind the required check. The release then
@@ -187,7 +197,7 @@ jobs:
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         timeout-minutes: 30
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
           PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
           APPEARANCE_TIMEOUT_SECONDS: "300"
           POLL_INTERVAL_SECONDS: "30"
@@ -221,22 +231,10 @@ jobs:
 
           gh pr checks "${PR_NUMBER}" --required --watch --fail-fast --interval "${POLL_INTERVAL_SECONDS}"
 
-      # The token minted at the top of the job lasts an hour. The bump renders
-      # the documentation and the gate then waits for the matrix, so that hour
-      # can run out here, after the checks have passed and with the merge left
-      # undone. Mint a fresh one for the merge itself.
-      - name: Create GitHub App token for the merge
-        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
-        uses: actions/create-github-app-token@v3
-        id: merge-token
-        with:
-          client-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_KEY }}
-
       - name: Merge the version bump pull request
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.merge-token.outputs.token }}
+          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
           PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,11 +149,12 @@ jobs:
 
           sleep 5
           PR_URL=$(gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:" | tail -n 1)
-          if [ -z "${PR_URL}" ]; then
+          PR_NUMBER="${PR_URL##*/}"
+          if [ -z "${PR_NUMBER}" ]; then
             echo "::error::Failed to create the version bump pull request."
             exit 1
           fi
-          echo "number=${PR_URL##*/}" >> "${GITHUB_OUTPUT}"
+          echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
       # `gh pr merge --auto` does not hold the pull request here. The token that
       # opens it can bypass the ruleset, so the automatic merge flag merges at
@@ -166,7 +167,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
           APPEARANCE_TIMEOUT_SECONDS: "300"
-          POLL_INTERVAL_SECONDS: "15"
+          POLL_INTERVAL_SECONDS: "30"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
The release workflow opened the version bump pull request and merged it with `gh pr merge --auto` on the next line. The App token that opens the pull request can bypass the branch ruleset, so the automatic merge flag merged at once rather than queueing behind the required check. Release 3.4.0 merged its bump before any build job had started, and the release went on to package and publish while the matrix was still running.

The bump touches `package.json`, `package-lock.json` and the workspace manifests, which `build.yml` treats as build inputs, so the matrix does run on it. Nothing carried that result to the merge.

The workflow now gates the merge itself:

- It refuses to run when dispatched from a branch other than `main`, because `build.yml` runs on pull requests against `main` alone and the `package` job checks out `main`.
- It opens the bump pull request, or reuses the open one left by a run that stopped at the gate, and reads the number from it.
- It waits up to five minutes for a required check to register, then watches that check to completion. A failure stops the release before it packages anything, and the pull request stays open.
- It merges with a token minted after the bump, since the matrix can outlast the hour the first one lasts.

Verified with a stubbed `gh` across the paths the gate can take: the pull request is reused or created, the create output is unparseable, the check passes, the check is pending and then passes, the check appears late, the check fails, no check ever reports, and the token is rejected. The last two report the reason `gh` gave rather than a bare timeout. `actionlint` reports nothing that the file did not already carry.