### PR TITLE
fix: guard the opening run of a fence from the backtick scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+- fix: Show the diagnostics for a Pandoc attribute that is written between two code fences with the same number of backticks. (#428)
 - fix: Pin the golden Typst fixtures to `typst-render` 0.22.1, the version they actually reproduce. The old pin named `0.21.0`, but that release's own manifest already carries the document brand feature that shipped in `0.22.0`. (#424)
 
 ## 3.5.0 (2026-09-06)

--- a/src/providers/elementAttributeCompletionProvider.ts
+++ b/src/providers/elementAttributeCompletionProvider.ts
@@ -7,7 +7,7 @@ import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 import { parseAttributeAtPosition, type PandocElementType } from "../utils/elementAttributeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
-import { getDocumentCodeBlockRanges } from "../utils/documentScan";
+import { getDocumentFencedBlocks } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 
 /**
@@ -296,7 +296,7 @@ export class ElementAttributeCompletionProvider implements vscode.CompletionItem
 				return null;
 			}
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
+			const codeBlockRanges = getDocumentFencedBlocks(document, text);
 			const parsed = parseAttributeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;
@@ -528,7 +528,7 @@ export class ElementAttributeHoverProvider implements vscode.HoverProvider {
 			const text = document.getText();
 			const offset = document.offsetAt(position);
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
+			const codeBlockRanges = getDocumentFencedBlocks(document, text);
 			const parsed = parseAttributeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -265,9 +265,9 @@ interface BlockMatch {
  * not really an attribute.
  *
  * Inline code spans use a stricter rule: only exclude when the match start
- * lies inside an inline span.  This avoids false exclusion of fence-header
- * attribute blocks like `` ```{.r code-summary="see `fn()`"} `` whose body
- * contains quoted backticks that look like an inline code span.
+ * lies inside an inline span. An attribute that follows a closing run, as in
+ * `` `code`{=html} ``, starts outside the span and stays eligible, while the
+ * span itself is still skipped.
  */
 function overlapsExclusionRanges(
 	fencedRanges: readonly TextRange[],
@@ -293,13 +293,14 @@ function overlapsExclusionRanges(
 export function extractBlocks(text: string, fencedBlocks?: readonly FencedBlock[]): BlockMatch[] {
 	const codeRanges = fencedBlocks ?? findFencedBlocks(text);
 	const yamlRange = getYamlFrontMatterRange(text);
-	const fencedRanges: readonly TextRange[] = yamlRange ? [yamlRange, ...codeRanges] : codeRanges;
+	const withYaml = (ranges: readonly TextRange[]): readonly TextRange[] =>
+		yamlRange ? [yamlRange, ...ranges] : ranges;
+	const fencedRanges = withYaml(codeRanges);
 	// The body ranges above keep the `{r}` of a fence header outside the
 	// exclusion, so it is still read as an attribute. The backtick scan needs
 	// the opening run guarded instead, or the run of one fence pairs with the
 	// run of the next and the span swallows the prose between them.
-	const guardRanges = getFenceGuardRanges(codeRanges);
-	const inlineRanges = getInlineCodeSpanRanges(text, yamlRange ? [yamlRange, ...guardRanges] : guardRanges);
+	const inlineRanges = getInlineCodeSpanRanges(text, withYaml(getFenceGuardRanges(codeRanges)));
 	const blocks: BlockMatch[] = [];
 
 	for (const match of text.matchAll(ELEMENT_ATTRIBUTE_RE)) {

--- a/src/providers/inlineAttributeDiagnosticsProvider.ts
+++ b/src/providers/inlineAttributeDiagnosticsProvider.ts
@@ -12,13 +12,15 @@ import {
 import { collectShortcodeSchemas, resolveShortcodeAttribute } from "./shortcodeCompletionProvider";
 import { getErrorMessage } from "@quarto-wizard/core";
 import {
-	getCodeBlockRanges,
+	findFencedBlocks,
+	getFenceGuardRanges,
 	getInlineCodeSpanRanges,
 	getYamlFrontMatterRange,
 	isInCodeBlockRange,
+	type FencedBlock,
 	type TextRange,
 } from "../utils/yamlPosition";
-import { getDocumentCodeBlockRanges } from "../utils/documentScan";
+import { getDocumentFencedBlocks } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 import { debounce } from "../utils/debounce";
 
@@ -288,11 +290,16 @@ function overlapsExclusionRanges(
  * excluding matches that fall inside fenced code blocks, the YAML front
  * matter, or inline code spans.
  */
-export function extractBlocks(text: string, codeBlockRanges?: readonly TextRange[]): BlockMatch[] {
-	const codeRanges = codeBlockRanges ?? getCodeBlockRanges(text);
+export function extractBlocks(text: string, fencedBlocks?: readonly FencedBlock[]): BlockMatch[] {
+	const codeRanges = fencedBlocks ?? findFencedBlocks(text);
 	const yamlRange = getYamlFrontMatterRange(text);
-	const fencedRanges = yamlRange ? [yamlRange, ...codeRanges] : codeRanges;
-	const inlineRanges = getInlineCodeSpanRanges(text, fencedRanges);
+	const fencedRanges: readonly TextRange[] = yamlRange ? [yamlRange, ...codeRanges] : codeRanges;
+	// The body ranges above keep the `{r}` of a fence header outside the
+	// exclusion, so it is still read as an attribute. The backtick scan needs
+	// the opening run guarded instead, or the run of one fence pairs with the
+	// run of the next and the span swallows the prose between them.
+	const guardRanges = getFenceGuardRanges(codeRanges);
+	const inlineRanges = getInlineCodeSpanRanges(text, yamlRange ? [yamlRange, ...guardRanges] : guardRanges);
 	const blocks: BlockMatch[] = [];
 
 	for (const match of text.matchAll(ELEMENT_ATTRIBUTE_RE)) {
@@ -959,7 +966,7 @@ export class InlineAttributeDiagnosticsProvider implements vscode.Disposable {
 
 		const version = ++this.validationVersion;
 		const text = document.getText();
-		const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
+		const codeBlockRanges = getDocumentFencedBlocks(document, text);
 		const blocks = extractBlocks(text, codeBlockRanges);
 		const diagnostics: vscode.Diagnostic[] = [];
 
@@ -1290,7 +1297,7 @@ export class InlineAttributeCodeActionProvider implements vscode.CodeActionProvi
 		}
 
 		const text = document.getText();
-		const blocks = extractBlocks(text, getDocumentCodeBlockRanges(document, text));
+		const blocks = extractBlocks(text, getDocumentFencedBlocks(document, text));
 
 		for (const diagnostic of relevant) {
 			for (const block of blocks) {

--- a/src/providers/shortcodeCompletionProvider.ts
+++ b/src/providers/shortcodeCompletionProvider.ts
@@ -7,7 +7,7 @@ import { ensureProjectRoots } from "../utils/projectRootsRegistry";
 import { parseShortcodeAtPosition } from "../utils/shortcodeParser";
 import { getWordAtOffset, hasCompletableValues, buildAttributeDoc } from "../utils/schemaDocumentation";
 import { isFilePathDescriptor, buildFilePathCompletions } from "../utils/filePathCompletion";
-import { getDocumentCodeBlockRanges } from "../utils/documentScan";
+import { getDocumentFencedBlocks } from "../utils/documentScan";
 import { logMessage } from "../utils/log";
 
 /**
@@ -40,7 +40,7 @@ export class ShortcodeCompletionProvider implements vscode.CompletionItemProvide
 				return null;
 			}
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
+			const codeBlockRanges = getDocumentFencedBlocks(document, text);
 			const parsed = parseShortcodeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;
@@ -497,7 +497,7 @@ export class ShortcodeHoverProvider implements vscode.HoverProvider {
 			const text = document.getText();
 			const offset = document.offsetAt(position);
 
-			const codeBlockRanges = getDocumentCodeBlockRanges(document, text);
+			const codeBlockRanges = getDocumentFencedBlocks(document, text);
 			const parsed = parseShortcodeAtPosition(text, offset, codeBlockRanges);
 			if (!parsed) {
 				return null;

--- a/src/test/suite/documentScan.test.ts
+++ b/src/test/suite/documentScan.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocumentCodeBlockRanges, getDocumentTypstBlocks } from "../../utils/documentScan";
+import { getDocumentFencedBlocks, getDocumentTypstBlocks } from "../../utils/documentScan";
 
 /** One document, as the cache sees it: an identity, a URI and a version. */
 function document(uri: string, version = 1): { document: vscode.TextDocument; edit: () => void } {
@@ -13,16 +13,16 @@ const TEXT = "```typst\n#circle()\n```\n\n```python\n1\n```\n";
 suite("Document scan cache", () => {
 	test("Should return the same ranges again at the same document version", () => {
 		const { document: held } = document("/same-version.qmd");
-		const first = getDocumentCodeBlockRanges(held, TEXT);
-		assert.strictEqual(getDocumentCodeBlockRanges(held, TEXT), first);
+		const first = getDocumentFencedBlocks(held, TEXT);
+		assert.strictEqual(getDocumentFencedBlocks(held, TEXT), first);
 		assert.strictEqual(first.length, 2);
 	});
 
 	test("Should read the text again when the document version moves", () => {
 		const { document: held, edit } = document("/moved-version.qmd");
-		const first = getDocumentCodeBlockRanges(held, TEXT);
+		const first = getDocumentFencedBlocks(held, TEXT);
 		edit();
-		assert.notStrictEqual(getDocumentCodeBlockRanges(held, TEXT), first);
+		assert.notStrictEqual(getDocumentFencedBlocks(held, TEXT), first);
 	});
 
 	test("Should keep what one document holds while another is read", () => {
@@ -30,9 +30,9 @@ suite("Document scan cache", () => {
 		// alternate, so a single entry would be rebuilt on every other call.
 		const { document: one } = document("/one.qmd");
 		const { document: two } = document("/two.qmd");
-		const first = getDocumentCodeBlockRanges(one, TEXT);
-		getDocumentCodeBlockRanges(two, TEXT);
-		assert.strictEqual(getDocumentCodeBlockRanges(one, TEXT), first);
+		const first = getDocumentFencedBlocks(one, TEXT);
+		getDocumentFencedBlocks(two, TEXT);
+		assert.strictEqual(getDocumentFencedBlocks(one, TEXT), first);
 	});
 
 	test("Should read the text again for the document that took a reused name", () => {
@@ -41,8 +41,8 @@ suite("Document scan cache", () => {
 		// starts at version one with other text, so a URI and a version together
 		// name two documents. This is what a preview answered from the image of
 		// the document before it, and the whole suite passes without this case.
-		const first = getDocumentCodeBlockRanges(document("/untitled-1").document, TEXT);
-		const again = getDocumentCodeBlockRanges(document("/untitled-1").document, TEXT);
+		const first = getDocumentFencedBlocks(document("/untitled-1").document, TEXT);
+		const again = getDocumentFencedBlocks(document("/untitled-1").document, TEXT);
 		assert.notStrictEqual(again, first);
 	});
 
@@ -50,10 +50,10 @@ suite("Document scan cache", () => {
 		// The two readers scan by different rules, so one entry holds both. A
 		// reader asking must not forget what the other one already built.
 		const { document: held } = document("/both.qmd");
-		const ranges = getDocumentCodeBlockRanges(held, TEXT);
+		const ranges = getDocumentFencedBlocks(held, TEXT);
 		const blocks = getDocumentTypstBlocks(held, () => TEXT);
 		assert.strictEqual(blocks.length, 1);
-		assert.strictEqual(getDocumentCodeBlockRanges(held, TEXT), ranges);
+		assert.strictEqual(getDocumentFencedBlocks(held, TEXT), ranges);
 		assert.strictEqual(
 			getDocumentTypstBlocks(held, () => TEXT),
 			blocks,

--- a/src/test/suite/inlineAttributeDiagnostics.test.ts
+++ b/src/test/suite/inlineAttributeDiagnostics.test.ts
@@ -654,6 +654,27 @@ suite("Inline Attribute Diagnostics", () => {
 	});
 
 	suite("extractBlocks (inline code spans)", () => {
+		test("should extract an attribute between two fences of the same run length", () => {
+			// The opening run of the first fence must not pair with the opening
+			// run of the second. A span across both would swallow the prose
+			// between them, and the attribute in it would report nothing.
+			const text = [
+				"```{r}",
+				"x <- 1",
+				"```",
+				"",
+				"Prose with [text]{.note} in it.",
+				"",
+				"```{python}",
+				"y = 1",
+				"```",
+				"",
+			].join("\n");
+			const blocks = extractBlocks(text);
+			const contents = blocks.map((block) => block.content);
+			assert.ok(contents.includes(".note"), `Expected ".note" among ${JSON.stringify(contents)}`);
+		});
+
 		test("should not extract attribute block from inside a single-backtick span", () => {
 			const text = 'Pandoc syntax: `{key="value"}` produces an attribute.';
 			const blocks = extractBlocks(text);

--- a/src/utils/documentScan.ts
+++ b/src/utils/documentScan.ts
@@ -30,7 +30,7 @@
 import type * as vscode from "vscode";
 import { findTypstUnits, type TypstUnit } from "./typst/typstBlocks";
 import { annotateYaml, yamlRegionOf, type AnnotatedYaml } from "./yamlAnnotated";
-import { findFencedBlocks, type FencedBlock, type TextRange } from "./yamlPosition";
+import { findFencedBlocks, type FencedBlock } from "./yamlPosition";
 
 /** The scans of one document version, each built when it is first asked for. */
 interface DocumentScan {
@@ -67,21 +67,11 @@ function scanOf(document: vscode.TextDocument): DocumentScan {
 }
 
 /**
- * The fenced code block bodies of a document.
+ * The fenced code blocks of a document.
  *
- * @param document - The document being read.
- * @param text - The full text of that document.
- * @returns The ranges of `getCodeBlockRanges`.
- */
-export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: string): readonly TextRange[] {
-	return getDocumentFencedBlocks(document, text);
-}
-
-/**
- * The fenced code blocks of a document, with the fence details each carries.
- *
- * The same cached array as `getDocumentCodeBlockRanges`, widened rather than
- * narrowed, for a reader that needs `fenceStart` as well as the body range.
+ * A `FencedBlock` is a `TextRange` over the block body, so a reader that only
+ * skips over code takes these as they are. A reader of backtick runs wants the
+ * opening fence line covered as well, and passes them to `getFenceGuardRanges`.
  *
  * @param document - The document being read.
  * @param text - The full text of that document.

--- a/src/utils/documentScan.ts
+++ b/src/utils/documentScan.ts
@@ -74,6 +74,20 @@ function scanOf(document: vscode.TextDocument): DocumentScan {
  * @returns The ranges of `getCodeBlockRanges`.
  */
 export function getDocumentCodeBlockRanges(document: vscode.TextDocument, text: string): readonly TextRange[] {
+	return getDocumentFencedBlocks(document, text);
+}
+
+/**
+ * The fenced code blocks of a document, with the fence details each carries.
+ *
+ * The same cached array as `getDocumentCodeBlockRanges`, widened rather than
+ * narrowed, for a reader that needs `fenceStart` as well as the body range.
+ *
+ * @param document - The document being read.
+ * @param text - The full text of that document.
+ * @returns The blocks of `findFencedBlocks`.
+ */
+export function getDocumentFencedBlocks(document: vscode.TextDocument, text: string): readonly FencedBlock[] {
 	const scan = scanOf(document);
 	scan.fenced ??= findFencedBlocks(text);
 	return scan.fenced;

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -1,4 +1,9 @@
-import { findFencedBlocks, getInlineCodeSpanRanges, getYamlFrontMatterRange } from "../yamlPosition";
+import {
+	findFencedBlocks,
+	getFenceGuardRanges,
+	getInlineCodeSpanRanges,
+	getYamlFrontMatterRange,
+} from "../yamlPosition";
 import type { TypstUnit, TypstUnitKind } from "./typstBlocks";
 
 /**
@@ -100,12 +105,7 @@ export function findTypstInlines(text: string): TypstUnit[] {
 		}
 	}
 
-	// `findFencedBlocks` reports the body range, which starts after the opening
-	// fence line so a reader of the info string finds it outside the range. That
-	// leaves the opening backtick run itself unguarded, and two fences of the
-	// same length let that run pair with the next fence's opening run, so the
-	// range given here has to reach back to `fenceStart` instead.
-	const fences = findFencedBlocks(source).map((block) => ({ start: block.fenceStart, end: block.end }));
+	const fences = getFenceGuardRanges(findFencedBlocks(source));
 
 	const units: TypstUnit[] = [];
 	// The spans arrive sorted, so the line of each one is counted onward from the

--- a/src/utils/yamlPosition.ts
+++ b/src/utils/yamlPosition.ts
@@ -455,6 +455,26 @@ export function getCodeBlockRanges(text: string): TextRange[] {
 }
 
 /**
+ * The fence-inclusive ranges of blocks, for a reader that scans backtick runs.
+ *
+ * A body range starts after the opening fence line, so a reader of the info
+ * string finds it outside the range. That leaves the opening backtick run
+ * unguarded, and two fences of the same run length let the opening run of one
+ * pair with the opening run of the next. The span then covers both fences and
+ * everything between them.
+ *
+ * Only a reader of backtick runs needs this. A reader that skips over code
+ * wants the body range, so that the `{r}` of a fence header stays available to
+ * completion and to the attribute diagnostics.
+ *
+ * @param blocks - The blocks of `findFencedBlocks`.
+ * @returns An array of ranges sorted by start offset.
+ */
+export function getFenceGuardRanges(blocks: readonly FencedBlock[]): TextRange[] {
+	return blocks.map((block) => ({ start: block.fenceStart, end: block.end }));
+}
+
+/**
  * Find all inline code span regions in the document text.
  *
  * Inline code spans are delimited by matching backtick runs of equal length


### PR DESCRIPTION
`findFencedBlocks` reports a body range that starts after the opening fence line, so a reader of the info string finds it outside the range. That leaves the opening backtick run unguarded. In a document with two fences of the same run length, the opening run of the first pairs with the opening run of the second, and the inline code span scan reports one span covering both fences and the prose between them.

A Pandoc attribute written in that prose then reported no diagnostic, because the phantom span swallowed it.

The Typst reader met the same defect and corrected it in place, which left one helper with two callers following two rules. `getFenceGuardRanges` now holds the correction, and both callers use it. A reader that skips over code still takes the body range, so the `{r}` of a fence header stays eligible for completion and for the attribute diagnostics.

`getDocumentCodeBlockRanges` became a delegate that narrowed the same cached array, so it is gone. Every reader takes the blocks and narrows them where it needs to.

The regression test is a document with two fences of the same run length and a span attribute in the prose between them. It fails without the fix, and reports only the second fence header.