### PR TITLE
ci: scope the build concurrency by draft state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,15 @@ on:
     # expensive jobs have anything to do.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.action }}-${{ github.ref }}-${{ github.event_name }}
+  # The draft state and not the event name. Every activity type above reports
+  # `pull_request`, so a synchronize run and a ready_for_review run shared one
+  # group and cancelled each other. When the draft run won that race, the jobs
+  # below skipped on their draft guard, the required summary failed by design,
+  # and the pull request was left ready, red, and with no further event coming.
+  #
+  # `github.action` is the step identifier and is empty here, so it grouped
+  # nothing. `github.ref` already separates a pull request from a dispatch.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.draft }}
   cancel-in-progress: true
 
 permissions: read-all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,14 +320,36 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          IS_DRAFT=$(gh pr view "${PR_NUMBER}" --json isDraft --jq '.isDraft')
+
+          # This is the single required check, so an unanswered call must not
+          # be what fails it. No pull request event follows a failure here, and
+          # the check would stay red with nothing left to clear it. After three
+          # attempts the step falls back to the payload, which is what this
+          # check read before and is a state the workflow already handled.
+          IS_DRAFT=""
+          for _ in 1 2 3; do
+            IS_DRAFT=$(gh pr view "${PR_NUMBER}" --json isDraft --jq '.isDraft' || true)
+            if [ -n "${IS_DRAFT}" ]; then
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "${IS_DRAFT}" ]; then
+            echo "::warning::Could not read the draft state of pull request ${PR_NUMBER}. Reporting on the event payload instead."
+            IS_DRAFT="${BUILT_AS_DRAFT}"
+          fi
+
           if [ "${BUILT_AS_DRAFT}" != "true" ] && [ "${IS_DRAFT}" != "true" ]; then
             exit 0
           fi
           {
             echo "# 🚧 Build deferred"
             echo ""
-            if [ "${IS_DRAFT}" = "true" ]; then
+            if [ "${BUILT_AS_DRAFT}" != "true" ]; then
+              echo "This pull request went back to being a draft after the run started."
+              echo "The matrix ran, but on the state the pull request has left."
+              echo "Mark it ready for review to get a verdict on the state it has now."
+            elif [ "${IS_DRAFT}" = "true" ]; then
               echo "This pull request is a draft, so the build matrix did not run."
               echo "Mark it ready for review to build it."
             else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ concurrency:
   #
   # `github.action` is the step identifier and is empty here, so it grouped
   # nothing. `github.ref` already separates a pull request from a dispatch.
+  #
+  # The two groups no longer cancel each other, so a pull request sent back to
+  # draft leaves its ready matrix running to an answer nobody needs. That costs
+  # runner minutes in a rare case, and it is the price of never cancelling the
+  # run that carries the verdict.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.draft }}
   cancel-in-progress: true
 
@@ -329,27 +334,27 @@ jobs:
           IS_DRAFT=""
           for _ in 1 2 3; do
             IS_DRAFT=$(gh pr view "${PR_NUMBER}" --json isDraft --jq '.isDraft' || true)
-            if [ -n "${IS_DRAFT}" ]; then
+            if [[ -n "${IS_DRAFT}" ]]; then
               break
             fi
             sleep 5
           done
-          if [ -z "${IS_DRAFT}" ]; then
+          if [[ -z "${IS_DRAFT}" ]]; then
             echo "::warning::Could not read the draft state of pull request ${PR_NUMBER}. Reporting on the event payload instead."
             IS_DRAFT="${BUILT_AS_DRAFT}"
           fi
 
-          if [ "${BUILT_AS_DRAFT}" != "true" ] && [ "${IS_DRAFT}" != "true" ]; then
+          if [[ "${BUILT_AS_DRAFT}" != "true" && "${IS_DRAFT}" != "true" ]]; then
             exit 0
           fi
           {
             echo "# 🚧 Build deferred"
             echo ""
-            if [ "${BUILT_AS_DRAFT}" != "true" ]; then
+            if [[ "${BUILT_AS_DRAFT}" != "true" ]]; then
               echo "This pull request went back to being a draft after the run started."
               echo "The matrix ran, but on the state the pull request has left."
               echo "Mark it ready for review to get a verdict on the state it has now."
-            elif [ "${IS_DRAFT}" = "true" ]; then
+            elif [[ "${IS_DRAFT}" == "true" ]]; then
               echo "This pull request is a draft, so the build matrix did not run."
               echo "Mark it ready for review to build it."
             else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,14 +304,36 @@ jobs:
         # failure here states that, where a skip stated nothing and counted as
         # satisfied. The guards above are what keep a draft off the runners; the
         # cost of this step is one job that ends in seconds.
-        if: github.event.pull_request.draft == true
+        #
+        # Two questions, and a payload answers only the first. The payload is
+        # frozen at the moment its event fired, so it says what this run built,
+        # while the pull request may have changed since. Both have to hold for
+        # a pass: this run must have built the matrix, and the pull request must
+        # be ready now. Reporting on the payload alone made the verdict depend
+        # on which of two racing runs spoke last.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BUILT_AS_DRAFT: ${{ github.event.pull_request.draft }}
         shell: bash
         run: |
+          set -euo pipefail
+          IS_DRAFT=$(gh pr view "${PR_NUMBER}" --json isDraft --jq '.isDraft')
+          if [ "${BUILT_AS_DRAFT}" != "true" ] && [ "${IS_DRAFT}" != "true" ]; then
+            exit 0
+          fi
           {
             echo "# 🚧 Build deferred"
             echo ""
-            echo "This pull request is a draft, so the build matrix did not run."
-            echo "Mark it ready for review to build it."
+            if [ "${IS_DRAFT}" = "true" ]; then
+              echo "This pull request is a draft, so the build matrix did not run."
+              echo "Mark it ready for review to build it."
+            else
+              echo "This run started while the pull request was a draft, so it built nothing."
+              echo "The run started by marking it ready for review carries the verdict."
+            fi
           } >> "${GITHUB_STEP_SUMMARY}"
           exit 1
 


### PR DESCRIPTION
Every activity type this workflow listens to reports `pull_request`, so a `synchronize` run and a `ready_for_review` run shared one concurrency group and cancelled each other. When the draft run won that race, the three jobs skipped on their draft guard, the required `summary` failed by design, and the pull request was left ready, red, and with no further event coming. Pull request 428 hit this, and the only way out was to turn it back into a draft and mark it ready again, which spends a second matrix run.

The group now carries the draft state rather than the event name, so the two runs no longer cancel each other. `github.action` goes with it, being the step identifier and empty at workflow level.

Splitting the group alone would have traded one hole for another. A run that started on a ready pull request kept reporting a pass from its frozen payload even after the pull request went back to being a draft, which is the state the draft guard exists to refuse. So `summary` now asks what the pull request is when it reports, and passes only when both hold: this run built the matrix, and the pull request is ready now. Each of the three deferral cases states what actually happened, rather than one message claiming the matrix did not run when it did.

The state is read with three attempts, and the event payload answers when none of them do. This is the single required check and no pull request event follows a failure here, so an unanswered call would otherwise leave a red check with nothing left to clear it. The fallback is the behaviour this check had before.

The cost is named in the workflow: two groups that do not cancel each other leave a ready matrix running after the pull request goes back to draft. That is rare, and it is the price of never cancelling the run that carries the verdict.

Verified against a stubbed `gh` over both payload states crossed with ready, draft, and an API that never answers. This pull request reproduces the original race on its own CI.