### PR TITLE
ci: drop the dead parts of the linter concurrency key

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.action }}-${{ github.ref }}-${{ github.event_name }}
+  # `github.action` is the step identifier and is empty here, and this
+  # workflow answers one event, so neither grouped anything.
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: read-all


### PR DESCRIPTION
The key carried `github.action` and `github.event_name`. `github.action` is the step identifier and is empty at workflow level. This workflow answers `workflow_dispatch` alone, so the event name is a constant. Neither grouped anything.

Pull request 429 removed the same two from `build.yml`, where they hid a real race between a draft run and a ready run. Nothing of that kind can happen here, since a dispatch has no draft state. This is the tidy that was left out of that change to keep it to one concern.