### PR TITLE
build: take vitest 5 and drop the coverage that never ran

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,6 @@ The `@quarto-wizard/core` package (`packages/core`) uses Vitest for testing.
 #### Core Dependencies
 
 - `vitest` - The test framework.
-- `@vitest/coverage-v8` - Code coverage support.
 
 #### Core Configuration
 
@@ -131,9 +130,6 @@ npm test
 
 # Run tests in watch mode
 npm run test:watch
-
-# Run tests with coverage
-npm test -- --coverage
 ```
 
 Or from the root directory:

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,52 +253,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.28.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
 			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.29.0"
-			},
-			"bin": {
-				"parser": "bin/babel-parser.js"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
-			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -321,40 +281,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.17.0"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -705,25 +631,6 @@
 				"resolve": "~1.22.2"
 			}
 		},
-		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tybys/wasm-util": "^0.10.3"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -763,13 +670,14 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.139.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+			"version": "0.149.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.149.0.tgz",
+			"integrity": "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
+				"url": "https://github.com/sponsors/oxc-project"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -795,10 +703,28 @@
 			"resolved": "packages/snippets",
 			"link": true
 		},
+		"node_modules/@rolldown/binding-android-arm-eabi": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.8.tgz",
+			"integrity": "sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.8.tgz",
+			"integrity": "sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -808,14 +734,15 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.8.tgz",
+			"integrity": "sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA==",
 			"cpu": [
 				"arm64"
 			],
@@ -825,14 +752,15 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.8.tgz",
+			"integrity": "sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA==",
 			"cpu": [
 				"x64"
 			],
@@ -842,14 +770,15 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.8.tgz",
+			"integrity": "sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ==",
 			"cpu": [
 				"x64"
 			],
@@ -859,14 +788,15 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.8.tgz",
+			"integrity": "sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q==",
 			"cpu": [
 				"arm"
 			],
@@ -876,152 +806,141 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.8.tgz",
+			"integrity": "sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.8.tgz",
+			"integrity": "sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.8.tgz",
+			"integrity": "sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.8.tgz",
+			"integrity": "sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.8.tgz",
+			"integrity": "sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.8.tgz",
+			"integrity": "sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "1.11.1",
-				"@emnapi/runtime": "1.11.1",
-				"@napi-rs/wasm-runtime": "^1.1.6"
-			},
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.8.tgz",
+			"integrity": "sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1031,14 +950,15 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.8.tgz",
+			"integrity": "sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng==",
 			"cpu": [
 				"x64"
 			],
@@ -1048,6 +968,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1057,7 +978,8 @@
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@secretlint/config-creator": {
 			"version": "10.2.2",
@@ -1295,13 +1217,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@textlint/ast-node-types": {
 			"version": "15.5.1",
 			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.1.tgz",
@@ -1407,17 +1322,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@textlint/ast-node-types": "15.5.1"
-			}
-		},
-		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/archiver": {
@@ -2053,65 +1957,17 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-			"integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.10",
-				"ast-v8-to-istanbul": "^1.0.0",
-				"istanbul-lib-coverage": "^3.2.2",
-				"istanbul-lib-report": "^3.0.1",
-				"istanbul-reports": "^3.2.0",
-				"magicast": "^0.5.2",
-				"obug": "^2.1.1",
-				"std-env": "^4.0.0-rc.1",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"@vitest/browser": "4.1.10",
-				"vitest": "4.1.10"
-			},
-			"peerDependenciesMeta": {
-				"@vitest/browser": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/expect": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@standard-schema/spec": "^1.1.0",
-				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.10",
-				"@vitest/utils": "4.1.10",
-				"chai": "^6.2.2",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+			"integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.10",
+				"@jridgewell/trace-mapping": "0.3.31",
+				"@vitest/spy": "5.0.0",
 				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
+				"magic-string": "^1.2.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -2129,70 +1985,12 @@
 				}
 			}
 		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/runner": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/utils": "4.1.10",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/snapshot": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.10",
-				"@vitest/utils": "4.1.10",
-				"magic-string": "^0.30.21",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+			"integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
 			"dev": true,
 			"license": "MIT",
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/utils": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.10",
-				"convert-source-map": "^2.0.0",
-				"tinyrainbow": "^3.1.0"
-			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
@@ -2956,18 +2754,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/ast-v8-to-istanbul": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.31",
-				"estree-walker": "^3.0.3",
-				"js-tokens": "^10.0.0"
 			}
 		},
 		"node_modules/astral-regex": {
@@ -4150,9 +3936,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+			"integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4881,6 +4667,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -5693,13 +5480,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/js-tokens": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/js-yaml": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
@@ -5986,6 +5766,7 @@
 			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
 			"dev": true,
 			"license": "MPL-2.0",
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3"
 			},
@@ -6023,6 +5804,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6044,6 +5826,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6065,6 +5848,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6086,6 +5870,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6107,6 +5892,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6123,11 +5909,15 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6144,11 +5934,15 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6165,11 +5959,15 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6186,11 +5984,15 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6212,6 +6014,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6233,6 +6036,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -6374,25 +6178,13 @@
 			"license": "MIT"
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.21",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+			"integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
-		"node_modules/magicast": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/make-dir": {
@@ -6935,6 +6727,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -7088,9 +6881,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
-			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+			"integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
@@ -7486,13 +7279,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7619,6 +7405,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.18",
 				"picocolors": "^1.1.1",
@@ -8070,13 +7857,14 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.8.tgz",
+			"integrity": "sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@oxc-project/types": "=0.139.0",
+				"@oxc-project/types": "=0.149.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -8086,21 +7874,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.1.5",
-				"@rolldown/binding-darwin-arm64": "1.1.5",
-				"@rolldown/binding-darwin-x64": "1.1.5",
-				"@rolldown/binding-freebsd-x64": "1.1.5",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
-				"@rolldown/binding-linux-arm64-musl": "1.1.5",
-				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
-				"@rolldown/binding-linux-x64-gnu": "1.1.5",
-				"@rolldown/binding-linux-x64-musl": "1.1.5",
-				"@rolldown/binding-openharmony-arm64": "1.1.5",
-				"@rolldown/binding-wasm32-wasi": "1.1.5",
-				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
-				"@rolldown/binding-win32-x64-msvc": "1.1.5"
+				"@rolldown/binding-android-arm-eabi": "1.2.8",
+				"@rolldown/binding-android-arm64": "1.2.8",
+				"@rolldown/binding-darwin-arm64": "1.2.8",
+				"@rolldown/binding-darwin-x64": "1.2.8",
+				"@rolldown/binding-freebsd-x64": "1.2.8",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.8",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.8",
+				"@rolldown/binding-linux-arm64-musl": "1.2.8",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.8",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.8",
+				"@rolldown/binding-linux-x64-gnu": "1.2.8",
+				"@rolldown/binding-linux-x64-musl": "1.2.8",
+				"@rolldown/binding-openharmony-arm64": "1.2.8",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.8",
+				"@rolldown/binding-win32-x64-msvc": "1.2.8"
 			}
 		},
 		"node_modules/run-applescript": {
@@ -8477,6 +8265,7 @@
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9052,16 +8841,19 @@
 			}
 		},
 		"node_modules/tinybench": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+			"integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
 		},
 		"node_modules/tinyexec": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9114,16 +8906,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/tinyrainbow": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tmp": {
@@ -9557,16 +9339,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.1.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+			"integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"lightningcss": "^1.32.0",
+				"lightningcss": "^1.33.0",
 				"picomatch": "^4.0.5",
-				"postcss": "^8.5.17",
-				"rolldown": "~1.1.5",
+				"postcss": "^8.5.26",
+				"rolldown": "~1.2.4",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
@@ -9583,7 +9366,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.3.0",
+				"@vitejs/devtools": "^0.4.0 || ^0.5.0",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
@@ -9635,11 +9418,12 @@
 			}
 		},
 		"node_modules/vite/node_modules/picomatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -9648,38 +9432,31 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+			"integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.10",
-				"@vitest/mocker": "4.1.10",
-				"@vitest/pretty-format": "4.1.10",
-				"@vitest/runner": "4.1.10",
-				"@vitest/snapshot": "4.1.10",
-				"@vitest/spy": "4.1.10",
-				"@vitest/utils": "4.1.10",
-				"es-module-lexer": "^2.0.0",
-				"expect-type": "^1.3.0",
-				"magic-string": "^0.30.21",
-				"obug": "^2.1.1",
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.3",
-				"std-env": "^4.0.0-rc.1",
-				"tinybench": "^2.9.0",
-				"tinyexec": "^1.0.2",
-				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.1.0",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/mocker": "5.0.0",
+				"chai": "^6.2.2",
+				"es-module-lexer": "^2.3.2",
+				"expect-type": "^1.4.0",
+				"magic-string": "^1.2.3",
+				"obug": "^2.1.4",
+				"picomatch": "^4.0.7",
+				"std-env": "^4.2.0",
+				"tinybench": "6.1.4",
+				"tinyexec": "1.3.0",
+				"tinyglobby": "^0.2.17",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+				"node": "^22.12.0 || ^24.0.0 || >=26.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -9687,16 +9464,16 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
-				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.10",
-				"@vitest/browser-preview": "4.1.10",
-				"@vitest/browser-webdriverio": "4.1.10",
-				"@vitest/coverage-istanbul": "4.1.10",
-				"@vitest/coverage-v8": "4.1.10",
-				"@vitest/ui": "4.1.10",
+				"@types/node": "^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "5.0.0",
+				"@vitest/browser-preview": "5.0.0",
+				"@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+				"@vitest/coverage-istanbul": "5.0.0",
+				"@vitest/coverage-v8": "5.0.0",
+				"@vitest/ui": "5.0.0",
 				"happy-dom": "*",
 				"jsdom": "*",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -9738,9 +9515,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/picomatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10310,10 +10087,9 @@
 				"@types/node": "^26.1.1",
 				"@types/semver": "^7.7.1",
 				"@types/unzipper": "^0.10.11",
-				"@vitest/coverage-v8": "^4.1.10",
 				"archiver": "^8.0.0",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.10"
+				"vitest": "^5.0.0"
 			},
 			"engines": {
 				"node": ">=25.0.0"
@@ -10376,9 +10152,8 @@
 			},
 			"devDependencies": {
 				"@types/node": "^26.1.1",
-				"@vitest/coverage-v8": "^4.1.10",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.10"
+				"vitest": "^5.0.0"
 			},
 			"engines": {
 				"node": ">=25.0.0"
@@ -10390,9 +10165,8 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.1",
-				"@vitest/coverage-v8": "^4.1.10",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.10"
+				"vitest": "^5.0.0"
 			},
 			"engines": {
 				"node": ">=25.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
 		"management"
 	],
 	"author": {
-		"name": "Micka\u00ebl CANOUIL",
+		"name": "Mickaël CANOUIL",
 		"url": "https://mickael.canouil.fr"
 	},
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
 		"management"
 	],
 	"author": {
-		"name": "Mickaël CANOUIL",
+		"name": "Micka\u00ebl CANOUIL",
 		"url": "https://mickael.canouil.fr"
 	},
 	"license": "MIT",
@@ -45,10 +45,9 @@
 		"@types/node": "^26.1.1",
 		"@types/semver": "^7.7.1",
 		"@types/unzipper": "^0.10.11",
-		"@vitest/coverage-v8": "^4.1.10",
 		"archiver": "^8.0.0",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.10"
+		"vitest": "^5.0.0"
 	},
 	"engines": {
 		"node": ">=25.0.0"

--- a/packages/core/tests/operations/use.test.ts
+++ b/packages/core/tests/operations/use.test.ts
@@ -412,15 +412,35 @@ describe("use with a local directory source", () => {
 describe("use with a local archive source", () => {
 	let sourceDir: string;
 	let projectDir: string;
+	let tempRoot: string;
+	let heldTempEnv: Record<string, string | undefined>;
+
+	// The extraction directory is named after the whole temp directory, and any
+	// other test file extracting an archive at the same moment adds one to it.
+	// Vitest runs the files of a package in parallel, so a scan of the shared
+	// directory reads work that is not this test's. Each test here gets a temp
+	// directory of its own instead, which `os.tmpdir()` reads from these three.
+	const TEMP_VARS = ["TMPDIR", "TEMP", "TMP"] as const;
 
 	beforeEach(() => {
+		tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "qw-use-archive-root-"));
+		heldTempEnv = Object.fromEntries(TEMP_VARS.map((name) => [name, process.env[name]]));
+		for (const name of TEMP_VARS) {
+			process.env[name] = tempRoot;
+		}
 		sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "qw-use-archive-source-"));
 		projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "qw-use-archive-project-"));
 	});
 
 	afterEach(() => {
-		fs.rmSync(sourceDir, { recursive: true, force: true });
-		fs.rmSync(projectDir, { recursive: true, force: true });
+		for (const name of TEMP_VARS) {
+			if (heldTempEnv[name] === undefined) {
+				delete process.env[name];
+			} else {
+				process.env[name] = heldTempEnv[name];
+			}
+		}
+		fs.rmSync(tempRoot, { recursive: true, force: true });
 	});
 
 	function listExtractionDirs(): string[] {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		include: ["tests/**/*.test.ts"],
-		coverage: {
-			provider: "v8",
-			reporter: ["text", "json", "html"],
-			include: ["src/**/*.ts"],
-			exclude: ["src/**/*.d.ts"],
-		},
 	},
 });

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -23,7 +23,7 @@
 		"schema"
 	],
 	"author": {
-		"name": "Micka\u00ebl CANOUIL",
+		"name": "Mickaël CANOUIL",
 		"url": "https://mickael.canouil.fr"
 	},
 	"license": "MIT",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -23,7 +23,7 @@
 		"schema"
 	],
 	"author": {
-		"name": "Mickaël CANOUIL",
+		"name": "Micka\u00ebl CANOUIL",
 		"url": "https://mickael.canouil.fr"
 	},
 	"license": "MIT",
@@ -37,9 +37,8 @@
 	},
 	"devDependencies": {
 		"@types/node": "^26.1.1",
-		"@vitest/coverage-v8": "^4.1.10",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.10"
+		"vitest": "^5.0.0"
 	},
 	"engines": {
 		"node": ">=25.0.0"

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		include: ["tests/**/*.test.ts"],
-		coverage: {
-			provider: "v8",
-			reporter: ["text", "json", "html"],
-			include: ["src/**/*.ts"],
-			exclude: ["src/**/*.d.ts"],
-		},
 	},
 });

--- a/packages/snippets/package.json
+++ b/packages/snippets/package.json
@@ -22,7 +22,7 @@
 		"snippets"
 	],
 	"author": {
-		"name": "Micka\u00ebl CANOUIL",
+		"name": "Mickaël CANOUIL",
 		"url": "https://mickael.canouil.fr"
 	},
 	"license": "MIT",

--- a/packages/snippets/package.json
+++ b/packages/snippets/package.json
@@ -22,7 +22,7 @@
 		"snippets"
 	],
 	"author": {
-		"name": "Mickaël CANOUIL",
+		"name": "Micka\u00ebl CANOUIL",
 		"url": "https://mickael.canouil.fr"
 	},
 	"license": "MIT",
@@ -33,9 +33,8 @@
 	},
 	"devDependencies": {
 		"@types/node": "^26.1.1",
-		"@vitest/coverage-v8": "^4.1.10",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.10"
+		"vitest": "^5.0.0"
 	},
 	"engines": {
 		"node": ">=25.0.0"

--- a/packages/snippets/vitest.config.ts
+++ b/packages/snippets/vitest.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		include: ["tests/**/*.test.ts"],
-		coverage: {
-			provider: "v8",
-			reporter: ["text", "json", "html"],
-			include: ["src/**/*.ts"],
-			exclude: ["src/**/*.d.ts"],
-		},
 	},
 });


### PR DESCRIPTION
The three advisories left after pull request 430 were all `vitest`, and clearing them needs a major version. Vitest 5 asks for Node 22 and Vite 6.4, and the packages already declare Node 25 and resolve Vite 8, so nothing else had to move. `npm audit` now reports nothing.

`@vitest/coverage-v8` goes with the bump. It was declared in the three packages and configured in the three `vitest.config.ts`, and no script or workflow ever asked for a report. `TESTING.md` did tell a reader to run `npm test -- --coverage`, which is the only place the feature existed, and that is gone too. Reinstating coverage later is a deliberate change of its own.

Mocks now clear before each test by default. Nothing depended on the old behaviour.

The upgrade uncovered a flake, and the cause is the test rather than the runner. `use.test.ts` scans the whole temp directory for entries named `quarto-ext-` and asserts that the operation added none, while `src/archive/extract.ts` and `src/github/download.ts` both create entries with that prefix, and vitest runs the files of a package in parallel. The assertion was reading work that belonged to another file.

Measured before changing anything: version 5 failed twice in seven runs, version 4 passed eight, and the file on its own passed six. The race was always there, and the runner only changed how often it shows. Each test in that block now takes a temp directory of its own, which `os.tmpdir()` reads from `TMPDIR`, `TEMP` and `TMP`, restored afterwards. Ten runs pass.

Checked locally: 471, 235 and 53 tests in the core, schema and snippets packages, 1217 in the extension, `eslint`, `prettier` and `tsc` clean, and `npm audit` at zero.