### PR TITLE
fix: size the hover guard by its data URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules
 /.luarc.json
 /.quarto/
 **/*.quarto_ipynb
+
+# Subagent-driven development scratch
+.superpowers/

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -15,8 +15,8 @@ import { surfaceSettings, type TypstSurfaceSettings } from "./typstPreviewSettin
 /**
  * How much image a hover carries.
  *
- * A base64 string is a third larger than the image, and the whole of it is
- * rendered inside a tooltip that appears and disappears with the pointer. A
+ * This bounds the data URI, not the SVG it encodes: base64 inflates the raw
+ * image by a third, and the URI, not the SVG, is what the hover renders. A
  * dense page of glyph outlines takes long enough to decode that the hover
  * arrives after the pointer has moved on, so above this the reader is sent to
  * the panel, which renders once and stays.
@@ -103,12 +103,13 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 			// A hover cannot size an image, so the root element is scaled instead and
 			// the `viewBox` is left alone, which keeps the drawing filling it.
 			const clamped = clampSvg(result.svg, maxHeight);
-			if (clamped.length > IMAGE_LIMIT_BYTES) {
+			const uri = svgDataUri(clamped);
+			if (uri.length > IMAGE_LIMIT_BYTES) {
 				markdown.appendText(
 					"The compiled image is too large for a hover. Run Quarto Wizard: Preview Typst Block to see it in the panel.",
 				);
 			} else {
-				markdown.appendMarkdown(`![The compiled Typst block.](${svgDataUri(clamped)})`);
+				markdown.appendMarkdown(`![The compiled Typst block.](${uri})`);
 			}
 		}
 		if (result.error !== undefined) {

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -420,6 +420,46 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should point at the panel for an image whose data URI alone is too large", async () => {
+		// The guard used to measure the raw SVG, which the markdown never carries.
+		// An image in the gap between the raw limit and the base64 limit passed the
+		// guard and reached VS Code as a literal `![...](data:...)` string, because
+		// the URI was too long for VS Code to parse as an image.
+		const prefix = '<svg viewBox="0 0 10 10" width="10pt" height="10pt"><!--';
+		const suffix = "--></svg>";
+		const padded = prefix + "x".repeat(240_000 - prefix.length - suffix.length) + suffix;
+		assert.strictEqual(padded.length, 240_000, "the fixture itself must land at the intended length");
+		assert.ok(padded.length < 256 * 1024, "the raw SVG must be under the raw limit");
+		assert.ok(
+			Buffer.from(padded, "utf-8").toString("base64").length > 256 * 1024,
+			"the encoded image must be over the limit",
+		);
+		const controller = makeController(new StubCompiler({ svg: padded, stderr: "" }));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes("panel"), `unexpected hover: ${hoverText(shown)}`);
+		assert.ok(
+			!hoverText(shown).includes("data:image/svg+xml"),
+			`the oversized URI reached the hover: ${hoverText(shown)}`,
+		);
+		controller.dispose();
+	});
+
+	test("Should still show an image well under the data URI limit", async () => {
+		// The guard above must not be simply always on.
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes("data:image/svg+xml"), `no image in the hover: ${hoverText(shown)}`);
+		controller.dispose();
+	});
+
 	test("Should offer no hover when the document asks for another surface", async () => {
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);


### PR DESCRIPTION
The hover guards against an image too large to render, and it measured the wrong string. It compared the compiled SVG against its limit, while the markdown carries the base64 data URI, which is about a third longer. An image between the two sizes passed the guard, and VS Code then refused to parse an image URL that long and printed the `![...](data:image/svg+xml;base64,...)` syntax as text in the hover.

A real document shows it. A gribouille plot compiles to 236,183 bytes of SVG, which is under the 262,144 limit, and 314,912 bytes once encoded, which is over it. That hover showed a wall of base64.

The guard now measures the data URI, which is the exact string interpolated into the markdown. The limit keeps its value, and the sentence pointing at the panel is unchanged.

Scaling the image is not an alternative. `clampSvg` rewrites the root width and height alone, so the byte count barely moves.

Two tests cover it. One builds an image in the gap, raw length under the limit and encoded length over it, and asserts the hover offers the panel instead of an image. It fails without the change. The other keeps a small image rendering as an image, so the guard is not simply always on.

A plot of that size now says to use the panel rather than showing a picture. That is correct, and it is not the outcome a reader wants. Whether a hover can render an image from a file instead, which would lift the length limit entirely, is a separate question and is not answered here.

Checked locally: the extension suite passes at 1219 tests, up from 1217, and `npm run lint` and `npm run format:check` are clean.