### PR TITLE
fix: match the webpack task with the one-shot tsc matcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"problemMatcher": ["$tsc-watch"]
+			"problemMatcher": ["$tsc"]
 		},
 		{
 			"label": "npm: watch",


### PR DESCRIPTION
`npm: webpack` carried the `$tsc-watch` problem matcher, which is written for a compiler that stays running and reads a begin and an end pattern to tell when a build starts and ends. The task runs once and exits, so it never sends either signal. It now uses `$tsc`, the matcher the other one-shot compile tasks in the same file already use. `npm: watch` keeps `$tsc-watch`, which is right for it.

The task is the `preLaunchTask` of the `Run Extension` configuration, so a matcher that cannot tell when the task ended is the class of thing that makes a launch hang or end early.

One point for a reviewer: this does not yet let the Problems panel open the right file. The workspace package builds run through `cd packages/<name>`, so `tsc` reports a path relative to the package and the matcher joins it to the workspace folder. That is a separate defect, it already affects `npm: build:core` and `npm: test-compile`, and it is tracked on its own.