### PR TITLE
fix: read format options from the top level of the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+- fix: Read the options of an output format from the top level of the metadata in the Lua reference validator. The format name is never a metadata key, so `validate_format` collected nothing and passed whatever the document wrote. (#439)
 - fix: Offer the panel when a compiled Typst image is too large for a hover. The hover measured the image and not the text it carries, so a large image printed as unreadable markup. (#436)
 - fix: Show the diagnostics for a Pandoc attribute that is written between two code fences with the same number of backticks. (#428)
 - fix: Pin the golden Typst fixtures to `typst-render` 0.22.1, the version they actually reproduce. The old pin named `0.21.0`, but that release's own manifest already carries the document brand feature that shipped in `0.22.0`. (#424)

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2382,6 +2382,12 @@ function M.validate_attributes(attributes, group, schema, options)
 end
 
 --- Validate the options of one output format against the `formats` section.
+--- Quarto merges the options of the selected format into the top level of the
+--- metadata, so the values are read from there. The format name is never a key.
+--- A value is collected only when a descriptor declares its name, which keeps
+--- the document's own keys, such as `title`, out of the merge. The `unknown`
+--- option therefore has nothing to report here, and is kept so that the entry
+--- points keep one signature.
 --- @param meta table Document metadata
 --- @param format string Format name, such as 'html' or 'typst'
 --- @param schema table Loaded schema
@@ -2401,11 +2407,25 @@ function M.validate_format(meta, format, schema, options)
     return _finish(context, {})
   end
 
+  -- Each value is stored under the spelling the document wrote, never under the
+  -- declared name. `_validate_map` is what moves an alias or the other spelling
+  -- to the declared name, and it needs the original key to say which two
+  -- spellings a document supplied for one field.
   local values = {}
-  local format_meta = meta and _lookup(meta, format)
-  if format_meta ~= nil then
-    for key, value in pairs(format_meta) do
-      values[tostring(key)] = _convert_pandoc_value(value)
+  for field, raw_spec in pairs(descriptors) do
+    local value, found_key = _lookup(meta, field)
+    if value ~= nil then
+      values[found_key] = _convert_pandoc_value(value)
+    end
+
+    local spec = _compile(raw_spec)
+    if type(spec) == 'table' and type(spec.aliases) == 'table' then
+      for _, alias in ipairs(spec.aliases) do
+        local aliased, alias_key = _lookup(meta, alias)
+        if aliased ~= nil then
+          values[alias_key] = _convert_pandoc_value(aliased)
+        end
+      end
     end
   end
 

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2411,20 +2411,35 @@ function M.validate_format(meta, format, schema, options)
   -- declared name. `_validate_map` is what moves an alias or the other spelling
   -- to the declared name, and it needs the original key to say which two
   -- spellings a document supplied for one field.
+  --
+  -- `_lookup` returns the first spelling it finds, so a document that wrote one
+  -- name in both spellings loses the other. Every other entry point reports the
+  -- loser through the `unknown` option, which has nothing to report here, so the
+  -- collection reports it in the same words `_validate_map` uses.
   local values = {}
-  for field, raw_spec in pairs(descriptors) do
-    local value, found_key = _lookup(meta, field)
-    if value ~= nil then
-      values[found_key] = _convert_pandoc_value(value)
+  local function collect(name, owner)
+    local value, found_key = _lookup(meta, name)
+    if value == nil then
+      return
     end
+    values[found_key] = _convert_pandoc_value(value)
+
+    for _, other in ipairs({ (name:gsub('%-', '_')), (name:gsub('_', '-')) }) do
+      if other ~= found_key and meta[other] ~= nil then
+        _report(context, 'warning', format .. '.' .. owner, 'aliases',
+          string.format('was given as both "%s" and "%s"; "%s" was used.',
+            found_key, other, found_key))
+      end
+    end
+  end
+
+  for field, raw_spec in pairs(descriptors) do
+    collect(field, field)
 
     local spec = _compile(raw_spec)
     if type(spec) == 'table' and type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        local aliased, alias_key = _lookup(meta, alias)
-        if aliased ~= nil then
-          values[alias_key] = _convert_pandoc_value(aliased)
-        end
+        collect(alias, field)
       end
     end
   end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2429,10 +2429,15 @@ function M.validate_format(meta, format, schema, options)
     local listed = { [(field:gsub('_', '-'))] = true }
     if type(spec) == 'table' and type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        local normalised = (alias:gsub('_', '-'))
-        if not listed[normalised] then
-          listed[normalised] = true
-          names[#names + 1] = alias
+        -- A schema file is not read against the meta-schema, so an unquoted
+        -- `no` reaches here as a boolean. `_lookup` skips a key that is not a
+        -- string everywhere else, and so does this.
+        if type(alias) == 'string' then
+          local normalised = (alias:gsub('_', '-'))
+          if not listed[normalised] then
+            listed[normalised] = true
+            names[#names + 1] = alias
+          end
         end
       end
     end

--- a/docs/assets/schema/v2/schema.lua
+++ b/docs/assets/schema/v2/schema.lua
@@ -2417,29 +2417,38 @@ function M.validate_format(meta, format, schema, options)
   -- loser through the `unknown` option, which has nothing to report here, so the
   -- collection reports it in the same words `_validate_map` uses.
   local values = {}
-  local function collect(name, owner)
-    local value, found_key = _lookup(meta, name)
-    if value == nil then
-      return
-    end
-    values[found_key] = _convert_pandoc_value(value)
-
-    for _, other in ipairs({ (name:gsub('%-', '_')), (name:gsub('_', '-')) }) do
-      if other ~= found_key and meta[other] ~= nil then
-        _report(context, 'warning', format .. '.' .. owner, 'aliases',
-          string.format('was given as both "%s" and "%s"; "%s" was used.',
-            found_key, other, found_key))
-      end
-    end
-  end
-
   for field, raw_spec in pairs(descriptors) do
-    collect(field, field)
-
     local spec = _compile(raw_spec)
+
+    -- One entry per name, and not one per spelling. `_lookup` reads both
+    -- spellings of whichever entry is kept, so an alias that is only the other
+    -- spelling of a name already listed adds nothing. Probing it as well would
+    -- collect the two spellings under separate keys, and one mistake would then
+    -- be reported three times, once by each probe and once by `_validate_map`.
+    local names = { field }
+    local listed = { [(field:gsub('_', '-'))] = true }
     if type(spec) == 'table' and type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        collect(alias, field)
+        local normalised = (alias:gsub('_', '-'))
+        if not listed[normalised] then
+          listed[normalised] = true
+          names[#names + 1] = alias
+        end
+      end
+    end
+
+    for _, name in ipairs(names) do
+      local value, found_key = _lookup(meta, name)
+      if value ~= nil then
+        values[found_key] = _convert_pandoc_value(value)
+
+        for _, other in ipairs({ (name:gsub('%-', '_')), (name:gsub('_', '-')) }) do
+          if other ~= found_key and meta[other] ~= nil then
+            _report(context, 'warning', format .. '.' .. field, 'aliases',
+              string.format('was given as both "%s" and "%s"; "%s" was used.',
+                found_key, other, found_key))
+          end
+        end
       end
     end
   end

--- a/docs/reference/schema-validator.qmd
+++ b/docs/reference/schema-validator.qmd
@@ -129,6 +129,7 @@ It says what to do with a key that the schema does not declare.
 `validate_format` reads a value only when a descriptor declares its name, under that name, its other spelling, or one of its aliases.
 No undeclared key ever reaches the check, so the setting has no effect.
 It is accepted so that the five entry points keep one signature.
+A name that the document wrote in two spellings is still reported as a warning, because the setting cannot report it.
 
 A group or a format that the schema does not declare is not an error.
 `validate_attributes` then returns the supplied attributes unchanged, and `validate_format` returns an empty table.

--- a/docs/reference/schema-validator.qmd
+++ b/docs/reference/schema-validator.qmd
@@ -110,20 +110,25 @@ It also enforces the parent-level `required` array of that entry.
 It is the one exception for `merged`, which holds `{arguments = ..., attributes = ...}`, because a shortcode call carries two sets of values.
 `validate_attributes` takes the attributes of an element, the group that they belong to, and the loaded schema.
 `validate_format` takes the metadata, a format name, and the loaded schema.
+Quarto merges the options of the selected format into the top level of the metadata, so the values are read from there.
+The format name is never a key in the metadata.
 
 Each also accepts an optional `{unknown = ...}` table as its last parameter.
 It says what to do with a key that the schema does not declare.
 
-| Function              | Accepts                     | Default  |
-| --------------------- | --------------------------- | -------- |
-| `validate`            | `warn`, `error` or `ignore` | `warn`   |
-| `validate_arguments`  | `warn` or `ignore`          | `warn`   |
-| `validate_shortcode`  | `warn`, `error` or `ignore` | `warn`   |
-| `validate_attributes` | `warn`, `error` or `ignore` | `ignore` |
-| `validate_format`     | `warn`, `error` or `ignore` | `ignore` |
+| Function              | Accepts                     | Default   |
+| --------------------- | --------------------------- | --------- |
+| `validate`            | `warn`, `error` or `ignore` | `warn`    |
+| `validate_arguments`  | `warn` or `ignore`          | `warn`    |
+| `validate_shortcode`  | `warn`, `error` or `ignore` | `warn`    |
+| `validate_attributes` | `warn`, `error` or `ignore` | `ignore`  |
+| `validate_format`     | `warn`, `error` or `ignore` | no effect |
 
 `validate_arguments` has no `error` value, because a surplus positional argument is never an error.
-`validate_attributes` and `validate_format` default to `ignore`, because a Pandoc element and a format block both carry keys from Quarto and from other filters.
+`validate_attributes` defaults to `ignore`, because a Pandoc element carries keys from Quarto and from other filters.
+`validate_format` reads a value only when a descriptor declares its name, under that name, its other spelling, or one of its aliases.
+No undeclared key ever reaches the check, so the setting has no effect.
+It is accepted so that the five entry points keep one signature.
 
 A group or a format that the schema does not declare is not an error.
 `validate_attributes` then returns the supplied attributes unchanged, and `validate_format` returns an empty table.

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2382,6 +2382,12 @@ function M.validate_attributes(attributes, group, schema, options)
 end
 
 --- Validate the options of one output format against the `formats` section.
+--- Quarto merges the options of the selected format into the top level of the
+--- metadata, so the values are read from there. The format name is never a key.
+--- A value is collected only when a descriptor declares its name, which keeps
+--- the document's own keys, such as `title`, out of the merge. The `unknown`
+--- option therefore has nothing to report here, and is kept so that the entry
+--- points keep one signature.
 --- @param meta table Document metadata
 --- @param format string Format name, such as 'html' or 'typst'
 --- @param schema table Loaded schema
@@ -2401,11 +2407,25 @@ function M.validate_format(meta, format, schema, options)
     return _finish(context, {})
   end
 
+  -- Each value is stored under the spelling the document wrote, never under the
+  -- declared name. `_validate_map` is what moves an alias or the other spelling
+  -- to the declared name, and it needs the original key to say which two
+  -- spellings a document supplied for one field.
   local values = {}
-  local format_meta = meta and _lookup(meta, format)
-  if format_meta ~= nil then
-    for key, value in pairs(format_meta) do
-      values[tostring(key)] = _convert_pandoc_value(value)
+  for field, raw_spec in pairs(descriptors) do
+    local value, found_key = _lookup(meta, field)
+    if value ~= nil then
+      values[found_key] = _convert_pandoc_value(value)
+    end
+
+    local spec = _compile(raw_spec)
+    if type(spec) == 'table' and type(spec.aliases) == 'table' then
+      for _, alias in ipairs(spec.aliases) do
+        local aliased, alias_key = _lookup(meta, alias)
+        if aliased ~= nil then
+          values[alias_key] = _convert_pandoc_value(aliased)
+        end
+      end
     end
   end
 

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2411,20 +2411,35 @@ function M.validate_format(meta, format, schema, options)
   -- declared name. `_validate_map` is what moves an alias or the other spelling
   -- to the declared name, and it needs the original key to say which two
   -- spellings a document supplied for one field.
+  --
+  -- `_lookup` returns the first spelling it finds, so a document that wrote one
+  -- name in both spellings loses the other. Every other entry point reports the
+  -- loser through the `unknown` option, which has nothing to report here, so the
+  -- collection reports it in the same words `_validate_map` uses.
   local values = {}
-  for field, raw_spec in pairs(descriptors) do
-    local value, found_key = _lookup(meta, field)
-    if value ~= nil then
-      values[found_key] = _convert_pandoc_value(value)
+  local function collect(name, owner)
+    local value, found_key = _lookup(meta, name)
+    if value == nil then
+      return
     end
+    values[found_key] = _convert_pandoc_value(value)
+
+    for _, other in ipairs({ (name:gsub('%-', '_')), (name:gsub('_', '-')) }) do
+      if other ~= found_key and meta[other] ~= nil then
+        _report(context, 'warning', format .. '.' .. owner, 'aliases',
+          string.format('was given as both "%s" and "%s"; "%s" was used.',
+            found_key, other, found_key))
+      end
+    end
+  end
+
+  for field, raw_spec in pairs(descriptors) do
+    collect(field, field)
 
     local spec = _compile(raw_spec)
     if type(spec) == 'table' and type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        local aliased, alias_key = _lookup(meta, alias)
-        if aliased ~= nil then
-          values[alias_key] = _convert_pandoc_value(aliased)
-        end
+        collect(alias, field)
       end
     end
   end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2429,10 +2429,15 @@ function M.validate_format(meta, format, schema, options)
     local listed = { [(field:gsub('_', '-'))] = true }
     if type(spec) == 'table' and type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        local normalised = (alias:gsub('_', '-'))
-        if not listed[normalised] then
-          listed[normalised] = true
-          names[#names + 1] = alias
+        -- A schema file is not read against the meta-schema, so an unquoted
+        -- `no` reaches here as a boolean. `_lookup` skips a key that is not a
+        -- string everywhere else, and so does this.
+        if type(alias) == 'string' then
+          local normalised = (alias:gsub('_', '-'))
+          if not listed[normalised] then
+            listed[normalised] = true
+            names[#names + 1] = alias
+          end
         end
       end
     end

--- a/packages/schema/src/validation/schema.lua
+++ b/packages/schema/src/validation/schema.lua
@@ -2417,29 +2417,38 @@ function M.validate_format(meta, format, schema, options)
   -- loser through the `unknown` option, which has nothing to report here, so the
   -- collection reports it in the same words `_validate_map` uses.
   local values = {}
-  local function collect(name, owner)
-    local value, found_key = _lookup(meta, name)
-    if value == nil then
-      return
-    end
-    values[found_key] = _convert_pandoc_value(value)
-
-    for _, other in ipairs({ (name:gsub('%-', '_')), (name:gsub('_', '-')) }) do
-      if other ~= found_key and meta[other] ~= nil then
-        _report(context, 'warning', format .. '.' .. owner, 'aliases',
-          string.format('was given as both "%s" and "%s"; "%s" was used.',
-            found_key, other, found_key))
-      end
-    end
-  end
-
   for field, raw_spec in pairs(descriptors) do
-    collect(field, field)
-
     local spec = _compile(raw_spec)
+
+    -- One entry per name, and not one per spelling. `_lookup` reads both
+    -- spellings of whichever entry is kept, so an alias that is only the other
+    -- spelling of a name already listed adds nothing. Probing it as well would
+    -- collect the two spellings under separate keys, and one mistake would then
+    -- be reported three times, once by each probe and once by `_validate_map`.
+    local names = { field }
+    local listed = { [(field:gsub('_', '-'))] = true }
     if type(spec) == 'table' and type(spec.aliases) == 'table' then
       for _, alias in ipairs(spec.aliases) do
-        collect(alias, field)
+        local normalised = (alias:gsub('_', '-'))
+        if not listed[normalised] then
+          listed[normalised] = true
+          names[#names + 1] = alias
+        end
+      end
+    end
+
+    for _, name in ipairs(names) do
+      local value, found_key = _lookup(meta, name)
+      if value ~= nil then
+        values[found_key] = _convert_pandoc_value(value)
+
+        for _, other in ipairs({ (name:gsub('%-', '_')), (name:gsub('_', '-')) }) do
+          if other ~= found_key and meta[other] ~= nil then
+            _report(context, 'warning', format .. '.' .. field, 'aliases',
+              string.format('was given as both "%s" and "%s"; "%s" was used.',
+                found_key, other, found_key))
+          end
+        end
       end
     end
   end

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1228,6 +1228,37 @@ formats:
   assert_eq(other_merged['page-width'], '21cm', 'the underscore spelling resolves to the declared name')
 end)
 
+test('S7: validate_format reports a name that a document wrote twice', function()
+  local loaded = load_schema([[
+formats:
+  typst:
+    page-width:
+      type: string
+      aliases:
+        - text-width
+]])
+  local both_spellings = pandoc.read('---\npage-width: 21cm\npage_width: 12cm\n---\n', 'markdown').meta
+  local valid, errors, warnings, merged = schema.validate_format(both_spellings, 'typst', loaded)
+  assert_valid(valid, errors)
+  assert_eq(merged['page-width'], '21cm', 'the declared spelling wins')
+  assert_eq(merged['page_width'], nil, 'the losing spelling is not kept as well')
+  assert_contains(warnings, 'was given as both "page-width" and "page_width"')
+
+  local with_alias = pandoc.read('---\npage-width: 21cm\ntext-width: 12cm\n---\n', 'markdown').meta
+  local alias_valid, alias_errors, alias_warnings, alias_merged = schema.validate_format(with_alias, 'typst', loaded)
+  assert_valid(alias_valid, alias_errors)
+  assert_eq(alias_merged['page-width'], '21cm', 'the declared name wins over an alias')
+  assert_eq(alias_merged['text-width'], nil, 'the alias is not kept as well')
+  assert_contains(alias_warnings, 'was given as both "page-width" and "text-width"')
+
+  local alias_spellings = pandoc.read('---\ntext-width: 21cm\ntext_width: 12cm\n---\n', 'markdown').meta
+  local spelling_valid, spelling_errors, spelling_warnings, spelling_merged =
+    schema.validate_format(alias_spellings, 'typst', loaded)
+  assert_valid(spelling_valid, spelling_errors)
+  assert_eq(spelling_merged['page-width'], '21cm', 'the first spelling of the alias wins')
+  assert_contains(spelling_warnings, 'was given as both "text-width" and "text_width"')
+end)
+
 test('S7: validate_format keeps an undeclared metadata key out of the merge', function()
   local loaded = load_schema([[
 formats:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1259,6 +1259,24 @@ formats:
   assert_contains(spelling_warnings, 'was given as both "text-width" and "text_width"')
 end)
 
+test('S7: validate_format reads a schema whose alias is not a string', function()
+  -- `no` reads as a boolean and `42` as a number, and a schema file is not
+  -- checked against the meta-schema before it is used. A malformed alias is
+  -- skipped, as `_lookup` skips it everywhere else, rather than stopping a
+  -- render over a configuration file.
+  local loaded = load_schema([[
+formats:
+  typst:
+    paper:
+      type: string
+      aliases: [no, 42]
+]])
+  local meta = pandoc.read('---\npaper: a4\n---\n', 'markdown').meta
+  local valid, errors, _, merged = schema.validate_format(meta, 'typst', loaded)
+  assert_valid(valid, errors)
+  assert_eq(merged.paper, 'a4')
+end)
+
 test('S7: validate_format reports one name written twice once', function()
   -- The alias is only the other spelling of the name that declares it, which
   -- `_lookup` already reads, so the pair is one mistake and not two.

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1259,6 +1259,25 @@ formats:
   assert_contains(spelling_warnings, 'was given as both "text-width" and "text_width"')
 end)
 
+test('S7: validate_format reports one name written twice once', function()
+  -- The alias is only the other spelling of the name that declares it, which
+  -- `_lookup` already reads, so the pair is one mistake and not two.
+  local loaded = load_schema([[
+formats:
+  typst:
+    page-width:
+      type: string
+      aliases:
+        - page_width
+]])
+  local meta = pandoc.read('---\npage-width: 21cm\npage_width: 12cm\n---\n', 'markdown').meta
+  local valid, errors, warnings, merged = schema.validate_format(meta, 'typst', loaded)
+  assert_valid(valid, errors)
+  assert_eq(merged['page-width'], '21cm', 'the declared spelling wins')
+  assert_eq(#warnings, 1, 'one mistake is reported once')
+  assert_contains(warnings, 'was given as both "page-width" and "page_width"; "page-width" was used.')
+end)
+
 test('S7: validate_format keeps an undeclared metadata key out of the merge', function()
   local loaded = load_schema([[
 formats:

--- a/packages/schema/tests/validation/lua/run.lua
+++ b/packages/schema/tests/validation/lua/run.lua
@@ -1178,15 +1178,69 @@ formats:
       type: string
       enum: [a4, letter]
 ]])
-  local meta = pandoc.read('---\ntypst:\n  paper: a4\n---\n', 'markdown').meta
+  -- Quarto merges the options of the selected format into the top level of
+  -- the metadata, so that is where the values are read from.
+  local meta = pandoc.read('---\npaper: a4\n---\n', 'markdown').meta
   local valid, errors, _, merged = schema.validate_format(meta, 'typst', loaded)
   assert_valid(valid, errors)
   assert_eq(merged.paper, 'a4')
 
-  local bad_meta = pandoc.read('---\ntypst:\n  paper: a3\n---\n', 'markdown').meta
+  local bad_meta = pandoc.read('---\npaper: a3\n---\n', 'markdown').meta
   local bad_valid, bad_errors = schema.validate_format(bad_meta, 'typst', loaded)
   assert_false(bad_valid)
   assert_contains(bad_errors, 'typst.paper')
+end)
+
+test('S7: validate_format ignores the format name as a metadata key', function()
+  local loaded = load_schema([[
+formats:
+  typst:
+    paper:
+      type: string
+      enum: [a4, letter]
+]])
+  local meta = pandoc.read('---\ntypst:\n  paper: a3\n---\n', 'markdown').meta
+  local valid, errors, _, merged = schema.validate_format(meta, 'typst', loaded)
+  assert_valid(valid, errors)
+  assert_eq(merged.paper, nil, 'a value under the format name is not a format option')
+end)
+
+test('S7: validate_format reads an alias and the other spelling', function()
+  local loaded = load_schema([[
+formats:
+  typst:
+    page-width:
+      type: string
+      aliases:
+        - width
+    paper:
+      type: string
+]])
+  local aliased = pandoc.read('---\nwidth: 21cm\n---\n', 'markdown').meta
+  local valid, errors, _, merged = schema.validate_format(aliased, 'typst', loaded)
+  assert_valid(valid, errors)
+  assert_eq(merged['page-width'], '21cm', 'an alias lands under the declared name')
+  assert_eq(merged.width, nil, 'the alias spelling is not kept as well')
+
+  local underscored = pandoc.read('---\npage_width: 21cm\n---\n', 'markdown').meta
+  local other_valid, other_errors, _, other_merged = schema.validate_format(underscored, 'typst', loaded)
+  assert_valid(other_valid, other_errors)
+  assert_eq(other_merged['page-width'], '21cm', 'the underscore spelling resolves to the declared name')
+end)
+
+test('S7: validate_format keeps an undeclared metadata key out of the merge', function()
+  local loaded = load_schema([[
+formats:
+  typst:
+    paper:
+      type: string
+]])
+  local meta = pandoc.read('---\ntitle: A document\npaper: a4\n---\n', 'markdown').meta
+  local valid, errors, warnings, merged = schema.validate_format(meta, 'typst', loaded, { unknown = 'warn' })
+  assert_valid(valid, errors)
+  assert_eq(merged.paper, 'a4')
+  assert_eq(merged.title, nil, 'a document key no descriptor declares is not a format option')
+  assert_eq(#warnings, 0, 'a document key no descriptor declares raises no warning')
 end)
 
 test('S11: a second YAML document is reported clearly', function()


### PR DESCRIPTION
`validate_format` resolved its values with `meta[format]`, looking for the format name as a top-level metadata key. Quarto never writes one. It merges the options of the selected format into the top level instead. The lookup was therefore always nil, and the function returned a pass with an empty merge for every input it was given. Nothing calls it yet, so no rendered document is affected today. It matters because the runtime checker was about to call it, which would have added a check that silently passes everything.

A value is now collected from the top level, and only when a descriptor declares its name, under that name, its other spelling, or one of its aliases. The document's own keys, such as `title`, stay out of the merge. The `unknown` option consequently has nothing left to report, which the documentation now says.

Two smaller corrections came out of reviewing that change:

- A name that a document wrote in both spellings lost one of them without a word, because `unknown` is the setting that used to report the loser. The collection reports it, in the wording `_validate_map` already uses.
- An `aliases` sequence holding an unquoted `no` reads as a boolean, and a schema file is never checked against the meta-schema before it is used. Such an alias is skipped now, rather than stopping the render.

The published copy at `docs/assets/schema/v2/schema.lua` is updated to match. The validator reaches extensions as a release asset, so a release is needed before any of them see this.