### PR TITLE
ci: mirror the verdict of the run that built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,16 +385,30 @@ jobs:
           # it never saw. That red clears itself: a sibling that has not reported
           # yet reports after this one, so its check run is the later of the two
           # and is the one the required context resolves to.
+          # Every earlier run on this commit left a `summary` behind, and a draft
+          # run leaves a failure. Only a check run that started after this run
+          # did can be the sibling, so an old draft verdict cannot be mirrored,
+          # and the newest of those is taken rather than whichever the API lists
+          # first. A completed status is what excludes this run's own check,
+          # which is still in progress while this step runs; the run identifier
+          # in the URL says so a second time, in case that ever stops holding.
+          SINCE=$(gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}" --jq '.run_started_at' || true)
+          if [[ -z "${SINCE}" ]]; then
+            echo "::warning::Could not read the start time of this run. Reading every completed sibling instead."
+            SINCE="1970-01-01T00:00:00Z"
+          fi
+
           VERDICT=""
           for _ in $(seq 1 48); do
             VERDICT=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null \
-              | jq -r --arg run "/runs/${GITHUB_RUN_ID}/" '
+              | jq -r --arg run "/runs/${GITHUB_RUN_ID}/" --arg since "${SINCE}" '
                   [ .check_runs[]
                     | select(.name == "summary")
-                    | select(.html_url | contains($run) | not)
                     | select(.status == "completed")
-                    | .conclusion
-                  ] | first // empty' || true)
+                    | select(.started_at > $since)
+                    | select(.html_url | contains($run) | not)
+                  ]
+                  | sort_by(.started_at) | last | .conclusion // empty' || true)
             if [[ -n "${VERDICT}" ]]; then
               break
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,33 +300,36 @@ jobs:
       - changes
       - build
       - lua
-    timeout-minutes: 10
+    # Long enough for the wait below, which is bounded at eight minutes.
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - name: Report that a draft defers the build
+      - name: Report on a run that built nothing
         # `changes`, `build` and `lua` are each guarded on the draft state, so a
         # run on a draft skips all of them and there is nothing to report. A
         # failure here states that, where a skip stated nothing and counted as
-        # satisfied. The guards above are what keep a draft off the runners; the
-        # cost of this step is one job that ends in seconds.
+        # satisfied. The guards above are what keep a draft off the runners.
         #
-        # The live state decides, and the payload only says what this run built.
         # Marking a draft ready starts two runs, and the concurrency group above
         # keeps both alive on purpose, so both report a check named `summary` on
         # one commit. GitHub resolves a required context to the check run that
-        # started last, and not to the one that passed, so a run that built
-        # nothing must never fail: two seconds of scheduling order is enough to
-        # leave a ready pull request red with no event left to clear it.
+        # started last, and not to the one that passed, and two seconds of
+        # scheduling order decided it on pull request 439. Neither run may
+        # therefore answer for itself: one that failed by design left a ready
+        # pull request red with no event left to clear it, and one that passed
+        # by design would hide a failed matrix behind a green check.
         #
-        # A ready pull request always has a sibling run that built the matrix,
-        # and that run carries the verdict. This step therefore answers one
-        # question only, which is whether the pull request is a draft now.
+        # The run that built carries the verdict, and the run that built nothing
+        # repeats it. The two check runs then say the same thing, so which one
+        # the context resolves to stops mattering.
+        id: report
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BUILT_AS_DRAFT: ${{ github.event.pull_request.draft }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -349,35 +352,81 @@ jobs:
             IS_DRAFT="${BUILT_AS_DRAFT}"
           fi
 
-          if [[ "${IS_DRAFT}" != "true" ]]; then
-            # Passing, and still worth saying. This run skipped every job above
-            # on its draft guard, so a reader who opens it finds a green check
-            # over an empty matrix and no reason for it.
-            if [[ "${BUILT_AS_DRAFT}" == "true" ]]; then
-              {
-                echo "# 🚧 Nothing to build"
-                echo ""
-                echo "This run started while the pull request was a draft, so it built nothing."
-                echo "The run started by marking it ready for review carries the verdict."
-              } >> "${GITHUB_STEP_SUMMARY}"
-            fi
+          if [[ "${IS_DRAFT}" == "true" ]]; then
+            {
+              echo "# 🚧 Build deferred"
+              echo ""
+              if [[ "${BUILT_AS_DRAFT}" != "true" ]]; then
+                echo "This pull request went back to being a draft after the run started."
+                echo "The matrix ran, but on the state the pull request has left."
+                echo "Mark it ready for review to get a verdict on the state it has now."
+              else
+                echo "This pull request is a draft, so the build matrix did not run."
+                echo "Mark it ready for review to build it."
+              fi
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+
+          if [[ "${BUILT_AS_DRAFT}" != "true" ]]; then
+            # This run built the matrix, so the steps below report on it.
+            echo "built=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          {
-            echo "# 🚧 Build deferred"
-            echo ""
-            if [[ "${BUILT_AS_DRAFT}" != "true" ]]; then
-              echo "This pull request went back to being a draft after the run started."
-              echo "The matrix ran, but on the state the pull request has left."
-              echo "Mark it ready for review to get a verdict on the state it has now."
-            else
-              echo "This pull request is a draft, so the build matrix did not run."
-              echo "Mark it ready for review to build it."
+
+          # Nothing was built here, so the steps below have nothing to read.
+          echo "built=false" >> "${GITHUB_OUTPUT}"
+
+          # The sibling reports once its matrix has answered, which takes about
+          # as long as the matrix does. Waiting costs one small job, and it buys
+          # a verdict that does not depend on which run is scheduled first.
+          #
+          # A wait that runs out fails, because a check cannot vouch for a build
+          # it never saw. That red clears itself: a sibling that has not reported
+          # yet reports after this one, so its check run is the later of the two
+          # and is the one the required context resolves to.
+          VERDICT=""
+          for _ in $(seq 1 48); do
+            VERDICT=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" 2>/dev/null \
+              | jq -r --arg run "/runs/${GITHUB_RUN_ID}/" '
+                  [ .check_runs[]
+                    | select(.name == "summary")
+                    | select(.html_url | contains($run) | not)
+                    | select(.status == "completed")
+                    | .conclusion
+                  ] | first // empty' || true)
+            if [[ -n "${VERDICT}" ]]; then
+              break
             fi
+            sleep 10
+          done
+
+          {
+            echo "# 🚧 Nothing to build"
+            echo ""
+            echo "This run started while the pull request was a draft, so it built nothing."
+            case "${VERDICT}" in
+              success)
+                echo "The run started by marking it ready for review passed, and this reports the same."
+                ;;
+              "")
+                echo "The run started by marking it ready for review has not reported yet."
+                echo "This check cannot vouch for a build it did not see, so it fails."
+                echo "Push again, or re-run this job once that run has finished."
+                ;;
+              *)
+                echo "The run started by marking it ready for review ended as ${VERDICT}, and this reports the same."
+                ;;
+            esac
           } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${VERDICT}" == "success" ]]; then
+            exit 0
+          fi
           exit 1
 
       - name: Download all job summaries
+        if: steps.report.outputs.built != 'false'
         # The summary now runs even when a needed job fails, so there may be no
         # artifact at all. The consolidated summary below falls back to the job
         # results in that case, which it cannot do if this step fails first.
@@ -388,6 +437,10 @@ jobs:
           path: job-summaries
 
       - name: Generate consolidated summary
+        # A run that built nothing has no job result worth a table, and the
+        # success branch below would read the skipped `changes` job and name the
+        # paths filter as the reason the matrix did not run, which is not why.
+        if: steps.report.outputs.built != 'false'
         shell: bash
         env:
           # A pull request title is attacker controlled. Read through the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,6 +350,17 @@ jobs:
           fi
 
           if [[ "${IS_DRAFT}" != "true" ]]; then
+            # Passing, and still worth saying. This run skipped every job above
+            # on its draft guard, so a reader who opens it finds a green check
+            # over an empty matrix and no reason for it.
+            if [[ "${BUILT_AS_DRAFT}" == "true" ]]; then
+              {
+                echo "# 🚧 Nothing to build"
+                echo ""
+                echo "This run started while the pull request was a draft, so it built nothing."
+                echo "The run started by marking it ready for review carries the verdict."
+              } >> "${GITHUB_STEP_SUMMARY}"
+            fi
             exit 0
           fi
           {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,12 +310,17 @@ jobs:
         # satisfied. The guards above are what keep a draft off the runners; the
         # cost of this step is one job that ends in seconds.
         #
-        # Two questions, and a payload answers only the first. The payload is
-        # frozen at the moment its event fired, so it says what this run built,
-        # while the pull request may have changed since. Both have to hold for
-        # a pass: this run must have built the matrix, and the pull request must
-        # be ready now. Reporting on the payload alone made the verdict depend
-        # on which of two racing runs spoke last.
+        # The live state decides, and the payload only says what this run built.
+        # Marking a draft ready starts two runs, and the concurrency group above
+        # keeps both alive on purpose, so both report a check named `summary` on
+        # one commit. GitHub resolves a required context to the check run that
+        # started last, and not to the one that passed, so a run that built
+        # nothing must never fail: two seconds of scheduling order is enough to
+        # leave a ready pull request red with no event left to clear it.
+        #
+        # A ready pull request always has a sibling run that built the matrix,
+        # and that run carries the verdict. This step therefore answers one
+        # question only, which is whether the pull request is a draft now.
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -344,7 +349,7 @@ jobs:
             IS_DRAFT="${BUILT_AS_DRAFT}"
           fi
 
-          if [[ "${BUILT_AS_DRAFT}" != "true" && "${IS_DRAFT}" != "true" ]]; then
+          if [[ "${IS_DRAFT}" != "true" ]]; then
             exit 0
           fi
           {
@@ -354,12 +359,9 @@ jobs:
               echo "This pull request went back to being a draft after the run started."
               echo "The matrix ran, but on the state the pull request has left."
               echo "Mark it ready for review to get a verdict on the state it has now."
-            elif [[ "${IS_DRAFT}" == "true" ]]; then
+            else
               echo "This pull request is a draft, so the build matrix did not run."
               echo "Mark it ready for review to build it."
-            else
-              echo "This run started while the pull request was a draft, so it built nothing."
-              echo "The run started by marking it ready for review carries the verdict."
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
           exit 1


### PR DESCRIPTION
Marking a draft ready starts two runs of this workflow, and the concurrency group keeps both alive on purpose, so both report a check named `summary` on one commit. GitHub resolves a required context to the check run that started last, not to the one that passed. On pull request 439 the two started two seconds apart, the deferral run started second, and the pull request was left ready, green on every other check, and unmergeable, with no event left to clear it.

Neither run can answer for itself. Failing by design produces that red. Passing by design would hide a failed matrix behind a green check, which is worse.

The run that built carries the verdict, and the run that built nothing waits for it and reports the same conclusion. The two check runs then agree, so which one the context resolves to stops mattering. A wait that runs out fails, because a check cannot vouch for a build it never saw, and that red clears itself: a sibling that has not reported yet reports later, so its check run is the later of the two.

A candidate verdict has to have started after this run started. Every earlier run on a commit leaves a `summary` behind, a draft run leaves a failure, and a draft marked ready without a push keeps its commit, so that stale failure is sitting there completed when the waiting run looks.

The steps that read job artefacts are skipped in a run that built nothing. They had nothing to read, and the success branch named the paths filter as the reason the matrix did not run, which is not the reason.

Checked before pushing:

- `actionlint`, which reports the same notes as `main` and none in these steps.
- The decision over all six combinations of the draft payload, the live draft state, and the sibling verdict.
- The sibling selector against the real check runs of pull request 439, and against a fixture holding a stale draft failure with no sibling verdict yet, where the previous selector answered `failure` and this one waits.

Marking this ready is itself the test, since the workflow that runs on a pull request is the one on its own branch.