### PR TITLE
fix: centre the image in a Typst hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - docs: Point the social card of the documentation website at the image that exists, so a link to the site shows a card. (#441)
+- fix: Centre the image in a Typst hover. It sat against the left edge of a box that is wider than the image, because the hover keeps room for its copy button and merges the hovers of several providers into one. (#442)
 - fix: Read the options of an output format from the top level of the metadata in the Lua reference validator. The format name is never a metadata key, so `validate_format` collected nothing and passed whatever the document wrote. (#439)
 - fix: Offer the panel when a compiled Typst image is too large for a hover. The hover measured the image and not the text it carries, so a large image printed as unreadable markup. (#436)
 - fix: Show the diagnostics for a Pandoc attribute that is written between two code fences with the same number of backticks. (#428)

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -124,10 +124,10 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 	/**
 	 * One preview as markdown, which is an image, a failure, or both.
 	 *
-	 * Two parts and never one. The image allows HTML, because that is what
-	 * centres it, and a compiler message is arbitrary text that a string allowing
-	 * HTML must never carry: a message holding angle brackets would reach the
-	 * reader as markup rather than as what Typst said.
+	 * An image and a message never travel in one part. The image allows HTML,
+	 * because that is what centres it, and a compiler message is arbitrary text
+	 * that a string allowing HTML must never carry: a message holding angle
+	 * brackets would reach the reader as markup rather than as what Typst said.
 	 */
 	private describe(result: TypstPreviewResult, maxHeight: number): vscode.MarkdownString[] {
 		const parts: vscode.MarkdownString[] = [];

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -78,6 +78,31 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 	}
 
 	/**
+	 * The image, centred, as the one part of a hover that allows HTML.
+	 *
+	 * A hover widget is wider than the image it carries. It keeps room for its
+	 * own copy button, and VS Code merges the hovers of every provider that
+	 * answers for a position into one widget, so the width follows the widest of
+	 * them. An image left where it falls sits against the left edge of all that.
+	 *
+	 * A hover cannot size an image, so the root element is scaled instead and the
+	 * `viewBox` is left alone, which keeps the drawing filling it.
+	 */
+	private image(svg: string, maxHeight: number): vscode.MarkdownString {
+		const markdown = new vscode.MarkdownString();
+		const uri = svgDataUri(clampSvg(svg, maxHeight));
+		if (uri.length > IMAGE_LIMIT_BYTES) {
+			markdown.appendText(
+				"The compiled image is too large for a hover. Run Quarto Wizard: Preview Typst Block to see it in the panel.",
+			);
+			return markdown;
+		}
+		markdown.supportHtml = true;
+		markdown.appendMarkdown(`<div align="center">\n\n![The compiled Typst block.](${uri})\n\n</div>`);
+		return markdown;
+	}
+
+	/**
 	 * The held preview, when it describes this block of this document version.
 	 *
 	 * Asked twice: before compiling, because the block on screen needs no compile,
@@ -96,30 +121,26 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 			: undefined;
 	}
 
-	/** One preview as markdown, which is an image, a failure, or both. */
-	private describe(result: TypstPreviewResult, maxHeight: number): vscode.MarkdownString {
-		const markdown = new vscode.MarkdownString();
+	/**
+	 * One preview as markdown, which is an image, a failure, or both.
+	 *
+	 * Two parts and never one. The image allows HTML, because that is what
+	 * centres it, and a compiler message is arbitrary text that a string allowing
+	 * HTML must never carry: a message holding angle brackets would reach the
+	 * reader as markup rather than as what Typst said.
+	 */
+	private describe(result: TypstPreviewResult, maxHeight: number): vscode.MarkdownString[] {
+		const parts: vscode.MarkdownString[] = [];
 		if (result.svg !== undefined) {
-			// A hover cannot size an image, so the root element is scaled instead and
-			// the `viewBox` is left alone, which keeps the drawing filling it.
-			const clamped = clampSvg(result.svg, maxHeight);
-			const uri = svgDataUri(clamped);
-			if (uri.length > IMAGE_LIMIT_BYTES) {
-				markdown.appendText(
-					"The compiled image is too large for a hover. Run Quarto Wizard: Preview Typst Block to see it in the panel.",
-				);
-			} else {
-				markdown.appendMarkdown(`![The compiled Typst block.](${uri})`);
-			}
+			parts.push(this.image(result.svg, maxHeight));
 		}
 		if (result.error !== undefined) {
-			if (markdown.value.length > 0) {
-				markdown.appendMarkdown("\n\n");
-			}
+			const message = new vscode.MarkdownString();
 			// Written as text and not as markdown: a Typst message carries backticks,
 			// underscores and asterisks, and rendering them would change what it says.
-			markdown.appendText(result.error);
+			message.appendText(result.error);
+			parts.push(message);
 		}
-		return markdown;
+		return parts;
 	}
 }

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -94,22 +94,6 @@ function nextResultFor(
 	});
 }
 
-/** Run an action and wait for the result it publishes. */
-function nextPublished(controller: TypstPreviewController, act: () => void): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const timer = setTimeout(() => {
-			subscription.dispose();
-			reject(new Error("no result was published"));
-		}, 2000);
-		const subscription = controller.onDidChangeResult(() => {
-			clearTimeout(timer);
-			subscription.dispose();
-			resolve();
-		});
-		act();
-	});
-}
-
 /** Settings that answer the same way for every document. */
 function fixedSettings(
 	surfaces: readonly TypstPreviewSurface[],
@@ -288,15 +272,22 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	test("Should keep a failure out of the HTML part when both reach one hover", async () => {
 		// A failure keeps the last good image of the same block behind it, so a
 		// hover can carry an image and a message at once. That is the case the
-		// split exists for, and the one where merging them would be a defect.
+		// split exists for, and the one where merging them would be a defect. It is
+		// also the ordinary one: a working block edited into a broken one.
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
-		await nextResultFor(controller, document, INSIDE_PLAIN);
+		await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 		compiler.next = { stderr: "error: unexpected <script>alert(1)</script>\n" };
-		await nextPublished(controller, () => controller.reload());
+		// The body of the block, so the source changes and the compile is not
+		// answered out of the cache. The line is inserted above the one the
+		// position names, which leaves the position inside the same block.
+		const edit = new vscode.WorkspaceEdit();
+		edit.insert(document.uri, new vscode.Position(INSIDE_PLAIN.line, 0), "#line()\n");
+		assert.ok(await vscode.workspace.applyEdit(edit), "the fixture edit must apply");
+
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 
 		const parts = hoverParts(shown);

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -107,10 +107,21 @@ function settle(delayMs = 50): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
-/** The markdown of a hover, which every assertion here reads. */
+/**
+ * The markdown of a hover, which every assertion here reads.
+ *
+ * Every part, because an image and a compiler message travel as two, so that
+ * the one that enables HTML carries nothing a compiler wrote.
+ */
 function hoverText(hover: vscode.Hover | undefined): string {
 	assert.ok(hover, "expected a hover");
-	return (hover.contents[0] as vscode.MarkdownString).value;
+	return (hover.contents as vscode.MarkdownString[]).map((part) => part.value).join("\n\n");
+}
+
+/** The parts of a hover, for an assertion about which part holds what. */
+function hoverParts(hover: vscode.Hover | undefined): vscode.MarkdownString[] {
+	assert.ok(hover, "expected a hover");
+	return hover.contents as vscode.MarkdownString[];
 }
 
 suite("Typst Preview Surfaces Test Suite", () => {
@@ -236,6 +247,41 @@ suite("Typst Preview Surfaces Test Suite", () => {
 			`no image in the first hover: ${hoverText(shown)}`,
 		);
 		assert.strictEqual(compiler.sources.length, 1);
+		controller.dispose();
+	});
+
+	test("Should centre the image inside the hover", async () => {
+		// The widget is wider than the image, because it reserves room for its copy
+		// button and because VS Code merges the hovers of several providers into
+		// one. An image left where it falls sits against the left edge of all that.
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		const [image] = hoverParts(shown);
+		assert.ok(image.value.includes('<div align="center">'), `the image is not centred: ${image.value}`);
+		assert.strictEqual(image.supportHtml, true, "a centred image needs the markdown string to allow HTML");
+		controller.dispose();
+	});
+
+	test("Should keep a compile failure out of a part that allows HTML", async () => {
+		// A Typst message is arbitrary text. Carrying it in a string that allows
+		// HTML would let angle brackets in a message reach the reader as markup.
+		const stderr = "error: unexpected <script>alert(1)</script>\n";
+		const controller = makeController(new StubCompiler({ stderr }));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		for (const part of hoverParts(shown)) {
+			if (part.value.includes("script")) {
+				assert.notStrictEqual(part.supportHtml, true, "the message allows HTML");
+			}
+		}
+		assert.ok(hoverText(shown).includes("script"), `no message in the hover: ${hoverText(shown)}`);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -19,11 +19,14 @@ const SVG = '<svg viewBox="0 0 10 10" width="10pt" height="10pt"></svg>';
 class StubCompiler implements TypstCompilerLike {
 	readonly sources: string[] = [];
 
+	/** What the next compile answers with, so one test can make a block fail. */
+	next: TypstCompileResult | undefined;
+
 	constructor(private readonly result: TypstCompileResult) {}
 
 	compile(source: string): Promise<TypstCompileResult> {
 		this.sources.push(source);
-		return Promise.resolve(this.result);
+		return Promise.resolve(this.next ?? this.result);
 	}
 
 	dispose(): void {
@@ -88,6 +91,22 @@ function nextResultFor(
 			resolve();
 		});
 		controller.request(document, position);
+	});
+}
+
+/** Run an action and wait for the result it publishes. */
+function nextPublished(controller: TypstPreviewController, act: () => void): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			subscription.dispose();
+			reject(new Error("no result was published"));
+		}, 2000);
+		const subscription = controller.onDidChangeResult(() => {
+			clearTimeout(timer);
+			subscription.dispose();
+			resolve();
+		});
+		act();
 	});
 }
 
@@ -263,6 +282,30 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		const [image] = hoverParts(shown);
 		assert.ok(image.value.includes('<div align="center">'), `the image is not centred: ${image.value}`);
 		assert.strictEqual(image.supportHtml, true, "a centred image needs the markdown string to allow HTML");
+		controller.dispose();
+	});
+
+	test("Should keep a failure out of the HTML part when both reach one hover", async () => {
+		// A failure keeps the last good image of the same block behind it, so a
+		// hover can carry an image and a message at once. That is the case the
+		// split exists for, and the one where merging them would be a defect.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const controller = makeController(compiler);
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS);
+
+		await nextResultFor(controller, document, INSIDE_PLAIN);
+		compiler.next = { stderr: "error: unexpected <script>alert(1)</script>\n" };
+		await nextPublished(controller, () => controller.reload());
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		const parts = hoverParts(shown);
+		assert.strictEqual(parts.length, 2, `an image and a message are two parts: ${hoverText(shown)}`);
+		assert.ok(parts[0].value.includes("data:image/"), `no image in the first part: ${parts[0].value}`);
+		assert.strictEqual(parts[0].supportHtml, true, "the image part allows HTML");
+		assert.ok(!parts[0].value.includes("script"), "the message reached the part that allows HTML");
+		assert.ok(parts[1].value.includes("script"), `no message in the second part: ${parts[1].value}`);
+		assert.notStrictEqual(parts[1].supportHtml, true, "the message allows HTML");
 		controller.dispose();
 	});
 


### PR DESCRIPTION
A hover showed its image against the left edge of a box wider than the image. The image itself is symmetric: the preview compiles under `#set page(width: auto, height: auto, margin: 0.5em)`, so the page shrinks to the content with the same margin on four sides. The asymmetry belongs to the widget, which keeps room for its copy button and merges the hovers of every provider that answers for a position into one, so the width follows the widest of them.

The image is now wrapped in a centring `div`. That needs the markdown string to allow HTML, so the compiler message travels as a second hover part and the string that allows HTML never carries text a compiler wrote. A Typst message is arbitrary, and one holding angle brackets would otherwise reach the reader as markup.

Measured in the Extension Development Host: `align` on a `div` is kept by the sanitiser, and the empty strip on the right is the copy button, which no markdown reaches.

Tests cover the centring, the message staying out of the HTML part, and the case the split exists for, which is a working block edited into a broken one, where the failure keeps the last good image behind it and the hover carries both at once.