### PR TITLE
feat: show a Typst hover image as a raster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - feat: Preview an inline Typst cell, written as `` `{typst} ...` `` or `` `...`{.typst} ``. (#423)
 - feat: Show the Typst preview in the panel and in a hover at the same time. (#420)
-- feat: Show a Typst hover image as a raster of the height the hover displays, so a plot whose vector is too long for a data URI appears instead of pointing at the panel. The panel still shows the vector. (#443)
+- feat: Show a Typst hover image as a raster of the height the hover displays. A plot whose vector is too long for a data URI now appears in the hover, and the panel still shows the vector. (#443)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - feat: Preview an inline Typst cell, written as `` `{typst} ...` `` or `` `...`{.typst} ``. (#423)
 - feat: Show the Typst preview in the panel and in a hover at the same time. (#420)
-- feat: Show a Typst hover image as a raster of the height the hover displays, so a plot whose vector is too long for a data URI appears instead of pointing at the panel. The panel still shows the vector. (#442)
+- feat: Show a Typst hover image as a raster of the height the hover displays, so a plot whose vector is too long for a data URI appears instead of pointing at the panel. The panel still shows the vector. (#443)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat: Preview an inline Typst cell, written as `` `{typst} ...` `` or `` `...`{.typst} ``. (#423)
 - feat: Show the Typst preview in the panel and in a hover at the same time. (#420)
+- feat: Show a Typst hover image as a raster of the height the hover displays, so a plot whose vector is too long for a data URI appears instead of pointing at the panel. The panel still shows the vector. (#442)
 
 ### Bug Fixes
 

--- a/src/providers/typstPreview/typstCompiler.ts
+++ b/src/providers/typstPreview/typstCompiler.ts
@@ -120,8 +120,10 @@ const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 /** The outcome of one compile that Typst itself reported on. */
 export interface TypstCompileResult {
-	/** The image, absent when Typst produced none. */
+	/** The vector, absent when the command asked for a raster or Typst produced none. */
 	svg?: string;
+	/** The raster, absent when the command asked for a vector or Typst produced none. */
+	png?: Buffer;
 	/** The captured standard error, which carries every diagnostic. */
 	stderr: string;
 }
@@ -279,9 +281,16 @@ export class TypstCompiler {
 
 			child.on("close", (code: number | null) => {
 				settle(() => {
-					const svg = Buffer.concat(output).toString("utf-8");
+					const image = Buffer.concat(output);
 					const stderr = Buffer.concat(errorOutput).toString("utf-8");
-					resolve(code === 0 && svg.length > 0 ? { svg, stderr } : { stderr });
+					if (code !== 0 || image.length === 0) {
+						resolve({ stderr });
+						return;
+					}
+					// A raster stays bytes. Decoding one as text replaces every sequence
+					// that is not valid UTF-8, and the image would reach the surface
+					// corrupted with nothing along the way reporting it.
+					resolve(command.format === "png" ? { png: image, stderr } : { svg: image.toString("utf-8"), stderr });
 				});
 			});
 		});

--- a/src/providers/typstPreview/typstContext.ts
+++ b/src/providers/typstPreview/typstContext.ts
@@ -274,6 +274,7 @@ export async function buildCompileRequest(
 	header: string,
 	cache: TypstContextCache,
 	brandMode?: TypstBrandMode,
+	raster?: { ppi: number },
 ): Promise<CompileRequest | Unavailable> {
 	const text = document.getText();
 	// The whole list is kept, because a raw block compiles with the raw blocks
@@ -300,7 +301,7 @@ export async function buildCompileRequest(
 		// Neither kind reaches the filter, so neither carries an option of it. The
 		// directory of the document is the whole answer, and finding it costs no
 		// read, which is what keeps these two off the disk entirely.
-		const command = buildTypstCommand({ paths: { documentDirectory: documentDirectoryOf(document) } });
+		const command = buildTypstCommand({ paths: { documentDirectory: documentDirectoryOf(document) }, raster });
 		return { block, blockIndex, ...assembled, command, notes, bodyLineOffset: 0 };
 	}
 
@@ -331,6 +332,7 @@ export async function buildCompileRequest(
 		// document cannot be paired with the halves of another.
 		paths: chain,
 		readFile: (documentPath) => readTypstFile(documentPath, chain),
+		raster,
 	});
 	if (isUnavailable(built)) {
 		return built;

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -823,6 +823,12 @@ export class TypstPreviewController implements vscode.Disposable {
 		const previous = reason === "surface" ? this.result : this.shown();
 		const sameBlock =
 			previous?.uri.toString() === document.uri.toString() && previous?.blockIndex === request.blockIndex;
+		// Only a compile that produced nothing keeps what came before it. A compile
+		// that produced one format stamps this version of the block, and carrying
+		// the other format across would pair that version with an image compiled
+		// from text that has since changed, which a surface would then serve as
+		// current.
+		const kept = image === undefined && sameBlock ? previous : undefined;
 		this.result = {
 			uri: document.uri,
 			block: request.block,
@@ -830,11 +836,11 @@ export class TypstPreviewController implements vscode.Disposable {
 			version: compiledVersion,
 			source: request.source,
 			brandMode: request.brandMode,
-			svg: compiled.svg ?? (sameBlock ? previous?.svg : undefined),
-			png: compiled.png ?? (sameBlock ? previous?.png : undefined),
+			svg: compiled.svg ?? kept?.svg,
+			png: compiled.png ?? kept?.png,
 			// Beside the raster and never apart from it: a carried image keeps the
 			// resolution it was compiled at, not the one this compile asked for.
-			ppi: compiled.png === undefined ? (sameBlock ? previous?.ppi : undefined) : request.command.ppi,
+			ppi: compiled.png === undefined ? kept?.ppi : request.command.ppi,
 			header: headerText(document, request),
 			error: image === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -120,6 +120,8 @@ export interface TypstPreviewResult {
 	 * surface a reader can zoom stays a vector.
 	 */
 	png?: Buffer;
+	/** The resolution `png` was compiled at, which is how its page size is read. */
+	ppi?: number;
 	/** What the surface says about the block beside the image. */
 	header: string;
 	/** The one line a failure shows, absent when the compile produced an image. */
@@ -830,6 +832,9 @@ export class TypstPreviewController implements vscode.Disposable {
 			brandMode: request.brandMode,
 			svg: compiled.svg ?? (sameBlock ? previous?.svg : undefined),
 			png: compiled.png ?? (sameBlock ? previous?.png : undefined),
+			// Beside the raster and never apart from it: a carried image keeps the
+			// resolution it was compiled at, not the one this compile asked for.
+			ppi: compiled.png === undefined ? (sameBlock ? previous?.ppi : undefined) : request.command.ppi,
 			header: headerText(document, request),
 			error: image === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -112,6 +112,14 @@ export interface TypstPreviewResult {
 	brandMode?: TypstBrandMode;
 	/** The image on screen, which is the last one this block compiled to. */
 	svg?: string;
+	/**
+	 * The raster of this block, for a surface that asked for one.
+	 *
+	 * A hover carries its image inside a data URI, and a raster of the size shown
+	 * is shorter than a page of glyph outlines. The panel reads `svg`, so the
+	 * surface a reader can zoom stays a vector.
+	 */
+	png?: Buffer;
 	/** What the surface says about the block beside the image. */
 	header: string;
 	/** The one line a failure shows, absent when the compile produced an image. */
@@ -309,6 +317,17 @@ function isContextDocument(document: vscode.TextDocument): boolean {
 }
 
 /**
+ * How much of the budget one remembered compile takes.
+ *
+ * Whichever image the entry holds, because a raster and a vector are counted
+ * against one budget and reading the vector alone would let a session of
+ * rasters grow without any of them being counted.
+ */
+function imageBytes(compiled: TypstCompileResult | undefined): number {
+	return compiled?.svg?.length ?? compiled?.png?.length ?? 0;
+}
+
+/**
  * The state of the Typst preview, and every event that changes it.
  *
  * Nothing here spawns Typst until a surface is showing a preview or the user
@@ -436,6 +455,22 @@ export class TypstPreviewController implements vscode.Disposable {
 		return this.attempt(document, position, "surface");
 	}
 
+	/**
+	 * The same block, compiled as a raster at one resolution.
+	 *
+	 * Asked for by a surface that shows its image through a data URI, where the
+	 * length of the URI is what decides whether the image renders at all. The
+	 * resolution is part of what identifies the compile, so two surfaces asking
+	 * at two sizes do not read each other's image out of the cache.
+	 */
+	previewRaster(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		ppi: number,
+	): Promise<TypstPreviewResult | undefined> {
+		return this.attempt(document, position, "surface", false, { ppi });
+	}
+
 	/** Preview the block under the cursor again, because something changed. */
 	refresh(): void {
 		this.compile(cursorTarget(), "background");
@@ -556,8 +591,9 @@ export class TypstPreviewController implements vscode.Disposable {
 		position: vscode.Position,
 		reason: PreviewReason,
 		fresh = false,
+		raster?: { ppi: number },
 	): Promise<TypstPreviewResult | undefined> {
-		return this.run(document, position, reason, fresh).catch((error: unknown) => {
+		return this.run(document, position, reason, fresh, raster).catch((error: unknown) => {
 			const message = getErrorMessage(error);
 			logMessage(`Typst preview: ${message}`, "error");
 			if (reason === "asked") {
@@ -608,6 +644,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		position: vscode.Position,
 		reason: PreviewReason,
 		fresh: boolean,
+		raster?: { ppi: number },
 	): Promise<TypstPreviewResult | undefined> {
 		if (this.disposed || (reason === "background" && !this.options.hasSurface())) {
 			return undefined;
@@ -664,7 +701,14 @@ export class TypstPreviewController implements vscode.Disposable {
 		// so an edit landing during a compile would stamp the new version onto the
 		// old image, and a surface trusting the stamp would serve it as current.
 		const compiledVersion = document.version;
-		const request = await buildCompileRequest(document, position, header, this.contexts, this.brandModeOverride);
+		const request = await buildCompileRequest(
+			document,
+			position,
+			header,
+			this.contexts,
+			this.brandModeOverride,
+			raster,
+		);
 		if (stale()) {
 			return undefined;
 		}
@@ -755,7 +799,8 @@ export class TypstPreviewController implements vscode.Disposable {
 			return undefined;
 		}
 
-		if (compiled.svg === undefined) {
+		const image = compiled.svg ?? compiled.png;
+		if (image === undefined) {
 			if (failure === undefined) {
 				logMessage(`Typst preview: the compiler reported:\n${compiled.stderr}`, "debug");
 			}
@@ -784,8 +829,9 @@ export class TypstPreviewController implements vscode.Disposable {
 			source: request.source,
 			brandMode: request.brandMode,
 			svg: compiled.svg ?? (sameBlock ? previous?.svg : undefined),
+			png: compiled.png ?? (sameBlock ? previous?.png : undefined),
 			header: headerText(document, request),
-			error: compiled.svg === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
+			error: image === undefined ? (failure ?? errorText(compiled.stderr, request)) : undefined,
 		};
 		if (reason !== "surface") {
 			// Every other reason is a block a surface will render, so it is what the
@@ -798,7 +844,7 @@ export class TypstPreviewController implements vscode.Disposable {
 
 	/** Forget one compiled image, and the bytes it was counted for. */
 	private forget(key: string): void {
-		this.cacheBytes -= this.cache.get(key)?.svg?.length ?? 0;
+		this.cacheBytes -= imageBytes(this.cache.get(key));
 		this.cache.delete(key);
 	}
 
@@ -810,7 +856,7 @@ export class TypstPreviewController implements vscode.Disposable {
 		// recently used one.
 		this.forget(key);
 		this.cache.set(key, compiled);
-		this.cacheBytes += compiled.svg?.length ?? 0;
+		this.cacheBytes += imageBytes(compiled);
 		// A `Map` iterates in insertion order and every hit is re-inserted, so the
 		// first key is the one used longest ago. Both bounds matter: the count keeps
 		// a session of small blocks from growing without end, and the byte total
@@ -821,7 +867,7 @@ export class TypstPreviewController implements vscode.Disposable {
 			if (oldest.done) {
 				return;
 			}
-			this.cacheBytes -= this.cache.get(oldest.value)?.svg?.length ?? 0;
+			this.cacheBytes -= imageBytes(this.cache.get(oldest.value));
 			this.cache.delete(oldest.value);
 		}
 	}

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { blockAtOffset } from "../../utils/typst/typstBlocks";
-import { clampSvg, svgDataUri } from "../../utils/typst/typstSvg";
+import { pngDataUri, pngSize, rasterPpi } from "../../utils/typst/typstRaster";
 import type { TypstPreviewController, TypstPreviewResult } from "./typstPreviewController";
 import { surfaceSettings, type TypstSurfaceSettings } from "./typstPreviewSettings";
 
@@ -15,13 +15,25 @@ import { surfaceSettings, type TypstSurfaceSettings } from "./typstPreviewSettin
 /**
  * How much image a hover carries.
  *
- * This bounds the data URI, not the SVG it encodes: base64 inflates the raw
- * image by a third, and the URI, not the SVG, is what the hover renders. A
- * dense page of glyph outlines takes long enough to decode that the hover
- * arrives after the pointer has moved on, so above this the reader is sent to
- * the panel, which renders once and stays.
+ * This bounds the data URI, not the image it encodes: base64 inflates the raw
+ * bytes by a third, and the URI, not the image, is what the hover renders. A
+ * page dense enough to outrun this even as a raster of the size shown takes
+ * long enough to decode that the hover arrives after the pointer has moved on,
+ * so the reader is sent to the panel, which renders once and stays.
  */
 const IMAGE_LIMIT_BYTES = 256 * 1024;
+
+/**
+ * How many raster pixels one point of the shown image is compiled from.
+ *
+ * A dense display draws more than one pixel per point, and an extension is not
+ * told how many, so two is the assumption. A raster compiled at the height it
+ * is shown at would be soft on such a display.
+ */
+const PIXELS_PER_POINT = 2;
+
+/** Points to the inch, which is what a resolution is counted in. */
+const POINTS_PER_INCH = 72;
 
 export class TypstPreviewHover implements vscode.HoverProvider {
 	constructor(
@@ -62,8 +74,14 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		// The version is part of the identity, not decoration. Nothing recompiles in
 		// the background while the hover is the only surface, so a result that
 		// matches on place alone can describe text that has since been edited.
+		// A raster, because the image travels inside a data URI and the length of
+		// that URI is what decides whether it renders at all. The held result
+		// answers only when it holds one: the panel compiles a vector, and a
+		// vector is not something this surface can show.
+		const plain = PIXELS_PER_POINT * POINTS_PER_INCH;
 		const held = this.showing(document, blockIndex);
-		const result = held ?? (await this.controller.preview(document, position)) ?? this.showing(document, blockIndex);
+		const result =
+			held ?? (await this.controller.previewRaster(document, position, plain)) ?? this.showing(document, blockIndex);
 
 		// The pointer left while Typst ran, so the reader is looking somewhere else.
 		// The compile still finished and is held, which is what makes the hover they
@@ -71,26 +89,32 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		if (result === undefined || token.isCancellationRequested) {
 			return undefined;
 		}
-		if (result.svg === undefined && result.error === undefined) {
+		if (result.png === undefined && result.error === undefined) {
 			return undefined;
 		}
-		return new vscode.Hover(this.describe(result, settings.maxHeight), range);
+		const raster = await this.raster(document, position, settings.maxHeight, result);
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+		return new vscode.Hover(this.describe(result, raster), range);
 	}
 
 	/**
-	 * The image, centred, as the one part of a hover that allows HTML.
+	 * The image, centred and sized, as the one part of a hover that allows HTML.
 	 *
 	 * A hover widget is wider than the image it carries. It keeps room for its
 	 * own copy button, and VS Code merges the hovers of every provider that
 	 * answers for a position into one widget, so the width follows the widest of
 	 * them. An image left where it falls sits against the left edge of all that.
 	 *
-	 * A hover cannot size an image, so the root element is scaled instead and the
-	 * `viewBox` is left alone, which keeps the drawing filling it.
+	 * The height is written out because a raster carries a fixed number of pixels
+	 * and markdown cannot scale one. Twice the height shown is compiled and half
+	 * of it asked for back, so the image is sharp on a dense display and still
+	 * obeys the setting.
 	 */
-	private image(svg: string, maxHeight: number): vscode.MarkdownString {
+	private image(png: Buffer, shownHeight: number): vscode.MarkdownString {
 		const markdown = new vscode.MarkdownString();
-		const uri = svgDataUri(clampSvg(svg, maxHeight));
+		const uri = pngDataUri(png);
 		if (uri.length > IMAGE_LIMIT_BYTES) {
 			markdown.appendText(
 				"The compiled image is too large for a hover. Run Quarto Wizard: Preview Typst Block to see it in the panel.",
@@ -98,8 +122,39 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 			return markdown;
 		}
 		markdown.supportHtml = true;
-		markdown.appendMarkdown(`<div align="center">\n\n![The compiled Typst block.](${uri})\n\n</div>`);
+		const image = `<img src="${uri}" alt="The compiled Typst block." height="${Math.round(shownHeight)}">`;
+		markdown.appendMarkdown(`<div align="center">\n\n${image}\n\n</div>`);
 		return markdown;
+	}
+
+	/**
+	 * The raster of one block, at the resolution the hover shows it at.
+	 *
+	 * Compiled once at the plain resolution, which answers for every page the
+	 * hover shows whole. A page taller than that is scaled down before a reader
+	 * sees it, so it is compiled again at the resolution it is actually shown at,
+	 * rather than carrying pixels the hover throws away in a URI that has to
+	 * carry every one of them.
+	 */
+	private async raster(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		maxHeight: number,
+		first: TypstPreviewResult,
+	): Promise<{ png: Buffer; shownHeight: number } | undefined> {
+		if (first.png === undefined) {
+			return undefined;
+		}
+		const size = pngSize(first.png);
+		if (size === undefined) {
+			return undefined;
+		}
+		const pageHeight = size.height / PIXELS_PER_POINT;
+		if (pageHeight <= maxHeight) {
+			return { png: first.png, shownHeight: pageHeight };
+		}
+		const scaled = await this.controller.previewRaster(document, position, rasterPpi(pageHeight, maxHeight));
+		return { png: scaled?.png ?? first.png, shownHeight: maxHeight };
 	}
 
 	/**
@@ -114,6 +169,7 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 	private showing(document: vscode.TextDocument, blockIndex: number): TypstPreviewResult | undefined {
 		const shown = this.controller.current();
 		return shown !== undefined &&
+			shown.png !== undefined &&
 			shown.uri.toString() === document.uri.toString() &&
 			shown.blockIndex === blockIndex &&
 			shown.version === document.version
@@ -129,10 +185,13 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 	 * that a string allowing HTML must never carry: a message holding angle
 	 * brackets would reach the reader as markup rather than as what Typst said.
 	 */
-	private describe(result: TypstPreviewResult, maxHeight: number): vscode.MarkdownString[] {
+	private describe(
+		result: TypstPreviewResult,
+		raster: { png: Buffer; shownHeight: number } | undefined,
+	): vscode.MarkdownString[] {
 		const parts: vscode.MarkdownString[] = [];
-		if (result.svg !== undefined) {
-			parts.push(this.image(result.svg, maxHeight));
+		if (raster !== undefined) {
+			parts.push(this.image(raster.png, raster.shownHeight));
 		}
 		if (result.error !== undefined) {
 			const message = new vscode.MarkdownString();

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -96,6 +96,11 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		if (token.isCancellationRequested) {
 			return undefined;
 		}
+		// Bytes that carry no size are not an image, so a result holding only those
+		// has nothing to show and nothing to say.
+		if (raster === undefined && result.error === undefined) {
+			return undefined;
+		}
 		return new vscode.Hover(this.describe(result, raster), range);
 	}
 
@@ -149,7 +154,10 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		if (size === undefined) {
 			return undefined;
 		}
-		const pageHeight = size.height / PIXELS_PER_POINT;
+		// The pixels alone do not say how large the page is. A held raster can be
+		// the scaled one from a taller page, and reading it at the plain resolution
+		// would report the height of the hover that scaled it as the page.
+		const pageHeight = (size.height * POINTS_PER_INCH) / (first.ppi ?? PIXELS_PER_POINT * POINTS_PER_INCH);
 		if (pageHeight <= maxHeight) {
 			return { png: first.png, shownHeight: pageHeight };
 		}

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -162,7 +162,11 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 			return { png: first.png, shownHeight: pageHeight };
 		}
 		const scaled = await this.controller.previewRaster(document, position, rasterPpi(pageHeight, maxHeight));
-		return { png: scaled?.png ?? first.png, shownHeight: maxHeight };
+		// Read the same way the first pass is. A scaled compile that a newer
+		// request superseded answers with nothing, and the page still has to be
+		// shown at the height the hover shows it at.
+		const usable = scaled?.png !== undefined && pngSize(scaled.png) !== undefined ? scaled.png : first.png;
+		return { png: usable, shownHeight: maxHeight };
 	}
 
 	/**

--- a/src/providers/typstPreview/typstPreviewHover.ts
+++ b/src/providers/typstPreview/typstPreviewHover.ts
@@ -35,6 +35,9 @@ const PIXELS_PER_POINT = 2;
 /** Points to the inch, which is what a resolution is counted in. */
 const POINTS_PER_INCH = 72;
 
+/** The resolution a page shown whole is compiled at. */
+const PLAIN_PPI = PIXELS_PER_POINT * POINTS_PER_INCH;
+
 export class TypstPreviewHover implements vscode.HoverProvider {
 	constructor(
 		private readonly controller: TypstPreviewController,
@@ -78,10 +81,11 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		// that URI is what decides whether it renders at all. The held result
 		// answers only when it holds one: the panel compiles a vector, and a
 		// vector is not something this surface can show.
-		const plain = PIXELS_PER_POINT * POINTS_PER_INCH;
 		const held = this.showing(document, blockIndex);
 		const result =
-			held ?? (await this.controller.previewRaster(document, position, plain)) ?? this.showing(document, blockIndex);
+			held ??
+			(await this.controller.previewRaster(document, position, PLAIN_PPI)) ??
+			this.showing(document, blockIndex);
 
 		// The pointer left while Typst ran, so the reader is looking somewhere else.
 		// The compile still finished and is held, which is what makes the hover they
@@ -157,16 +161,23 @@ export class TypstPreviewHover implements vscode.HoverProvider {
 		// The pixels alone do not say how large the page is. A held raster can be
 		// the scaled one from a taller page, and reading it at the plain resolution
 		// would report the height of the hover that scaled it as the page.
-		const pageHeight = (size.height * POINTS_PER_INCH) / (first.ppi ?? PIXELS_PER_POINT * POINTS_PER_INCH);
-		if (pageHeight <= maxHeight) {
-			return { png: first.png, shownHeight: pageHeight };
+		const compiledAt = first.ppi ?? PLAIN_PPI;
+		const pageHeight = (size.height * POINTS_PER_INCH) / compiledAt;
+		const shownHeight = Math.min(pageHeight, maxHeight);
+
+		// One question rather than two: what resolution does this page want at the
+		// height it is shown at. A held raster that already answers it is kept, and
+		// one that does not is compiled again, whether it holds too many pixels for
+		// a tall page or too few for a page the reader has since made room for.
+		const wanted = rasterPpi(pageHeight, maxHeight);
+		if (compiledAt === wanted) {
+			return { png: first.png, shownHeight };
 		}
-		const scaled = await this.controller.previewRaster(document, position, rasterPpi(pageHeight, maxHeight));
-		// Read the same way the first pass is. A scaled compile that a newer
-		// request superseded answers with nothing, and the page still has to be
-		// shown at the height the hover shows it at.
-		const usable = scaled?.png !== undefined && pngSize(scaled.png) !== undefined ? scaled.png : first.png;
-		return { png: usable, shownHeight: maxHeight };
+		const again = await this.controller.previewRaster(document, position, wanted);
+		// Read the same way the first pass is. A compile that a newer request
+		// superseded answers with nothing, and the page still has to be shown.
+		const usable = again?.png !== undefined && pngSize(again.png) !== undefined ? again.png : first.png;
+		return { png: usable, shownHeight };
 	}
 
 	/**

--- a/src/test/suite/pngFixtures.ts
+++ b/src/test/suite/pngFixtures.ts
@@ -1,0 +1,15 @@
+/**
+ * A PNG header declaring one size.
+ *
+ * The size is all any surface reads out of a raster, so a header alone stands
+ * in for a whole image and nothing here has to compile one.
+ */
+export function pngHeader(width: number, height: number): Buffer {
+	const bytes = Buffer.alloc(24);
+	Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes, 0);
+	bytes.writeUInt32BE(13, 8);
+	bytes.write("IHDR", 12, "ascii");
+	bytes.writeUInt32BE(width, 16);
+	bytes.writeUInt32BE(height, 20);
+	return bytes;
+}

--- a/src/test/suite/typstCli.test.ts
+++ b/src/test/suite/typstCli.test.ts
@@ -87,6 +87,31 @@ suite("Typst CLI Test Suite", () => {
 			assert.strictEqual(command.cwd, undefined);
 		});
 
+		test("Should ask for a raster at the resolution a surface names", () => {
+			// A hover carries its image in a data URI, and a raster of the size shown
+			// is shorter than the vector for all but the simplest drawing.
+			const command = buildTypstCommand({ paths: PATHS, raster: { ppi: 96 } });
+			assert.strictEqual(command.format, "png");
+			assert.strictEqual(flag(command.argv, "--format"), "png");
+			assert.strictEqual(flag(command.argv, "--ppi"), "96");
+		});
+
+		test("Should ask for a vector when no surface names a resolution", () => {
+			const command = buildTypstCommand({ paths: PATHS });
+			assert.strictEqual(command.format, "svg");
+			// `--ppi` reads on a raster format alone, so a vector must not carry one.
+			assert.strictEqual(flag(command.argv, "--ppi"), undefined);
+		});
+
+		test("Should tell two resolutions of one block apart", () => {
+			// The key is what a cached image is found under, so a raster compiled for
+			// a short hover must not be served to a taller one.
+			const coarse = buildTypstCommand({ paths: PATHS, raster: { ppi: 48 } });
+			const fine = buildTypstCommand({ paths: PATHS, raster: { ppi: 144 } });
+			assert.notStrictEqual(commandKey(coarse), commandKey(fine));
+			assert.notStrictEqual(commandKey(coarse), commandKey(buildTypstCommand({ paths: PATHS })));
+		});
+
 		test("Should root a block at the root the configuration names", () => {
 			const command = buildTypstCommand({ global: { root: "/" }, paths: PATHS });
 			assert.strictEqual(flag(command.argv, "--root"), PROJECT);
@@ -142,7 +167,10 @@ suite("Typst CLI Test Suite", () => {
 	suite("commandKey", () => {
 		test("Should tell two commands apart by their directory alone", () => {
 			const argv = ["compile", "-", "-"];
-			assert.notStrictEqual(commandKey({ argv, cwd: "/a" }), commandKey({ argv, cwd: "/b" }));
+			assert.notStrictEqual(
+				commandKey({ argv, cwd: "/a", format: "svg" }),
+				commandKey({ argv, cwd: "/b", format: "svg" }),
+			);
 		});
 
 		test("Should give one command one key", () => {
@@ -151,7 +179,7 @@ suite("Typst CLI Test Suite", () => {
 		});
 
 		test("Should tell a directory that is absent from one that is empty", () => {
-			assert.notStrictEqual(commandKey({ argv: [] }), commandKey({ argv: [], cwd: "" }));
+			assert.notStrictEqual(commandKey({ argv: [], format: "svg" }), commandKey({ argv: [], cwd: "", format: "svg" }));
 		});
 
 		test("Should let no character of an argument spell a boundary", () => {
@@ -160,7 +188,10 @@ suite("Typst CLI Test Suite", () => {
 			// command never spawns, and aliasing one onto a command that does spawn
 			// would serve its image for the wrong document.
 			const nul = String.fromCharCode(0);
-			assert.notStrictEqual(commandKey({ argv: [`a${nul}b`] }), commandKey({ argv: ["a", "b"] }));
+			assert.notStrictEqual(
+				commandKey({ argv: [`a${nul}b`], format: "svg" }),
+				commandKey({ argv: ["a", "b"], format: "svg" }),
+			);
 		});
 	});
 });

--- a/src/test/suite/typstCompiler.test.ts
+++ b/src/test/suite/typstCompiler.test.ts
@@ -26,7 +26,7 @@ const RUNTIME = process.execPath;
 
 /** A command that runs one expression in a child process. */
 function run(source: string): TypstCommand {
-	return { argv: ["-e", source] };
+	return { argv: ["-e", source], format: "svg" };
 }
 
 /** A token that is already cancelled. */
@@ -109,6 +109,24 @@ suite("Typst Compiler Test Suite", () => {
 				const result = await compiler.compile("", run("process.stdout.write('<svg/>')"), never);
 				assert.strictEqual(result.svg, "<svg/>");
 				assert.strictEqual(result.stderr, "");
+			} finally {
+				compiler.dispose();
+			}
+		});
+
+		test("Should keep a raster as bytes rather than decoding it as text", async () => {
+			// A PNG holds bytes no text encoding round-trips. Decoding one as UTF-8
+			// replaces every invalid sequence, and the image reaches the surface
+			// corrupted with nothing reporting it.
+			const compiler = new TypstCompiler(RUNTIME);
+			try {
+				const emit = "process.stdout.write(Buffer.from([0x89,0x50,0x4e,0x47,0x00,0xff,0xfe]))";
+				const command: TypstCommand = { ...run(emit), format: "png" };
+
+				const result = await compiler.compile("", command, never);
+
+				assert.strictEqual(result.svg, undefined, "a raster is not text");
+				assert.deepStrictEqual(result.png, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe]));
 			} finally {
 				compiler.dispose();
 			}
@@ -247,7 +265,7 @@ suite("Typst Compiler Test Suite", () => {
 			const compiler = new TypstCompiler(path.join(BIN, "tools", "aarch64", "typst"));
 			try {
 				await assert.rejects(
-					compiler.compile("", { argv: [] }, never),
+					compiler.compile("", { argv: [], format: "svg" }, never),
 					(error: unknown) => error instanceof TypstCompileFailure && /Failed to start Typst/.test(String(error)),
 				);
 			} finally {

--- a/src/test/suite/typstPreviewMessages.test.ts
+++ b/src/test/suite/typstPreviewMessages.test.ts
@@ -109,7 +109,7 @@ suite("Typst Preview Messages Test Suite", () => {
 				block,
 				blockIndex: 0,
 				source: "",
-				command: { argv: [] },
+				command: { argv: [], format: "svg" },
 				injectedLines: 0,
 				bodyLineOffset: 0,
 				notes: [],

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -17,11 +17,8 @@ import {
 /** An image that is never compiled, so nothing here spawns Typst. */
 const SVG = '<svg viewBox="0 0 10 10" width="10pt" height="10pt"></svg>';
 
-/** A raster header declaring one size, which is all a surface reads from it. */
-const png = pngHeader;
-
 /** A raster of a page that fits the hover whole, at twice the height shown. */
-const PNG = png(20, 20);
+const PNG = pngHeader(20, 20);
 
 /**
  * A compiler that answers every compile with the same image.
@@ -345,7 +342,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// so the height comes from the markup. Twice the height is compiled and
 		// half of it asked for back, which is what keeps it sharp on a dense
 		// display.
-		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: png(40, 20), stderr: "" });
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: pngHeader(40, 20), stderr: "" });
 		const controller = makeController(compiler);
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"], 200));
 		const document = await quartoDocument(THREE_KINDS);
@@ -363,7 +360,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// Twice the height shown, and never twice the page. A page taller than the
 		// hover shows is scaled down before a reader sees it, and every pixel above
 		// that ratio is length in the URI that buys nothing.
-		const tall = new StubCompiler({ svg: SVG, stderr: "" }, { png: png(100, 800), stderr: "" });
+		const tall = new StubCompiler({ svg: SVG, stderr: "" }, { png: pngHeader(100, 800), stderr: "" });
 		const controller = makeController(tall);
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"], 100));
 		const document = await quartoDocument(THREE_KINDS);
@@ -397,8 +394,8 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// A held raster can be the scaled one from a taller page, so its height is
 		// not the page at the plain resolution. Reading the page size from the
 		// pixels alone would report the height of the hover that scaled it.
-		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: png(100, 800), stderr: "" }, (ppi) => ({
-			png: png(100, Math.round((800 * ppi) / 144)),
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: pngHeader(100, 800), stderr: "" }, (ppi) => ({
+			png: pngHeader(100, Math.round((800 * ppi) / 144)),
 			stderr: "",
 		}));
 		const controller = makeController(compiler);
@@ -611,7 +608,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// A raster of the size shown is shorter than the vector for all but the
 		// simplest drawing, and a page dense enough still outruns what a data URI
 		// can carry. The reader is sent to the panel rather than shown markup.
-		const huge = Buffer.concat([png(20, 20), Buffer.alloc(400_000)]);
+		const huge = Buffer.concat([pngHeader(20, 20), Buffer.alloc(400_000)]);
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }, { png: huge, stderr: "" }));
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
@@ -628,7 +625,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// markdown carries. An image in the gap between the two passed the guard and
 		// reached VS Code as a literal `![...](data:...)` string.
 		const raw = 200_000;
-		const padded = Buffer.concat([png(20, 20), Buffer.alloc(raw - 24)]);
+		const padded = Buffer.concat([pngHeader(20, 20), Buffer.alloc(raw - 24)]);
 		assert.ok(padded.length < 256 * 1024, "the raw image must be under the raw limit");
 		assert.ok(padded.toString("base64").length > 256 * 1024, "the encoded image must be over the limit");
 		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }, { png: padded, stderr: "" }));

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -376,6 +376,22 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should show a raster for an inline span as well as a fence", async () => {
+		// A span is a surface of its own, and it reached the compiler asking for a
+		// vector while every fence asked for a raster, so a hover over one showed
+		// nothing at all. The raw form is used here because it needs no extension
+		// installed in the workspace.
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS + "\nValue: `#calc.pi`{=typst}\n");
+		const inline = new vscode.Position(14, 10);
+
+		const shown = await hover.provideHover(document, inline, NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes("data:image/png;base64,"), `no image for a span: ${hoverText(shown)}`);
+		controller.dispose();
+	});
+
 	test("Should offer no hover for a raster it cannot read", async () => {
 		// Bytes that are not a raster carry no size, so there is nothing to show
 		// and nothing to say. An empty hover is a widget with no content in it.

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -409,6 +409,32 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 
 		assert.ok(hoverText(shown).includes('height="400"'), `the page was mis-sized: ${hoverText(shown)}`);
+		// The room the reader made is room for pixels as well. A held raster of 200
+		// pixels stretched over 400 points is a quarter of the density asked for,
+		// so the page is read again at the resolution it is now shown at. The image
+		// served says which one that is, where a count of compiles would not: the
+		// page was already compiled at this resolution once and is answered from
+		// the cache rather than by a second process.
+		assert.ok(
+			hoverText(shown).includes(pngHeader(100, 800).toString("base64")),
+			"the hover kept the raster of the smaller height",
+		);
+		controller.dispose();
+	});
+
+	test("Should keep the raster it has when the compile of a scaled one answers nothing", async () => {
+		// A newer request supersedes a compile, and the page still has to be shown.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: pngHeader(100, 800), stderr: "" }, (ppi) =>
+			ppi === 144 ? { png: pngHeader(100, 800), stderr: "" } : { png: Buffer.from("superseded", "utf-8"), stderr: "" },
+		);
+		const controller = makeController(compiler);
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"], 100));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes("data:image/png;base64,"), `no image: ${hoverText(shown)}`);
+		assert.ok(hoverText(shown).includes('height="100"'), `the page was mis-sized: ${hoverText(shown)}`);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { TypstPreviewController, type TypstCompilerLike } from "../../providers/typstPreview/typstPreviewController";
 import type { TypstCompileResult } from "../../providers/typstPreview/typstCompiler";
 import type { TypstCommand } from "../../utils/typst/typstCli";
+import { pngHeader } from "./pngFixtures";
 import { TypstPreviewCodeLens } from "../../providers/typstPreview/typstPreviewCodeLens";
 import { TypstPreviewHover } from "../../providers/typstPreview/typstPreviewHover";
 import {
@@ -17,15 +18,7 @@ import {
 const SVG = '<svg viewBox="0 0 10 10" width="10pt" height="10pt"></svg>';
 
 /** A raster header declaring one size, which is all a surface reads from it. */
-function png(width: number, height: number): Buffer {
-	const bytes = Buffer.alloc(24);
-	Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes, 0);
-	bytes.writeUInt32BE(13, 8);
-	bytes.write("IHDR", 12, "ascii");
-	bytes.writeUInt32BE(width, 16);
-	bytes.writeUInt32BE(height, 20);
-	return bytes;
-}
+const png = pngHeader;
 
 /** A raster of a page that fits the hover whole, at twice the height shown. */
 const PNG = png(20, 20);
@@ -48,6 +41,7 @@ class StubCompiler implements TypstCompilerLike {
 	constructor(
 		private readonly result: TypstCompileResult,
 		raster?: TypstCompileResult,
+		private readonly rasterFor?: (ppi: number) => TypstCompileResult,
 	) {
 		// A compiler that cannot compile a block cannot compile it in either
 		// format, so a stub given a failure fails whichever one is asked for.
@@ -60,7 +54,10 @@ class StubCompiler implements TypstCompilerLike {
 		if (this.next !== undefined) {
 			return Promise.resolve(this.next);
 		}
-		return Promise.resolve(command.format === "png" ? this.raster : this.result);
+		if (command.format !== "png") {
+			return Promise.resolve(this.result);
+		}
+		return Promise.resolve(this.rasterFor?.(ppiOf(command)) ?? this.raster);
 	}
 
 	dispose(): void {
@@ -141,6 +138,12 @@ function fixedSettings(
 	codeLens = true,
 ): () => TypstSurfaceSettings {
 	return () => ({ surfaces: new Set(surfaces), maxHeight, codeLens });
+}
+
+/** Settings a test can change between hovers, as a reader changes a setting. */
+function mutableSettings(surfaces: readonly TypstPreviewSurface[], maxHeight: number) {
+	const state = { surfaces: new Set(surfaces), maxHeight, codeLens: true };
+	return { read: () => state, set: (height: number) => (state.maxHeight = height) };
 }
 
 const NO_CANCEL = new vscode.CancellationTokenSource().token;
@@ -373,6 +376,42 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// tall, shown at 100. The resolution falls by that same ratio.
 		assert.strictEqual(ppiOf(tall.commands[1]), 36);
 		assert.ok(hoverText(shown).includes('height="100"'), `no clamped height: ${hoverText(shown)}`);
+		controller.dispose();
+	});
+
+	test("Should offer no hover for a raster it cannot read", async () => {
+		// Bytes that are not a raster carry no size, so there is nothing to show
+		// and nothing to say. An empty hover is a widget with no content in it.
+		const unreadable = { png: Buffer.from("not a raster", "utf-8"), stderr: "" };
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }, unreadable));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.strictEqual(shown, undefined, "a raster with no size is not a hover");
+		controller.dispose();
+	});
+
+	test("Should size a held raster by the resolution it was compiled at", async () => {
+		// A held raster can be the scaled one from a taller page, so its height is
+		// not the page at the plain resolution. Reading the page size from the
+		// pixels alone would report the height of the hover that scaled it.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: png(100, 800), stderr: "" }, (ppi) => ({
+			png: png(100, Math.round((800 * ppi) / 144)),
+			stderr: "",
+		}));
+		const controller = makeController(compiler);
+		const settings = mutableSettings(["hover"], 100);
+		const hover = new TypstPreviewHover(controller, () => settings.read());
+		const document = await quartoDocument(THREE_KINDS);
+
+		// A page of 400 points, shown at 100, so the second pass renders 200 pixels.
+		await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+		settings.set(400);
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes('height="400"'), `the page was mis-sized: ${hoverText(shown)}`);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { TypstPreviewController, type TypstCompilerLike } from "../../providers/typstPreview/typstPreviewController";
 import type { TypstCompileResult } from "../../providers/typstPreview/typstCompiler";
+import type { TypstCommand } from "../../utils/typst/typstCli";
 import { TypstPreviewCodeLens } from "../../providers/typstPreview/typstPreviewCodeLens";
 import { TypstPreviewHover } from "../../providers/typstPreview/typstPreviewHover";
 import {
@@ -15,23 +16,62 @@ import {
 /** An image that is never compiled, so nothing here spawns Typst. */
 const SVG = '<svg viewBox="0 0 10 10" width="10pt" height="10pt"></svg>';
 
-/** A compiler that answers every compile with the same image. */
+/** A raster header declaring one size, which is all a surface reads from it. */
+function png(width: number, height: number): Buffer {
+	const bytes = Buffer.alloc(24);
+	Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes, 0);
+	bytes.writeUInt32BE(13, 8);
+	bytes.write("IHDR", 12, "ascii");
+	bytes.writeUInt32BE(width, 16);
+	bytes.writeUInt32BE(height, 20);
+	return bytes;
+}
+
+/** A raster of a page that fits the hover whole, at twice the height shown. */
+const PNG = png(20, 20);
+
+/**
+ * A compiler that answers every compile with the same image.
+ *
+ * Answers in the format the command asks for, the way Typst does, so a hover
+ * asking for a raster is not handed a vector it cannot read.
+ */
 class StubCompiler implements TypstCompilerLike {
 	readonly sources: string[] = [];
+	readonly commands: TypstCommand[] = [];
 
 	/** What the next compile answers with, so one test can make a block fail. */
 	next: TypstCompileResult | undefined;
 
-	constructor(private readonly result: TypstCompileResult) {}
+	private readonly raster: TypstCompileResult;
 
-	compile(source: string): Promise<TypstCompileResult> {
+	constructor(
+		private readonly result: TypstCompileResult,
+		raster?: TypstCompileResult,
+	) {
+		// A compiler that cannot compile a block cannot compile it in either
+		// format, so a stub given a failure fails whichever one is asked for.
+		this.raster = raster ?? (result.svg === undefined ? { stderr: result.stderr } : { png: PNG, stderr: "" });
+	}
+
+	compile(source: string, command: TypstCommand): Promise<TypstCompileResult> {
 		this.sources.push(source);
-		return Promise.resolve(this.next ?? this.result);
+		this.commands.push(command);
+		if (this.next !== undefined) {
+			return Promise.resolve(this.next);
+		}
+		return Promise.resolve(command.format === "png" ? this.raster : this.result);
 	}
 
 	dispose(): void {
 		/* Nothing is spawned, so there is nothing to kill. */
 	}
+}
+
+/** The resolution one compile asked for, which decides how sharp it is. */
+function ppiOf(command: TypstCommand): number {
+	const at = command.argv.indexOf("--ppi");
+	return at === -1 ? 0 : Number(command.argv[at + 1]);
 }
 
 /** A document holding one plain block, one raw block and one cell. */
@@ -245,10 +285,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 
 		const shown = await hover.provideHover(document, INSIDE_RAW, NO_CANCEL);
 
-		assert.ok(
-			hoverText(shown).includes("data:image/svg+xml;base64,"),
-			`no image in the first hover: ${hoverText(shown)}`,
-		);
+		assert.ok(hoverText(shown).includes("data:image/png;base64,"), `no image in the first hover: ${hoverText(shown)}`);
 		assert.strictEqual(compiler.sources.length, 1);
 		controller.dispose();
 	});
@@ -300,6 +337,45 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should show a raster, sized to the height the hover shows", async () => {
+		// A raster carries a fixed number of pixels and markdown cannot scale one,
+		// so the height comes from the markup. Twice the height is compiled and
+		// half of it asked for back, which is what keeps it sharp on a dense
+		// display.
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" }, { png: png(40, 20), stderr: "" });
+		const controller = makeController(compiler);
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"], 200));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes("data:image/png;base64,"), `no raster: ${hoverText(shown)}`);
+		assert.ok(hoverText(shown).includes('height="10"'), `no height on the image: ${hoverText(shown)}`);
+		assert.strictEqual(compiler.commands.length, 1, "a page the hover shows whole compiles once");
+		assert.strictEqual(ppiOf(compiler.commands[0]), 144);
+		controller.dispose();
+	});
+
+	test("Should compile a tall page again, at the resolution the hover shows it at", async () => {
+		// Twice the height shown, and never twice the page. A page taller than the
+		// hover shows is scaled down before a reader sees it, and every pixel above
+		// that ratio is length in the URI that buys nothing.
+		const tall = new StubCompiler({ svg: SVG, stderr: "" }, { png: png(100, 800), stderr: "" });
+		const controller = makeController(tall);
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"], 100));
+		const document = await quartoDocument(THREE_KINDS);
+
+		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+
+		assert.strictEqual(tall.commands.length, 2, "a page taller than the hover shows is compiled again");
+		assert.strictEqual(ppiOf(tall.commands[0]), 144);
+		// The first pass reported 800 pixels at 144, which is a page 400 points
+		// tall, shown at 100. The resolution falls by that same ratio.
+		assert.strictEqual(ppiOf(tall.commands[1]), 36);
+		assert.ok(hoverText(shown).includes('height="100"'), `no clamped height: ${hoverText(shown)}`);
+		controller.dispose();
+	});
+
 	test("Should keep a compile failure out of a part that allows HTML", async () => {
 		// A Typst message is arbitrary text. Carrying it in a string that allows
 		// HTML would let angle brackets in a message reach the reader as markup.
@@ -337,7 +413,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 
-		assert.ok(hoverText(shown).includes("data:image/svg+xml;base64,"));
+		assert.ok(hoverText(shown).includes("data:image/png;base64,"));
 		assert.strictEqual(compiler.sources.length, 1);
 		controller.dispose();
 	});
@@ -458,17 +534,22 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		controller.dispose();
 	});
 
-	test("Should answer from the preview on screen without compiling again", async () => {
+	test("Should answer a second hover of one block without compiling again", async () => {
+		// The panel compiles a vector and the hover shows a raster, so the panel
+		// cannot answer for the hover. One hover of a block still answers the next,
+		// which is what keeps a pointer moving over the same block free.
 		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
 		const controller = makeController(compiler);
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
-		await nextResultFor(controller, document, INSIDE_PLAIN);
+		await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
+		const compiledOnce = compiler.sources.length;
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 
-		assert.ok(hoverText(shown).includes("data:image/svg+xml;base64,"));
-		assert.strictEqual(compiler.sources.length, 1, "the block on screen is not compiled a second time");
+		assert.ok(hoverText(shown).includes("data:image/png;base64,"));
+		assert.strictEqual(compiledOnce, 1, "the first hover compiles the block once");
+		assert.strictEqual(compiler.sources.length, 1, "a second hover of one block compiles nothing");
 		controller.dispose();
 	});
 
@@ -488,8 +569,11 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	});
 
 	test("Should point at the panel for an image too large to hover", async () => {
-		const huge = `<svg width="10pt" height="10pt">${"x".repeat(400_000)}</svg>`;
-		const controller = makeController(new StubCompiler({ svg: huge, stderr: "" }));
+		// A raster of the size shown is shorter than the vector for all but the
+		// simplest drawing, and a page dense enough still outruns what a data URI
+		// can carry. The reader is sent to the panel rather than shown markup.
+		const huge = Buffer.concat([png(20, 20), Buffer.alloc(400_000)]);
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }, { png: huge, stderr: "" }));
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
@@ -501,30 +585,21 @@ suite("Typst Preview Surfaces Test Suite", () => {
 	});
 
 	test("Should point at the panel for an image whose data URI alone is too large", async () => {
-		// The guard used to measure the raw SVG, which the markdown never carries.
-		// An image in the gap between the raw limit and the base64 limit passed the
-		// guard and reached VS Code as a literal `![...](data:...)` string, because
-		// the URI was too long for VS Code to parse as an image.
-		const prefix = '<svg viewBox="0 0 10 10" width="10pt" height="10pt"><!--';
-		const suffix = "--></svg>";
-		const padded = prefix + "x".repeat(240_000 - prefix.length - suffix.length) + suffix;
-		assert.strictEqual(padded.length, 240_000, "the fixture itself must land at the intended length");
-		assert.ok(padded.length < 256 * 1024, "the raw SVG must be under the raw limit");
-		assert.ok(
-			Buffer.from(padded, "utf-8").toString("base64").length > 256 * 1024,
-			"the encoded image must be over the limit",
-		);
-		const controller = makeController(new StubCompiler({ svg: padded, stderr: "" }));
+		// The guard measures the URI and not the image, because the URI is what the
+		// markdown carries. An image in the gap between the two passed the guard and
+		// reached VS Code as a literal `![...](data:...)` string.
+		const raw = 200_000;
+		const padded = Buffer.concat([png(20, 20), Buffer.alloc(raw - 24)]);
+		assert.ok(padded.length < 256 * 1024, "the raw image must be under the raw limit");
+		assert.ok(padded.toString("base64").length > 256 * 1024, "the encoded image must be over the limit");
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }, { png: padded, stderr: "" }));
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS);
 
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 
 		assert.ok(hoverText(shown).includes("panel"), `unexpected hover: ${hoverText(shown)}`);
-		assert.ok(
-			!hoverText(shown).includes("data:image/svg+xml"),
-			`the oversized URI reached the hover: ${hoverText(shown)}`,
-		);
+		assert.ok(!hoverText(shown).includes("data:image/png"), `the oversized URI reached the hover: ${hoverText(shown)}`);
 		controller.dispose();
 	});
 
@@ -536,7 +611,7 @@ suite("Typst Preview Surfaces Test Suite", () => {
 
 		const shown = await hover.provideHover(document, INSIDE_PLAIN, NO_CANCEL);
 
-		assert.ok(hoverText(shown).includes("data:image/svg+xml"), `no image in the hover: ${hoverText(shown)}`);
+		assert.ok(hoverText(shown).includes("data:image/png"), `no image in the hover: ${hoverText(shown)}`);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstRaster.test.ts
+++ b/src/test/suite/typstRaster.test.ts
@@ -1,0 +1,55 @@
+import * as assert from "assert";
+import { pngDataUri, pngSize, rasterPpi } from "../../utils/typst/typstRaster";
+
+/** A PNG header declaring one size, which is all `pngSize` reads. */
+function pngHeader(width: number, height: number): Buffer {
+	const png = Buffer.alloc(24);
+	Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0);
+	png.writeUInt32BE(13, 8);
+	png.write("IHDR", 12, "ascii");
+	png.writeUInt32BE(width, 16);
+	png.writeUInt32BE(height, 20);
+	return png;
+}
+
+suite("Typst Raster Test Suite", () => {
+	test("Should read the size a PNG header declares", () => {
+		assert.deepStrictEqual(pngSize(pngHeader(800, 400)), { width: 800, height: 400 });
+	});
+
+	test("Should read no size from bytes that are not a PNG", () => {
+		// Typst answers a raster request with a raster, and a build that answered
+		// with anything else would otherwise be sized from whatever those bytes
+		// happen to hold at the offset a header keeps its dimensions at.
+		assert.strictEqual(pngSize(Buffer.from("<svg></svg>", "utf-8")), undefined);
+		assert.strictEqual(pngSize(Buffer.alloc(0)), undefined);
+		// The signature is right and the file stops before the size.
+		assert.strictEqual(pngSize(pngHeader(800, 400).subarray(0, 18)), undefined);
+		// A PNG whose first chunk is not the header declares no size here.
+		const wrongChunk = pngHeader(800, 400);
+		wrongChunk.write("IDAT", 12, "ascii");
+		assert.strictEqual(pngSize(wrongChunk), undefined);
+		// A size of zero is not a size, and dividing by it would follow.
+		assert.strictEqual(pngSize(pngHeader(800, 0)), undefined);
+	});
+
+	test("Should render twice the height a hover shows, and never twice the page", () => {
+		// A raster carries a fixed number of pixels, so rendering the whole page at
+		// twice its natural size wastes every pixel the hover then scales away. The
+		// resolution follows the height on screen instead.
+		//
+		// 72 points to the inch, so 144 is a page shown whole on a dense display.
+		assert.strictEqual(rasterPpi(100, 200), 144);
+		assert.strictEqual(rasterPpi(200, 200), 144);
+		// Taller than the hover shows: the resolution falls by the same ratio the
+		// image is scaled down by, which is what keeps a dense page inside a URI.
+		assert.strictEqual(rasterPpi(400, 200), 72);
+		assert.strictEqual(rasterPpi(800, 200), 36);
+		// A page of no height would divide by zero.
+		assert.strictEqual(rasterPpi(0, 200), 144);
+	});
+
+	test("Should carry the raster as a data URI a hover can render", () => {
+		assert.ok(pngDataUri(pngHeader(2, 2)).startsWith("data:image/png;base64,"));
+	});
+});

--- a/src/test/suite/typstRaster.test.ts
+++ b/src/test/suite/typstRaster.test.ts
@@ -1,16 +1,6 @@
 import * as assert from "assert";
 import { pngDataUri, pngSize, rasterPpi } from "../../utils/typst/typstRaster";
-
-/** A PNG header declaring one size, which is all `pngSize` reads. */
-function pngHeader(width: number, height: number): Buffer {
-	const png = Buffer.alloc(24);
-	Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0);
-	png.writeUInt32BE(13, 8);
-	png.write("IHDR", 12, "ascii");
-	png.writeUInt32BE(width, 16);
-	png.writeUInt32BE(height, 20);
-	return png;
-}
+import { pngHeader } from "./pngFixtures";
 
 suite("Typst Raster Test Suite", () => {
 	test("Should read the size a PNG header declares", () => {

--- a/src/test/suite/typstSource.test.ts
+++ b/src/test/suite/typstSource.test.ts
@@ -220,5 +220,22 @@ suite("Typst Source Test Suite", () => {
 			// A span carries no option run, so nothing of the body sits above the code.
 			assert.strictEqual(built.bodyLineOffset, 0);
 		});
+
+		test("Should ask for a raster when the surface asks for one", async () => {
+			// A hover shows a raster, and it shows one for a span as much as for a
+			// fence. A span left compiling a vector renders nothing at all there.
+			const [unit] = findTypstInlines("Value: `{typst} #calc.pi`.\n");
+			const built = await buildInlineCell(unit, {
+				levels: [],
+				brand: EMPTY_BRAND,
+				mode: "light",
+				paths: {},
+				readFile: () => Promise.resolve(undefined),
+				raster: { ppi: 144 },
+			});
+			assert.ok(!isUnavailable(built));
+			assert.strictEqual(built.command.format, "png");
+			assert.strictEqual(built.command.ppi, 144);
+		});
 	});
 });

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -28,12 +28,23 @@ export interface TypstCommand {
 	argv: string[];
 	/** The directory to run from, absent when the document names none. */
 	cwd?: string;
+	/**
+	 * What the image is, so a caller knows whether the output is text or bytes.
+	 *
+	 * Beside the argv that asks for it, because reading the format back out of
+	 * the arguments is a second place for the two to disagree, and decoding a
+	 * raster as text is not a mistake that reports itself.
+	 */
+	format: TypstImageFormat;
 }
+
+/** The formats a surface can ask a block to compile as. */
+export type TypstImageFormat = "svg" | "png";
 
 /** The arguments that read the source from stdin and write the image to stdout. */
 const STDIO: readonly string[] = ["-", "-"];
 
-/** The image format every surface can show, whatever the cell asks to render as. */
+/** The vector every surface can show, whatever the cell asks to render as. */
 const FORMAT: readonly string[] = ["compile", "--format", "svg"];
 
 /**
@@ -119,6 +130,15 @@ export interface TypstCommandRequest {
 	/** The text fill of the mode in force, absent when the cell sets none. */
 	foreground?: string;
 	paths: TypstPaths;
+	/**
+	 * The resolution a raster is wanted at, absent when a vector is wanted.
+	 *
+	 * A hover asks for one, because it carries its image inside a data URI and a
+	 * raster of the size shown is shorter than a page of glyph outlines. The
+	 * panel asks for none: it renders once and stays, and a reader looking at it
+	 * can see the difference between a vector and a raster.
+	 */
+	raster?: { ppi: number };
 }
 
 /**
@@ -128,12 +148,15 @@ export interface TypstCommandRequest {
  * author who writes `typst-render-background` in their own `input:` mapping has
  * it overridden by the resolved colour, the same way a render does.
  *
- * `--ppi` is not emitted, because the preview compiles to SVG and the flag reads
- * on a raster format alone.
+ * `--ppi` is emitted for a raster alone, because the flag reads on a raster
+ * format and says nothing about a vector. The filter compiles to SVG and never
+ * emits it; a hover asks for a raster of its own, which is a surface the filter
+ * has no equivalent of rather than a departure from what it renders.
  */
 export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
-	const { global = {}, paths } = request;
-	const argv = [...FORMAT];
+	const { global = {}, paths, raster } = request;
+	const format: TypstImageFormat = raster === undefined ? "svg" : "png";
+	const argv = raster === undefined ? [...FORMAT] : ["compile", "--format", format, "--ppi", String(raster.ppi)];
 
 	const root = resolveCompileRoot(global.root === undefined ? undefined : String(global.root), paths);
 	if (root !== undefined) {
@@ -166,7 +189,7 @@ export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
 	}
 
 	argv.push(...STDIO);
-	return { argv, cwd: compileCwd(paths) };
+	return { argv, cwd: compileCwd(paths), format };
 }
 
 /**

--- a/src/utils/typst/typstCli.ts
+++ b/src/utils/typst/typstCli.ts
@@ -36,6 +36,14 @@ export interface TypstCommand {
 	 * raster as text is not a mistake that reports itself.
 	 */
 	format: TypstImageFormat;
+	/**
+	 * The resolution a raster was compiled at, absent for a vector.
+	 *
+	 * A raster says how many pixels it holds and never how large the page was,
+	 * so the two together are what a surface reads a page size from. Assuming
+	 * one resolution reads a scaled raster as a smaller page.
+	 */
+	ppi?: number;
 }
 
 /** The formats a surface can ask a block to compile as. */
@@ -189,7 +197,7 @@ export function buildTypstCommand(request: TypstCommandRequest): TypstCommand {
 	}
 
 	argv.push(...STDIO);
-	return { argv, cwd: compileCwd(paths), format };
+	return { argv, cwd: compileCwd(paths), format, ppi: raster?.ppi };
 }
 
 /**

--- a/src/utils/typst/typstRaster.ts
+++ b/src/utils/typst/typstRaster.ts
@@ -1,0 +1,72 @@
+/**
+ * The raster a hover renders, beside `typstSvg.ts` which holds the vector one.
+ *
+ * A hover carries its image inside a data URI, and the length of that URI is
+ * what the markdown renderer gives up on. A raster of the size actually shown
+ * is shorter than the vector for everything but the simplest drawing, because
+ * a page of glyph outlines costs an outline per glyph however small it is
+ * drawn, while a raster costs the pixels on screen and nothing more.
+ */
+
+/** The size a raster declares, in pixels. */
+export interface RasterSize {
+	width: number;
+	height: number;
+}
+
+/** The eight bytes every PNG starts with. */
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Where the header chunk keeps the width, once the signature and length are past. */
+const WIDTH_AT = 16;
+
+/** The whole of a header: the signature, one chunk length, `IHDR` and two sizes. */
+const HEADER_BYTES = 24;
+
+/** Points to the inch, which is what `--ppi` is counted in. */
+const POINTS_PER_INCH = 72;
+
+/**
+ * The size a raster declares, or nothing when the bytes declare none.
+ *
+ * Read from the file rather than worked out from the resolution asked for, so
+ * a rounding difference between this and Typst cannot leave the hover naming a
+ * height the image does not have.
+ */
+export function pngSize(png: Buffer): RasterSize | undefined {
+	if (png.length < HEADER_BYTES || !png.subarray(0, SIGNATURE.length).equals(SIGNATURE)) {
+		return undefined;
+	}
+	// The first chunk of a PNG is always the header. Reading the size out of
+	// whatever chunk happens to be first would size the image from pixel data.
+	if (png.subarray(12, 16).toString("ascii") !== "IHDR") {
+		return undefined;
+	}
+	const width = png.readUInt32BE(WIDTH_AT);
+	const height = png.readUInt32BE(WIDTH_AT + 4);
+	return width > 0 && height > 0 ? { width, height } : undefined;
+}
+
+/**
+ * The resolution one block compiles at, for a hover that shows `maxHeight`.
+ *
+ * Twice the height on screen, so the image is still sharp on a dense display,
+ * and twice the height on screen rather than twice the page: a page taller than
+ * the hover shows is scaled down before a reader sees it, and every pixel above
+ * that ratio is length in the URI that buys nothing.
+ *
+ * A page of no height keeps the plain resolution, because there is no ratio to
+ * take and nothing to divide by.
+ */
+export function rasterPpi(pageHeight: number, maxHeight: number): number {
+	const whole = POINTS_PER_INCH * 2;
+	if (pageHeight <= maxHeight || pageHeight <= 0) {
+		return whole;
+	}
+	return (whole * maxHeight) / pageHeight;
+}
+
+/** The raster as a data URI, which is what a hover renders. */
+export function pngDataUri(png: Buffer): string {
+	return `data:image/png;base64,${png.toString("base64")}`;
+}

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -307,6 +307,14 @@ export interface CellContext {
 	 */
 	paths: TypstPaths;
 	readFile: ReadFile;
+	/**
+	 * The resolution a raster is wanted at, absent when a vector is wanted.
+	 *
+	 * A surface and not a document decides this, the way `mode` does: both
+	 * describe how one compile is to be shown rather than what the document
+	 * says. It travels here because this is what reaches the command builder.
+	 */
+	raster?: { ppi: number };
 }
 
 /** Something the preview cannot do, and the one line that says why. */
@@ -459,6 +467,7 @@ export async function buildCell(block: TypstUnit, context: CellContext): Promise
 		background,
 		foreground,
 		paths: context.paths,
+		raster: context.raster,
 	});
 	const notes = cellNotes(options);
 	// The upstream warning at `code-cell.lua:110-118`. An option line below the

--- a/src/utils/typst/typstSource.ts
+++ b/src/utils/typst/typstSource.ts
@@ -535,6 +535,7 @@ export async function buildInlineCell(unit: TypstUnit, context: CellContext): Pr
 		background,
 		foreground,
 		paths: context.paths,
+		raster: context.raster,
 	});
 	const notes = cellNotes(options);
 	for (const name of droppedOptions) {


### PR DESCRIPTION
Builds on #442.

A hover carries its image inside a data URI, and the length of that URI is what decides whether the markdown renderer draws an image or prints the markup. A page of glyph outlines costs an outline per glyph however small it is drawn, so a plot that fits on screen could still be turned away with a sentence pointing at the panel.

The hover now compiles a raster of the size it shows. Measured against a dense table with the Typst that ships inside Quarto:

| Transport | Data URI length |
| --- | --- |
| Vector, as shipped | 469082 |
| Vector, percent-encoded instead of base64 | 485487 |
| Raster at the height the hover displays | 97354 |

The vector has no minification headroom, and writing the image to disk does not help: a hover renders a data URI and refuses a `file:` URI, measured across five transports in the most permissive markdown state a hover accepts.

The height is written into the markup, because a raster carries a fixed number of pixels and markdown cannot scale one. Twice the height is compiled and half of it asked back, so the image stays sharp on a dense display. A page taller than the hover shows is compiled again at the resolution it is shown at, since rendering a tall page at twice its natural size puts pixels in the URI that the hover throws away.

The panel still reads the vector, so the surface a reader can look at closely does not change. A block shown in the panel and then hovered now compiles twice, because the two surfaces no longer want the same image. A second hover of one block still compiles nothing.

Two things worth a reviewer's eye:

- The resolution travels with the raster it describes, from the command through to the result. A held raster can be the scaled one from a taller page, and reading its pixels alone would report the height of the hover that scaled it as the page.
- Only a compile that produced nothing keeps the image that came before it. Carrying one format across a successful compile of the other paired the new document version with an image compiled from text that had since changed.