### PR TITLE
fix: read an inline span of the class form as plain code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug Fixes
 
-- fix: Read an inline span carrying the `.typst` class as plain code, the way the block form of that class is read. The span no longer needs the `typst-render` extension installed, and no option of a cell applies to it. (#444)
+- fix: Read an inline span carrying the `.typst` class as plain code, the way the block form of that class is read. The span no longer needs the `typst-render` extension installed, and no option of a cell applies to it. (#445)
 - docs: Point the social card of the documentation website at the image that exists, so a link to the site shows a card. (#441)
 - fix: Read the options of an output format from the top level of the metadata in the Lua reference validator. The format name is never a metadata key, so `validate_format` collected nothing and passed whatever the document wrote. (#439)
 - fix: Offer the panel when a compiled Typst image is too large for a hover. The hover measured the image and not the text it carries, so a large image printed as unreadable markup. (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+- fix: Read an inline span carrying the `.typst` class as plain code, the way the block form of that class is read. The span no longer needs the `typst-render` extension installed, and no option of a cell applies to it. (#444)
 - docs: Point the social card of the documentation website at the image that exists, so a link to the site shows a card. (#441)
 - fix: Read the options of an output format from the top level of the metadata in the Lua reference validator. The format name is never a metadata key, so `validate_format` collected nothing and passed whatever the document wrote. (#439)
 - fix: Offer the panel when a compiled Typst image is too large for a hover. The hover measured the image and not the text it carries, so a large image printed as unreadable markup. (#436)

--- a/docs/getting-started/typst-preview.qmd
+++ b/docs/getting-started/typst-preview.qmd
@@ -55,10 +55,14 @@ The other two kinds need no extension.
 
 ## Inline Forms
 
-An inline span compiles the same way a `{typst}` cell does.
-`` `{typst} #calc.pi` `` and `` `#calc.pi`{.typst} `` are the same executable inline cell, which is the rule of the `typst-render` extension.
+An inline span takes the same three kinds a fence takes.
+
+`` `{typst} #calc.pi` `` is a cell, which the `typst-render` extension renders to an image.
 An inline cell reads the global options only.
 It carries no `//|` option line, because there is no line above it to hold one.
+
+`` `#calc.pi`{.typst} `` is plain code, the inline counterpart of a ` ```typst ` block.
+Quarto styles it and nothing renders it, so the preview needs no extension and applies no option of a cell.
 
 `` `#a`{=typst} `` is a raw passthrough, the inline counterpart of a ` ```{=typst} ` block.
 It is passed to the Typst output untouched, and the prose around it is not compiled.

--- a/src/providers/typstPreview/typstPreviewController.ts
+++ b/src/providers/typstPreview/typstPreviewController.ts
@@ -242,10 +242,12 @@ export function errorText(stderr: string, place: ErrorPlace): string {
 export function headerText(document: vscode.TextDocument, request: CompileRequest): string {
 	const parts = [`${path.basename(document.fileName)} · line ${request.block.fenceLine + 1}`];
 	if (request.block.scope === "inline") {
-		// An inline unit is cropped to its glyphs by a page directive the filter
-		// fixes, so its image is a different shape from every fenced one, and the
-		// reader is told which they are looking at.
-		parts.push(request.block.kind === "raw" ? "inline passthrough" : "inline cell");
+		// Which of the three a reader is looking at, because the three compile
+		// differently: a cell is cropped to its glyphs by a page directive the
+		// filter fixes, so its image is a different shape from every fenced one,
+		// and the other two compile under the same page a fence does.
+		const INLINE_NAMES = { raw: "inline passthrough", cell: "inline cell", plain: "inline code" } as const;
+		parts.push(INLINE_NAMES[request.block.kind]);
 	}
 	if (request.brandMode !== undefined) {
 		// A cell resolves its `auto` colours against one side of the brand, and

--- a/src/test/suite/typstInline.test.ts
+++ b/src/test/suite/typstInline.test.ts
@@ -27,6 +27,17 @@ suite("Typst Inline Test Suite", () => {
 		assert.strictEqual(unit.unitEnd, text.indexOf("}") + 1);
 	});
 
+	test("Should read a span carrying both the prefix and the class as a cell", () => {
+		// The prefix is what makes a span executable, and a class added beside it
+		// for styling does not take that away. Read as plain the span compiled the
+		// prefix itself as Typst source, which is not what the document says.
+		const text = "A circle: `{typst} #circle()`{.typst}.\n";
+		const [unit] = findTypstInlines(text);
+		assert.strictEqual(unit.kind, "cell");
+		assert.strictEqual(unit.body, "#circle()");
+		assert.strictEqual(unit.bodyStart, text.indexOf("#circle()"));
+	});
+
 	test("Should read the raw form as raw", () => {
 		const text = "Bound here: `#let a = 1`{=typst}.\n";
 		const [unit] = findTypstInlines(text);

--- a/src/test/suite/typstInline.test.ts
+++ b/src/test/suite/typstInline.test.ts
@@ -15,10 +15,13 @@ suite("Typst Inline Test Suite", () => {
 		assert.strictEqual(unit.unitEnd, text.indexOf("` today") + 1);
 	});
 
-	test("Should read the class form as a cell, because the filter executes it", () => {
+	test("Should read the class form as plain, because nothing executes it", () => {
+		// The class marks code that Quarto styles, the way a `typst` fence does.
+		// Only the text prefix is executable, and a span carrying the class is read
+		// the way the block form of the same class is read.
 		const text = "A circle: `#circle()`{.typst}.\n";
 		const [unit] = findTypstInlines(text);
-		assert.strictEqual(unit.kind, "cell");
+		assert.strictEqual(unit.kind, "plain");
 		assert.strictEqual(unit.body, "#circle()");
 		// The attribute belongs to the unit, so a cursor inside it finds the unit.
 		assert.strictEqual(unit.unitEnd, text.indexOf("}") + 1);
@@ -33,7 +36,7 @@ suite("Typst Inline Test Suite", () => {
 
 	test("Should keep a class beside other classes", () => {
 		const text = "A circle: `#circle()`{.typst .extra}.\n";
-		assert.strictEqual(findTypstInlines(text)[0]?.kind, "cell");
+		assert.strictEqual(findTypstInlines(text)[0]?.kind, "plain");
 	});
 
 	test("Should read a span written with a longer backtick run", () => {
@@ -121,7 +124,7 @@ suite("Typst Inline Test Suite", () => {
 
 	test("Should read a real class beside another attribute", () => {
 		const text = 'A circle: `#circle()`{alt="see here" .typst}.\n';
-		assert.strictEqual(findTypstInlines(text)[0]?.kind, "cell");
+		assert.strictEqual(findTypstInlines(text)[0]?.kind, "plain");
 	});
 
 	test("Should read no phantom span between two fences of equal run length", () => {

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -250,6 +250,9 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		const shown = await hover.provideHover(document, new vscode.Position(14, 10), NO_CANCEL);
 
 		assert.ok(hoverText(shown).includes("data:image/svg+xml"), `no image for the span: ${hoverText(shown)}`);
+		// The header names the kind, and a span of this form is not a cell.
+		const header = controller.current()?.header ?? "";
+		assert.ok(header.includes("inline code"), `the header names the wrong kind: ${header}`);
 		controller.dispose();
 	});
 

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -239,6 +239,20 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		controller.dispose();
 	});
 
+	test("Should preview a span of the class form with no extension installed", async () => {
+		// The class marks code that Quarto styles, so nothing executes the span and
+		// the filter has nothing to say about it. Read as a cell it demanded an
+		// extension it does not use, and a project without one saw no preview.
+		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
+		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
+		const document = await quartoDocument(THREE_KINDS + "\nValue: `#calc.pi`{.typst}\n");
+
+		const shown = await hover.provideHover(document, new vscode.Position(14, 10), NO_CANCEL);
+
+		assert.ok(hoverText(shown).includes("data:image/svg+xml"), `no image for the span: ${hoverText(shown)}`);
+		controller.dispose();
+	});
+
 	test("Should compile for a hover even when nothing is showing a preview", async () => {
 		// A hover renders nothing until the pointer rests, so it is not a surface
 		// that makes a background edit worth compiling. It still has to be able to

--- a/src/test/suite/typstPreviewSurfaces.test.ts
+++ b/src/test/suite/typstPreviewSurfaces.test.ts
@@ -243,7 +243,8 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// The class marks code that Quarto styles, so nothing executes the span and
 		// the filter has nothing to say about it. Read as a cell it demanded an
 		// extension it does not use, and a project without one saw no preview.
-		const controller = makeController(new StubCompiler({ svg: SVG, stderr: "" }));
+		const compiler = new StubCompiler({ svg: SVG, stderr: "" });
+		const controller = makeController(compiler);
 		const hover = new TypstPreviewHover(controller, fixedSettings(["hover"]));
 		const document = await quartoDocument(THREE_KINDS + "\nValue: `#calc.pi`{.typst}\n");
 
@@ -253,6 +254,14 @@ suite("Typst Preview Surfaces Test Suite", () => {
 		// The header names the kind, and a span of this form is not a cell.
 		const header = controller.current()?.header ?? "";
 		assert.ok(header.includes("inline code"), `the header names the wrong kind: ${header}`);
+		// What was compiled, and not only what it was called. The body sits under
+		// the page directive a fence uses, with nothing of a cell around it: no
+		// page cropped to the glyphs, and none of the bindings a passthrough
+		// accumulates from the blocks above it.
+		const [source] = compiler.sources;
+		assert.ok(source.endsWith("#calc.pi"), `the span body is not what compiled: ${source}`);
+		assert.ok(!source.includes("#let a = 1"), `a passthrough chain reached the span: ${source}`);
+		assert.ok(!source.includes("bottom: 0.25em"), `the page of a cell reached the span: ${source}`);
 		controller.dispose();
 	});
 

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -12,13 +12,13 @@ import type { TypstUnit, TypstUnitKind } from "./typstBlocks";
  * The `typst-render` filter walks Pandoc `Code` inlines beside `CodeBlock`
  * elements, so an inline cell renders to an image and the editor has to say so.
  *
- * The rule is the filter's own, at `cell.is_inline_code`: the class `typst` and
- * the text prefix `{typst}` are the same executable cell. That is not the block
- * rule, where a `.typst` fence is a plain block Quarto only highlights, and the
- * difference is deliberate upstream.
+ * Three forms, and one of them is executed. The text prefix `{typst}` marks a
+ * cell that the filter renders. `{=typst}` marks raw Typst, passed to a Typst
+ * output as it is written and dropped from every other format. The class marks
+ * code that Quarto styles and nothing renders, which is the same rule the block
+ * form of that class follows.
  *
- * There is no inline `plain` kind for that reason. An inline span is a cell or
- * a raw passthrough, and nothing else.
+ * An inline span therefore takes any of the three kinds a fence takes.
  */
 
 /** An attribute that follows the closing backtick run, on the same line. */
@@ -179,10 +179,13 @@ export function findTypstInlines(text: string): TypstUnit[] {
  * class is read, as a plain unit: it is previewed, it needs no extension
  * installed, and no option of a cell applies to it.
  *
- * An attribute is read before a prefix, so `` `{typst} #x`{.python} `` is not a
- * cell even though its text carries the prefix. That follows the order of
- * `cell.is_inline_code` upstream, where the class test is reached first and an
- * element carrying `.python` fails it.
+ * An attribute is read before a prefix, so `` `{typst} #x`{.python} `` is read
+ * as not Typst at all even though its text carries the prefix. Whether the
+ * filter executes that span is not settled here: its class test failing may
+ * fall through to the prefix, in which case a render produces an image and this
+ * shows none. The direction is the safe one either way, because showing nothing
+ * costs a reader a preview and showing an image the render does not produce
+ * tells them something untrue about their document.
  *
  * @param text - The span's content, converted the way `spanContent` reads it,
  *   so a prefix that runs across a line ending is still found.

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -124,7 +124,10 @@ export function findTypstInlines(text: string): TypstUnit[] {
 			continue;
 		}
 
-		const prefix = attribute === "" ? (PREFIX.exec(content.text)?.[0].length ?? 0) : 0;
+		// Sliced off every cell and no other kind. A cell carries the prefix whether
+		// or not it also carries an attribute, and a span of another kind that
+		// happens to start with the same characters is not carrying a prefix at all.
+		const prefix = kind === "cell" ? (PREFIX.exec(content.text)?.[0].length ?? 0) : 0;
 		const body = content.text.slice(prefix);
 
 		// Every offset this module reports counts document characters, and `body`
@@ -135,7 +138,7 @@ export function findTypstInlines(text: string): TypstUnit[] {
 		// CommonMark ends already removed, so the length is in document units and
 		// needs no further correction.
 		const rawContent = raw.slice(content.leading, raw.length - content.trailing);
-		const rawPrefix = attribute === "" ? (PREFIX_RAW.exec(rawContent)?.[0].length ?? 0) : 0;
+		const rawPrefix = kind === "cell" ? (PREFIX_RAW.exec(rawContent)?.[0].length ?? 0) : 0;
 
 		const bodyStart = span.start + run + content.leading + rawPrefix + from;
 		const bodyEnd = span.end - run - content.trailing + from;
@@ -199,7 +202,13 @@ function classify(text: string, attribute: string): TypstUnitKind | undefined {
 		if (RAW_ATTRIBUTE.test(attribute)) {
 			return "raw";
 		}
-		return hasTypstClass(attribute) ? "plain" : undefined;
+		if (!hasTypstClass(attribute)) {
+			return undefined;
+		}
+		// The prefix is what makes a span executable, and a class added beside it
+		// for styling does not take that away. Read as plain, such a span would
+		// compile the prefix itself as Typst source.
+		return PREFIX.test(text) ? "cell" : "plain";
 	}
 	return PREFIX.test(text) ? "cell" : undefined;
 }

--- a/src/utils/typst/typstInline.ts
+++ b/src/utils/typst/typstInline.ts
@@ -173,15 +173,16 @@ export function findTypstInlines(text: string): TypstUnit[] {
 /**
  * The kind a span declares, or undefined when it is not Typst.
  *
- * Upstream, `cell.is_inline_code` tests the class first and reaches the text
- * prefix only when that test fails, so `` `{typst} #x`{.python} `` is read as
- * not an inline cell even though its text carries the prefix: the class test
- * alone decides it, because it is reached first and an element carrying
- * `.python` fails it. This module follows that order, an attribute before a
- * prefix, so the same span is skipped here too. The reasoning is a reading of
- * the filter and not a recorded render, and the direction it commits to on
- * that uncertainty is the safe one: show nothing rather than an image the
- * render does not produce.
+ * Three forms, and only one of them is executed. The text prefix marks a cell,
+ * `{=typst}` marks raw Typst used as it is written, and the class marks code
+ * that Quarto styles. The class is read here the way the block form of the same
+ * class is read, as a plain unit: it is previewed, it needs no extension
+ * installed, and no option of a cell applies to it.
+ *
+ * An attribute is read before a prefix, so `` `{typst} #x`{.python} `` is not a
+ * cell even though its text carries the prefix. That follows the order of
+ * `cell.is_inline_code` upstream, where the class test is reached first and an
+ * element carrying `.python` fails it.
  *
  * @param text - The span's content, converted the way `spanContent` reads it,
  *   so a prefix that runs across a line ending is still found.
@@ -195,7 +196,7 @@ function classify(text: string, attribute: string): TypstUnitKind | undefined {
 		if (RAW_ATTRIBUTE.test(attribute)) {
 			return "raw";
 		}
-		return hasTypstClass(attribute) ? "cell" : undefined;
+		return hasTypstClass(attribute) ? "plain" : undefined;
 	}
 	return PREFIX.test(text) ? "cell" : undefined;
 }


### PR DESCRIPTION
An inline span written as `` `#calc.pi`{.typst} `` was scanned as an executable cell. It is not one. The class marks code that Quarto styles, the way a ```` ```typst ```` fence does.

The three inline forms, confirmed by the author of `typst-render` against a rendered document:

- `` `{typst} #calc.pi` `` is a cell, which the extension renders to an image.
- `` `#calc.pi`{.typst} `` is plain code, which Quarto styles and nothing renders.
- `` `#calc.pi`{=typst} `` is raw Typst, passed to a Typst output as it is written and dropped from every other format.

The class form is now read as a plain unit, the way the block form of that class is read. It is still previewed. What changes is that it no longer demands `typst-render` installed in the project, and no option of a cell applies to it.

A span carrying both the prefix and the class stays a cell, because the prefix is what makes a span executable and a class added beside it for styling does not take that away. Read as plain it compiled the prefix itself as Typst source, so the prefix is now stripped from every cell rather than only from a span carrying no attribute.

The rule was stated in three places and all three said the old thing: the module header, the preview header, which called every span that is not a passthrough an "inline cell", and the user documentation. A comment claiming a reading of the filter as fact is now marked as unsettled, with the direction the doubt is taken and why.