### PR TITLE
fix: run the workspace package builds from the repository root

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
 	],
 	"main": "./dist/extension",
 	"scripts": {
-		"build:schema": "cd packages/schema && npm run build",
-		"build:snippets": "cd packages/snippets && npm run build",
-		"build:core": "cd packages/core && npm run build",
+		"build:schema": "npx tsc -p packages/schema && node packages/schema/scripts/copy-schemas.mjs",
+		"build:snippets": "npx tsc -p packages/snippets",
+		"build:core": "npx tsc -p packages/core",
 		"vscode:prepublish": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --mode production",
 		"webpack": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --mode development --stats-error-details",
 		"watch": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --watch --mode development --stats-error-details",


### PR DESCRIPTION
The root `build:schema`, `build:snippets` and `build:core` scripts changed directory into each package before running `tsc`. `tsc` then reported an error path relative to the package, such as `src/constants.ts(4,14)`. The `$tsc` problem matcher joins that path to the workspace folder, so the Problems panel opened `src/constants.ts` at the repository root. That file has no error, and the file that does have one is never marked.

Each script now runs `tsc` from the repository root with `-p packages/<name>`, so the reported path starts with `packages/`. Each `tsconfig.json` resolves `outDir`, `rootDir` and `include` relative to itself, so the output still goes to `packages/<name>/dist`. `packages/schema/scripts/copy-schemas.mjs` resolves every path from `import.meta.url`, so the copy of the published schema files works from any working directory.

This affects every task in `.vscode/tasks.json` that carries `$tsc` or `$tsc-watch` and builds a workspace package: `npm: build:core`, `npm: test-compile`, `npm: webpack` and `npm: watch`. The root `tsc -p ./` inside `test-compile` was already correct, because it runs at the root.

Verified with a type error in each package:

- Before: `src/constants.ts(3,14): error TS2322`.
- After: `packages/core/src/constants.ts(3,14): error TS2322`, and the same shape for `packages/schema` and `packages/snippets`.

A clean `npm run webpack`, with the three `dist` directories removed first, compiles and writes the schema files under `docs/assets/schema`. `npm test` passes with 1239 tests, and the package suites pass with 471, 235 and 53 tests.