### PR TITLE
ci: report the build verdict as a check run on the commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,11 @@ jobs:
     # No draft condition, unlike the jobs above. This is the single required
     # check, and a skipped required check does not block, so skipping here let
     # a draft reach a mergeable state with nothing built.
+    #
+    # The job id is a contract. `verdict.yml` reads the jobs of this run and
+    # selects the one whose API name is the literal `summary`. This job has no
+    # `name` key, so its API name is this job id. A `name` key added here
+    # would report every commit as not built.
     if: always()
     needs:
       - changes

--- a/.github/workflows/verdict.yml
+++ b/.github/workflows/verdict.yml
@@ -1,0 +1,122 @@
+# @license MIT
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
+
+name: Build Verdict
+
+on:
+  workflow_run:
+    workflows:
+      - Build & Test Extension
+    types:
+      - completed
+
+concurrency:
+  # One commit, one check run. Two build runs on one commit produce two
+  # verdict runs that write the same check run, so they must not overlap.
+  # The answer does not depend on which one wins, because both read the same
+  # commit, so this serialises the writes rather than deciding the verdict.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  # A workflow_run workflow gets a write token even when the run that
+  # triggered it did not, which is what covers a fork pull request. It
+  # therefore runs no code from the head commit and does not check it out.
+  checks: write
+  actions: read
+  contents: read
+
+jobs:
+  verdict:
+    # A manual build has no pull request to gate, so it gets no verdict.
+    if: github.event.workflow_run.event == 'pull_request'
+    name: Report whether the commit is built
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post the verdict check run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+
+          # The question is about the commit and not about the run that
+          # triggered this workflow. Every build run for this head SHA is
+          # read, so two verdict runs on one commit reach the same answer and
+          # the order they finish in stops mattering. That is what replaces
+          # the wait loop that used to mirror a sibling verdict.
+          #
+          # `github.event.workflow_run.conclusion` is reported empty in
+          # practice, so nothing here reads it.
+          runs=$(gh api --paginate \
+            "repos/${GH_REPO}/actions/workflows/build.yml/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" \
+            --jq '.workflow_runs[].id')
+
+          built=false
+          seen=false
+          while IFS= read -r run_id; do
+            if [[ -z "${run_id}" ]]; then
+              continue
+            fi
+            seen=true
+            # The summary job carries no `name` key, so its API name is its
+            # job id. It already knows whether the matrix passed, and whether
+            # a pull request that changed no build input had anything to run.
+            outcome=$(gh api "repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name == "summary") | .conclusion] | first // empty')
+            if [[ "${outcome}" == "success" ]]; then
+              built=true
+              break
+            fi
+          done <<< "${runs}"
+
+          if [[ "${built}" == "true" ]]; then
+            conclusion="success"
+            title="The commit is built"
+            text="A run of the build workflow for this commit has a summary job that passed."
+          elif [[ "${seen}" == "true" ]]; then
+            conclusion="failure"
+            title="The commit is not built"
+            text=$'No run of the build workflow for this commit has a summary job that passed.\n\nA draft pull request builds nothing, so mark it ready for review. Otherwise read the failed run.'
+          else
+            conclusion="failure"
+            title="The commit has no build"
+            text="No run of the build workflow exists for this commit."
+          fi
+
+          # A check run of this name may already exist, from an earlier build
+          # run on the same commit. Updating it keeps one check run per
+          # commit, so a required context cannot resolve to a stale duplicate.
+          check_id=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?check_name=verdict&per_page=100" \
+            --jq '.check_runs | sort_by(.started_at) | last | .id // empty')
+
+          if [[ -n "${check_id}" ]]; then
+            gh api --method PATCH "repos/${GH_REPO}/check-runs/${check_id}" \
+              -f status=completed \
+              -f conclusion="${conclusion}" \
+              -f details_url="${RUN_URL}" \
+              -f "output[title]=${title}" \
+              -f "output[summary]=${text}" > /dev/null
+          else
+            gh api --method POST "repos/${GH_REPO}/check-runs" \
+              -f name=verdict \
+              -f head_sha="${HEAD_SHA}" \
+              -f status=completed \
+              -f conclusion="${conclusion}" \
+              -f details_url="${RUN_URL}" \
+              -f "output[title]=${title}" \
+              -f "output[summary]=${text}" > /dev/null
+          fi
+
+          {
+            echo "# ${title}"
+            echo ""
+            echo "${text}"
+            echo ""
+            echo "Commit: \`${HEAD_SHA}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/verdict.yml
+++ b/.github/workflows/verdict.yml
@@ -30,7 +30,14 @@ permissions:
 jobs:
   verdict:
     # A manual build has no pull request to gate, so it gets no verdict.
-    if: github.event.workflow_run.event == 'pull_request'
+    #
+    # A build run that another push superseded still completes, and a verdict
+    # for the commit it was cancelled on is a job nobody reads. An empty
+    # conclusion is not `cancelled`, so a payload that omits it still runs
+    # this job, and only the definite case is dropped.
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion != 'cancelled'
     name: Report whether the commit is built
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -45,6 +52,24 @@ jobs:
         run: |
           set -euo pipefail
 
+          # A read that never answers must not be what leaves a commit with no
+          # verdict. This is the required check, and no event follows a step
+          # that dies part way through, so the pull request would stay blocked
+          # with nothing left to clear it. Each read is tried three times, and
+          # a read that still fails posts a failure that names itself, which a
+          # re-run of this job clears.
+          api() {
+            for _ in 1 2 3; do
+              if gh api "$@"; then
+                return 0
+              fi
+              sleep 5
+            done
+            return 1
+          }
+
+          read_failed=false
+
           # The question is about the commit and not about the run that
           # triggered this workflow. Every build run for this head SHA is
           # read, so two verdict runs on one commit reach the same answer and
@@ -52,33 +77,50 @@ jobs:
           # the wait loop that used to mirror a sibling verdict.
           #
           # `github.event.workflow_run.conclusion` is reported empty in
-          # practice, so nothing here reads it.
-          runs=$(gh api --paginate \
+          # practice, so the decision never reads it.
+          runs=$(api --paginate \
             "repos/${GH_REPO}/actions/workflows/build.yml/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" \
-            --jq '.workflow_runs[].id')
+            --jq '.workflow_runs[] | [.id, .html_url] | @tsv') || read_failed=true
 
           built=false
           seen=false
-          while IFS= read -r run_id; do
-            if [[ -z "${run_id}" ]]; then
-              continue
-            fi
-            seen=true
-            # The summary job carries no `name` key, so its API name is its
-            # job id. It already knows whether the matrix passed, and whether
-            # a pull request that changed no build input had anything to run.
-            outcome=$(gh api "repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.name == "summary") | .conclusion] | first // empty')
-            if [[ "${outcome}" == "success" ]]; then
-              built=true
-              break
-            fi
-          done <<< "${runs}"
+          built_url="${RUN_URL}"
 
-          if [[ "${built}" == "true" ]]; then
+          if [[ "${read_failed}" == "false" ]]; then
+            while IFS=$'\t' read -r run_id run_url; do
+              if [[ -z "${run_id}" ]]; then
+                continue
+              fi
+              seen=true
+              # The summary job carries no `name` key, so its API name is its
+              # job id. It already knows whether the matrix passed, and
+              # whether a pull request that changed no build input had
+              # anything to run.
+              outcome=$(api "repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
+                --jq '[.jobs[] | select(.name == "summary") | .conclusion] | first // empty') \
+                || { read_failed=true; break; }
+              if [[ "${outcome}" == "success" ]]; then
+                built=true
+                # The link points at the run that passed, and not at the run
+                # that triggered this one. A verdict fired by a draft run can
+                # read the answer of the ready run, and linking its own run
+                # would show a red run behind a green check.
+                built_url="${run_url}"
+                break
+              fi
+            done <<< "${runs}"
+          fi
+
+          details="${RUN_URL}"
+          if [[ "${read_failed}" == "true" ]]; then
+            conclusion="failure"
+            title="The build runs could not be read"
+            text=$'The GitHub API did not answer, so this check cannot say whether the commit is built.\n\nRe-run this job to try again.'
+          elif [[ "${built}" == "true" ]]; then
             conclusion="success"
             title="The commit is built"
             text="A run of the build workflow for this commit has a summary job that passed."
+            details="${built_url}"
           elif [[ "${seen}" == "true" ]]; then
             conclusion="failure"
             title="The commit is not built"
@@ -92,23 +134,27 @@ jobs:
           # A check run of this name may already exist, from an earlier build
           # run on the same commit. Updating it keeps one check run per
           # commit, so a required context cannot resolve to a stale duplicate.
-          check_id=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?check_name=verdict&per_page=100" \
-            --jq '.check_runs | sort_by(.started_at) | last | .id // empty')
+          # A lookup that fails creates a second check run, which is worse
+          # than one check run and better than none.
+          check_id=$(api "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?check_name=verdict&per_page=100" \
+            --jq '.check_runs | sort_by(.started_at) | last | .id // empty') || check_id=""
 
+          # The write is not caught. A write that fails three times leaves no
+          # verdict, and this job must go red and say so.
           if [[ -n "${check_id}" ]]; then
-            gh api --method PATCH "repos/${GH_REPO}/check-runs/${check_id}" \
+            api --method PATCH "repos/${GH_REPO}/check-runs/${check_id}" \
               -f status=completed \
               -f conclusion="${conclusion}" \
-              -f details_url="${RUN_URL}" \
+              -f details_url="${details}" \
               -f "output[title]=${title}" \
               -f "output[summary]=${text}" > /dev/null
           else
-            gh api --method POST "repos/${GH_REPO}/check-runs" \
+            api --method POST "repos/${GH_REPO}/check-runs" \
               -f name=verdict \
               -f head_sha="${HEAD_SHA}" \
               -f status=completed \
               -f conclusion="${conclusion}" \
-              -f details_url="${RUN_URL}" \
+              -f details_url="${details}" \
               -f "output[title]=${title}" \
               -f "output[summary]=${text}" > /dev/null
           fi

--- a/.github/workflows/verdict.yml
+++ b/.github/workflows/verdict.yml
@@ -58,9 +58,17 @@ jobs:
           # with nothing left to clear it. Each read is tried three times, and
           # a read that still fails posts a failure that names itself, which a
           # re-run of this job clears.
+          # Each attempt is buffered, and only the one that succeeded is
+          # printed. A paginated read streams a page at a time, so an attempt
+          # that failed on the second page has already written the first one.
+          # Printing straight to the caller would leave those lines in front
+          # of the full retry, and a doubled `success` fails the comparison
+          # below, which posts a red verdict on a commit that passed.
           api() {
+            local out
             for _ in 1 2 3; do
-              if gh api "$@"; then
+              if out=$(gh api "$@"); then
+                printf '%s\n' "${out}"
                 return 0
               fi
               sleep 5
@@ -120,6 +128,9 @@ jobs:
             conclusion="failure"
             title="The build runs could not be read"
             text=$'The GitHub API did not answer, so this check cannot say whether the commit is built.\n\nRe-run this job to try again.'
+            # The link is this run and not the build run, because re-running
+            # the build run does not refresh the verdict.
+            details="${GITHUB_SERVER_URL}/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}"
           elif [[ "${built}" == "true" ]]; then
             conclusion="success"
             title="The commit is built"

--- a/.github/workflows/verdict.yml
+++ b/.github/workflows/verdict.yml
@@ -73,8 +73,10 @@ jobs:
           # The question is about the commit and not about the run that
           # triggered this workflow. Every build run for this head SHA is
           # read, so two verdict runs on one commit reach the same answer and
-          # the order they finish in stops mattering. That is what replaces
-          # the wait loop that used to mirror a sibling verdict.
+          # the order they finish in stops mattering. Once the ruleset
+          # requires this check, that supersedes the wait loop in the summary
+          # job of `build.yml`, which mirrors a sibling verdict for the same
+          # reason. Both run until the ruleset moves.
           #
           # `github.event.workflow_run.conclusion` is reported empty in
           # practice, so the decision never reads it.
@@ -95,8 +97,10 @@ jobs:
               # The summary job carries no `name` key, so its API name is its
               # job id. It already knows whether the matrix passed, and
               # whether a pull request that changed no build input had
-              # anything to run.
-              outcome=$(api "repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
+              # anything to run. `build.yml` carries a note that this literal
+              # is a contract, because a `name` key added there would report
+              # every commit as not built.
+              outcome=$(api --paginate "repos/${GH_REPO}/actions/runs/${run_id}/jobs?per_page=100" \
                 --jq '[.jobs[] | select(.name == "summary") | .conclusion] | first // empty') \
                 || { read_failed=true; break; }
               if [[ "${outcome}" == "success" ]]; then


### PR DESCRIPTION
A draft pull request makes the build workflow fail, and that sends a failure notification for every push to a draft.
The failure is deliberate, because the `summary` job is both the conclusion of a workflow run and the single required status check.
A draft has nothing built, so the check cannot be green, and the only way for a job to say that is to fail.

This adds `verdict.yml`, which gives the merge gate its own carrier.
It triggers on `workflow_run` for the build workflow and posts a check run named `verdict` on the head commit.
The check answers one question about the commit rather than about a run:

> Does any run of `build.yml` for this head SHA have a `summary` job that concluded `success`?

Three things follow from asking about the commit.

- Two build runs on one commit produce two verdict runs that compute the same answer and write the same check run, so which one GitHub resolves last stops mattering.
  That is the failure recorded on #439, and it needs no ordering logic here.
- A commit with no passing build is red, so a commit cannot reach a mergeable state on the strength of a run that never built it.
  That is the failure recorded on #410.
- A check run conclusion sends no notification, unlike a run conclusion, so the gate can be red and quiet.

`workflow_run` runs in the base repository with a write-capable token, which is what covers a fork pull request.
The job does no checkout and runs no code from the head commit.
It makes API reads and one check-run write.

Every read retries three times and buffers each attempt, so a paginated read that dies part way through cannot leave half a page in front of the retry.
A read that never answers still posts a failure that names itself, which a re-run clears.
A write that never answers fails the job, because a missing verdict must be visible.

The only change to `build.yml` is a comment.
`verdict.yml` selects the job whose API name is the literal `summary`, and that name is the job id because the job has no `name` key.
The comment records that as a contract, since a `name` key added there would report every commit as not built.

The check is advisory for now.
The ruleset still requires `summary`, so a wrong `verdict` blocks nothing.
Once this is on `main` and has agreed with `summary` on live traffic, the ruleset moves to `verdict` and a second pull request stops the build workflow failing on a draft.
A `workflow_run` workflow only triggers from the default branch, so it cannot be exercised by this pull request.

Verified locally: `actionlint` is clean, `build.yml` keeps the same 24 pre-existing findings and gains none, and the decision rule was run against live API data.
Commit `c80e0541` carries both a run whose `summary` failed and a run whose `summary` passed, and the rule reports it as built in either listing order, linking the run that passed.
A commit with no build run reports as not built, and an unreadable API reports that it could not read rather than posting nothing.

This pull request is a draft, so the current build workflow fails its `summary` job by design.
That red is the behaviour the follow-up removes.
