### PR TITLE
ci: package the extension once and quiet the summary script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
-          name: quarto-wizard-${{ github.sha }}-${{ matrix.os }}-${{ matrix.node-version }}
+          name: quarto-wizard-${{ github.sha }}
           path: quarto-wizard.vsix
           retention-days: 10
 
@@ -331,6 +331,22 @@ jobs:
           mkdir -p job-summaries
 
           lua_summary="job-summaries/job-summary-lua/job-summary.txt"
+          mapfile -t summary_files < <(find job-summaries -type f -name "job-summary.txt")
+          successful_cells=0
+
+          # The verdict comes from the job results, which are reported whatever
+          # a job managed to upload. A matrix cell killed by its timeout leaves
+          # no summary file, so counting files would call that run a success.
+          # A skipped job is not a failure: this job is the required check, so
+          # a pull request that changes no build input has nothing to run and
+          # must still report a verdict.
+          failed_names=""
+          for job in "changes:${{ needs.changes.result }}" "build:${{ needs.build.result }}" "lua:${{ needs.lua.result }}"; do
+            case "${job#*:}" in
+              "success" | "skipped") ;;
+              *) failed_names="${failed_names} ${job}" ;;
+            esac
+          done
 
           {
             echo "# 🚀 Quarto Wizard Build & Test Results"
@@ -352,13 +368,13 @@ jobs:
             # The table reports the cells that uploaded a summary. A cell killed by
             # its timeout never reaches its upload step, so the table can be short.
             # The verdict below therefore comes from the job results, not from here.
-            find job-summaries -type f -name "job-summary.txt" 2>/dev/null | while read -r summary_file; do
+            for summary_file in "${summary_files[@]}"; do
               os=$(grep "OS:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
               node=$(grep "Node:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
               status=$(grep "Status:" "${summary_file}" | cut -d' ' -f2- || echo "unknown")
               timestamp=$(grep "Timestamp:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
               case "${status}" in
-                "success") status_emoji="✅" ;;
+                "success") status_emoji="✅" ; successful_cells=$((successful_cells + 1)) ;;
                 "failure") status_emoji="❌" ;;
                 "cancelled") status_emoji="🟡" ;;
                 *) status_emoji="⚠️" ;;
@@ -374,33 +390,13 @@ jobs:
             echo "## 📈 Summary Statistics"
             echo ""
 
-            # The table loop runs in a subshell, so its counters are lost. Recount
-            # the reported cells here. These describe the table, not the verdict.
-            reported_cells=$(find job-summaries -type f -name "job-summary.txt" 2>/dev/null | wc -l)
-            successful_cells=$(find job-summaries -type f -name "job-summary.txt" -exec grep -l "Status: success" {} \; 2>/dev/null | wc -l)
-
-            echo "- **Reported Cells**: ${reported_cells// /}"
-            echo "- **Successful**: ${successful_cells// /} ✅"
+            # These describe the table, not the verdict.
+            echo "- **Reported Cells**: ${#summary_files[@]}"
+            echo "- **Successful**: ${successful_cells} ✅"
             echo "- **Build Matrix**: ${{ needs.build.result }}"
             echo "- **Lua reference validator**: ${{ needs.lua.result }}"
             echo ""
-          } >> "${GITHUB_STEP_SUMMARY}"
 
-          # The verdict comes from the job results, which are reported whatever
-          # a job managed to upload. A matrix cell killed by its timeout leaves
-          # no summary file, so counting files would call that run a success.
-          # A skipped job is not a failure: this job is the required check, so
-          # a pull request that changes no build input has nothing to run and
-          # must still report a verdict.
-          failed_names=""
-          for job in "changes:${{ needs.changes.result }}" "build:${{ needs.build.result }}" "lua:${{ needs.lua.result }}"; do
-            case "${job#*:}" in
-              "success" | "skipped") ;;
-              *) failed_names="${failed_names} ${job}" ;;
-            esac
-          done
-
-          {
             if [[ -z "${failed_names}" ]]; then
               echo "## 🎉 Overall Result: SUCCESS"
               if [[ "${{ needs.changes.outputs.code }}" == "true" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,16 +192,16 @@ jobs:
         shell: bash
         run: npm test
 
-      - name: Install Visual Studio Code Extension Manager
-        shell: bash
-        run: npm install -g @vscode/vsce
-
+      # The package holds no native dependency and no `--target`, so one
+      # operating system produces the artefact that all three would.
       - name: Build extension
         id: build-extension
+        if: runner.os == 'Linux'
         shell: bash
-        run: vsce package --pre-release --out quarto-wizard.vsix
+        run: npx vsce package --pre-release --out quarto-wizard.vsix
 
       - name: Upload VSIX as workflow artifact
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
           name: quarto-wizard-${{ github.sha }}-${{ matrix.os }}-${{ matrix.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,9 +337,8 @@ jobs:
           # The verdict comes from the job results, which are reported whatever
           # a job managed to upload. A matrix cell killed by its timeout leaves
           # no summary file, so counting files would call that run a success.
-          # A skipped job is not a failure: this job is the required check, so
-          # a pull request that changes no build input has nothing to run and
-          # must still report a verdict.
+          # A skipped job is not a failure: a pull request that changes no
+          # build input has nothing to run and must still report a verdict.
           failed_names=""
           for job in "changes:${{ needs.changes.result }}" "build:${{ needs.build.result }}" "lua:${{ needs.lua.result }}"; do
             case "${job#*:}" in

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,59 +330,61 @@ jobs:
           # which is the case this job exists to report on.
           mkdir -p job-summaries
 
-          echo "# 🚀 Quarto Wizard Build & Test Results" >> ${GITHUB_STEP_SUMMARY}
-          echo "" >> ${GITHUB_STEP_SUMMARY}
-
-          # Add Pull Request link if triggered by PR event
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "**🔗 Pull Request**: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) - ${PR_TITLE}" >> ${GITHUB_STEP_SUMMARY}
-            echo "" >> ${GITHUB_STEP_SUMMARY}
-          fi
-
-          echo "## 📊 Build Matrix Results" >> ${GITHUB_STEP_SUMMARY}
-          echo "" >> ${GITHUB_STEP_SUMMARY}
-
-          # Create table header
-          echo "| Operating System | Node.js Version | Status | Timestamp |" >> ${GITHUB_STEP_SUMMARY}
-          echo "|------------------|-----------------|--------|-----------|" >> ${GITHUB_STEP_SUMMARY}
-
           lua_summary="job-summaries/job-summary-lua/job-summary.txt"
 
-          # The table reports the cells that uploaded a summary. A cell killed by
-          # its timeout never reaches its upload step, so the table can be short.
-          # The verdict below therefore comes from the job results, not from here.
-          find job-summaries -type f -name "job-summary.txt" 2>/dev/null | while read summary_file; do
-            os=$(grep "OS:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
-            node=$(grep "Node:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
-            status=$(grep "Status:" "${summary_file}" | cut -d' ' -f2- || echo "unknown")
-            timestamp=$(grep "Timestamp:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
-            case "${status}" in
-              "success") status_emoji="✅" ;;
-              "failure") status_emoji="❌" ;;
-              "cancelled") status_emoji="🟡" ;;
-              *) status_emoji="⚠️" ;;
-            esac
-            echo "| ${os} | ${node} | ${status_emoji} ${status} | ${timestamp} |" >> ${GITHUB_STEP_SUMMARY}
-          done
+          {
+            echo "# 🚀 Quarto Wizard Build & Test Results"
+            echo ""
 
-          if [[ ! -f "${lua_summary}" ]]; then
-            echo "| Lua reference validator | n/a | ⚠️ ${{ needs.lua.result }} (no summary uploaded) | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |" >> "${GITHUB_STEP_SUMMARY}"
-          fi
+            # Add Pull Request link if triggered by PR event
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "**🔗 Pull Request**: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }}) - ${PR_TITLE}"
+              echo ""
+            fi
 
-          echo "" >> ${GITHUB_STEP_SUMMARY}
-          echo "## 📈 Summary Statistics" >> ${GITHUB_STEP_SUMMARY}
-          echo "" >> ${GITHUB_STEP_SUMMARY}
+            echo "## 📊 Build Matrix Results"
+            echo ""
 
-          # The table loop runs in a subshell, so its counters are lost. Recount
-          # the reported cells here. These describe the table, not the verdict.
-          reported_cells=$(find job-summaries -type f -name "job-summary.txt" 2>/dev/null | wc -l)
-          successful_cells=$(find job-summaries -type f -name "job-summary.txt" -exec grep -l "Status: success" {} \; 2>/dev/null | wc -l)
+            # Create table header
+            echo "| Operating System | Node.js Version | Status | Timestamp |"
+            echo "|------------------|-----------------|--------|-----------|"
 
-          echo "- **Reported Cells**: ${reported_cells// /}" >> ${GITHUB_STEP_SUMMARY}
-          echo "- **Successful**: ${successful_cells// /} ✅" >> ${GITHUB_STEP_SUMMARY}
-          echo "- **Build Matrix**: ${{ needs.build.result }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "- **Lua reference validator**: ${{ needs.lua.result }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "" >> ${GITHUB_STEP_SUMMARY}
+            # The table reports the cells that uploaded a summary. A cell killed by
+            # its timeout never reaches its upload step, so the table can be short.
+            # The verdict below therefore comes from the job results, not from here.
+            find job-summaries -type f -name "job-summary.txt" 2>/dev/null | while read -r summary_file; do
+              os=$(grep "OS:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
+              node=$(grep "Node:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
+              status=$(grep "Status:" "${summary_file}" | cut -d' ' -f2- || echo "unknown")
+              timestamp=$(grep "Timestamp:" "${summary_file}" | cut -d' ' -f2- || echo "Unknown")
+              case "${status}" in
+                "success") status_emoji="✅" ;;
+                "failure") status_emoji="❌" ;;
+                "cancelled") status_emoji="🟡" ;;
+                *) status_emoji="⚠️" ;;
+              esac
+              echo "| ${os} | ${node} | ${status_emoji} ${status} | ${timestamp} |"
+            done
+
+            if [[ ! -f "${lua_summary}" ]]; then
+              echo "| Lua reference validator | n/a | ⚠️ ${{ needs.lua.result }} (no summary uploaded) | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |"
+            fi
+
+            echo ""
+            echo "## 📈 Summary Statistics"
+            echo ""
+
+            # The table loop runs in a subshell, so its counters are lost. Recount
+            # the reported cells here. These describe the table, not the verdict.
+            reported_cells=$(find job-summaries -type f -name "job-summary.txt" 2>/dev/null | wc -l)
+            successful_cells=$(find job-summaries -type f -name "job-summary.txt" -exec grep -l "Status: success" {} \; 2>/dev/null | wc -l)
+
+            echo "- **Reported Cells**: ${reported_cells// /}"
+            echo "- **Successful**: ${successful_cells// /} ✅"
+            echo "- **Build Matrix**: ${{ needs.build.result }}"
+            echo "- **Lua reference validator**: ${{ needs.lua.result }}"
+            echo ""
+          } >> "${GITHUB_STEP_SUMMARY}"
 
           # The verdict comes from the job results, which are reported whatever
           # a job managed to upload. A matrix cell killed by its timeout leaves
@@ -398,17 +400,19 @@ jobs:
             esac
           done
 
-          if [[ -z "${failed_names}" ]]; then
-            echo "## 🎉 Overall Result: SUCCESS" >> ${GITHUB_STEP_SUMMARY}
-            if [[ "${{ needs.changes.outputs.code }}" == "true" ]]; then
-              echo "Every job completed successfully." >> "${GITHUB_STEP_SUMMARY}"
+          {
+            if [[ -z "${failed_names}" ]]; then
+              echo "## 🎉 Overall Result: SUCCESS"
+              if [[ "${{ needs.changes.outputs.code }}" == "true" ]]; then
+                echo "Every job completed successfully."
+              else
+                echo "This pull request changes no build input, so the build matrix and the Lua job did not run."
+              fi
             else
-              echo "This pull request changes no build input, so the build matrix and the Lua job did not run." >> "${GITHUB_STEP_SUMMARY}"
+              echo "## ⚠️ Overall Result: FAILURE"
+              echo "Not successful:${failed_names}. Check the individual job logs for details."
             fi
-          else
-            echo "## ⚠️ Overall Result: FAILURE" >> ${GITHUB_STEP_SUMMARY}
-            echo "Not successful:${failed_names}. Check the individual job logs for details." >> ${GITHUB_STEP_SUMMARY}
-          fi
+          } >> "${GITHUB_STEP_SUMMARY}"
 
           # The job runs on every outcome, so it has to carry the verdict it
           # prints. Without this it reports success while the table says failure.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         id: build-extension
         if: runner.os == 'Linux'
         shell: bash
-        run: npx vsce package --pre-release --out quarto-wizard.vsix
+        run: npx @vscode/vsce package --pre-release --out quarto-wizard.vsix
 
       - name: Upload VSIX as workflow artifact
         if: runner.os == 'Linux'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build dev VSIX
         shell: bash
-        run: npx vsce package --pre-release --out docs/quarto-wizard-dev.vsix
+        run: npx @vscode/vsce package --pre-release --out docs/quarto-wizard-dev.vsix
 
       - name: Render dev site
         shell: bash


### PR DESCRIPTION
The build matrix packaged the extension on all three operating systems. The VSIX holds no native dependency and sets no `--target`, so two of the three artefacts were copies. Packaging now happens on Linux alone, which drops about 14 of the 56 billed minutes of each run. The artefact name loses the operating system and the Node.js version, because one cell produces it and both were constant.

`@vscode/vsce` is already a devDependency that `npm ci` installs, so the global install was a second copy. The call names the package, `npx @vscode/vsce`, because a bare `npx vsce` falls back to the deprecated `vsce` package on npm when the local binary is absent. `deploy.yml` carried the same bare call and is changed with it.

`actionlint` reported 24 `shellcheck` findings in the consolidated summary step. The step now writes through one grouped redirect, reads with `read -r`, and reads the job summary files once with `mapfile` instead of walking the directory three times. Counting inside the table loop retires the comment that explained why the counters were lost.

Verified locally: `actionlint` reports nothing on either workflow, `prettier --check` passes, and the rewritten summary script produces byte-identical output and exit codes against the version on `main` across five cases, including an empty artefact directory and an attacker-shaped pull request title.
