### PR TITLE
ci: cut the repeated build work and make the gates able to fail

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,10 @@
+# Prettier checks for LF, so a checkout has to give LF on every platform. A
+# Windows checkout converts to CRLF without this, and `format:check` then fails
+# on every file.
+* text=auto eol=lf
+
 # The Typst preview fixtures are recorded input and recorded output, and one of
 # them is written with CRLF on purpose. Normalising line endings on checkout or
-# on commit would leave that fixture passing while covering nothing.
+# on commit would leave that fixture passing while covering nothing. This rule
+# comes after the one above, because the last matching pattern wins.
 src/test/fixtures/typstPreview/** -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Lint schema package
         shell: bash
         working-directory: packages/schema
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Test schema package
         shell: bash
@@ -134,7 +134,7 @@ jobs:
       - name: Lint snippets package
         shell: bash
         working-directory: packages/snippets
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Test snippets package
         shell: bash
@@ -144,7 +144,7 @@ jobs:
       - name: Lint core package
         shell: bash
         working-directory: packages/core
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Test core package
         shell: bash
@@ -163,7 +163,7 @@ jobs:
 
       - name: Run linter
         shell: bash
-        run: npm run lint
+        run: npm run lint:check
 
       - name: Compile TypeScript
         shell: bash
@@ -203,10 +203,8 @@ jobs:
         if: always()
         shell: bash
         run: |
-          # `job.status` is the status of this job so far, which this step
-          # reads because it runs with `if: always()`. The step used to name
-          # every step of the job instead, so a step that nobody added to that
-          # list reported success when it failed.
+          # `job.status` holds the status of this job so far, which this step
+          # can read because it runs with `if: always()`.
           {
             echo "OS: ${{ matrix.os }}"
             echo "Node: ${{ matrix.node-version }}"
@@ -238,7 +236,6 @@ jobs:
           version: pre-release
 
       - name: Test Lua reference validator
-        id: test-lua
         shell: bash
         working-directory: packages/schema
         run: npm run test:lua
@@ -250,7 +247,7 @@ jobs:
           {
             echo "OS: ubuntu-latest (Lua)"
             echo "Node: n/a"
-            echo "Status: ${{ steps.test-lua.outcome }}"
+            echo "Status: ${{ job.status }}"
             echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
           } > job-summary.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,37 +122,31 @@ jobs:
         run: npm ci
 
       - name: Lint schema package
-        id: lint-schema
         shell: bash
         working-directory: packages/schema
         run: npm run lint
 
       - name: Test schema package
-        id: test-schema
         shell: bash
         working-directory: packages/schema
         run: npm test
 
       - name: Lint snippets package
-        id: lint-snippets
         shell: bash
         working-directory: packages/snippets
         run: npm run lint
 
       - name: Test snippets package
-        id: test-snippets
         shell: bash
         working-directory: packages/snippets
         run: npm test
 
       - name: Lint core package
-        id: lint-core
         shell: bash
         working-directory: packages/core
         run: npm run lint
 
       - name: Test core package
-        id: test-core
         shell: bash
         working-directory: packages/core
         run: npm test
@@ -160,29 +154,24 @@ jobs:
       # This runs before the build, because `npm run webpack` begins with
       # `npm run format`, which rewrites the files this step reads.
       - name: Check formatting
-        id: format
         shell: bash
         run: npm run format:check
 
       - name: Compile extension
-        id: webpack
         shell: bash
         run: npm run webpack
 
       - name: Run linter
-        id: lint
         shell: bash
         run: npm run lint
 
       - name: Compile TypeScript
-        id: test-compile
         shell: bash
         run: npm run test-compile
 
       # `npx vscode-test` and not `npm test`, which would run the `pretest`
       # script and repeat the compile and the lint of the steps above.
       - name: Run tests (Ubuntu)
-        id: test-ubuntu
         if: runner.os == 'Linux'
         shell: bash
         run: |
@@ -191,7 +180,6 @@ jobs:
           npx vscode-test
 
       - name: Run tests (Windows/macOS)
-        id: test-other
         if: runner.os != 'Linux'
         shell: bash
         run: npx vscode-test
@@ -199,7 +187,6 @@ jobs:
       # The package holds no native dependency and no `--target`, so one
       # operating system produces the artefact that all three would.
       - name: Build extension
-        id: build-extension
         if: runner.os == 'Linux'
         shell: bash
         run: npx @vscode/vsce package --pre-release --out quarto-wizard.vsix
@@ -216,26 +203,16 @@ jobs:
         if: always()
         shell: bash
         run: |
-          # Create a summary file for this specific job
-          echo "OS: ${{ matrix.os }}" > job-summary.txt
-          echo "Node: ${{ matrix.node-version }}" >> job-summary.txt
-
-          # Determine test step outcome based on OS
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            test_outcome="${{ steps.test-ubuntu.outcome }}"
-          else
-            test_outcome="${{ steps.test-other.outcome }}"
-          fi
-
-          # Use steps context to determine overall job status
-          if [[ "${{ steps.lint-schema.outcome }}" == "failure" || "${{ steps.test-schema.outcome }}" == "failure" || "${{ steps.lint-snippets.outcome }}" == "failure" || "${{ steps.test-snippets.outcome }}" == "failure" || "${{ steps.lint-core.outcome }}" == "failure" || "${{ steps.test-core.outcome }}" == "failure" || "${{ steps.webpack.outcome }}" == "failure" || "${{ steps.lint.outcome }}" == "failure" || "${{ steps.format.outcome }}" == "failure" || "${{ steps.test-compile.outcome }}" == "failure" || "$test_outcome" == "failure" || "${{ steps.build-extension.outcome }}" == "failure" ]]; then
-            echo "Status: failure" >> job-summary.txt
-          elif [[ "${{ steps.lint-schema.outcome }}" == "cancelled" || "${{ steps.test-schema.outcome }}" == "cancelled" || "${{ steps.lint-snippets.outcome }}" == "cancelled" || "${{ steps.test-snippets.outcome }}" == "cancelled" || "${{ steps.lint-core.outcome }}" == "cancelled" || "${{ steps.test-core.outcome }}" == "cancelled" || "${{ steps.webpack.outcome }}" == "cancelled" || "${{ steps.lint.outcome }}" == "cancelled" || "${{ steps.format.outcome }}" == "cancelled" || "${{ steps.test-compile.outcome }}" == "cancelled" || "$test_outcome" == "cancelled" || "${{ steps.build-extension.outcome }}" == "cancelled" ]]; then
-            echo "Status: cancelled" >> job-summary.txt
-          else
-            echo "Status: success" >> job-summary.txt
-          fi
-          echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> job-summary.txt
+          # `job.status` is the status of this job so far, which this step
+          # reads because it runs with `if: always()`. The step used to name
+          # every step of the job instead, so a step that nobody added to that
+          # list reported success when it failed.
+          {
+            echo "OS: ${{ matrix.os }}"
+            echo "Node: ${{ matrix.node-version }}"
+            echo "Status: ${{ job.status }}"
+            echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+          } > job-summary.txt
 
       - name: Upload job summary
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           inputs+='|webpack\.config\.js$'                 # webpack
           inputs+='|eslint\.config\.mjs$'                 # lint
           inputs+='|\.prettierrc\.json$|\.prettierignore$' # format:check
-          inputs+='|\.vscode-test\.mjs$'                  # npm test
+          inputs+='|\.vscode-test\.mjs$'                  # vscode-test
           inputs+='|\.vscodeignore$'                      # vsce package
           inputs+='|\.github/workflows/build\.yml$)'      # this workflow
 
@@ -157,6 +157,13 @@ jobs:
         working-directory: packages/core
         run: npm test
 
+      # This runs before the build, because `npm run webpack` begins with
+      # `npm run format`, which rewrites the files this step reads.
+      - name: Check formatting
+        id: format
+        shell: bash
+        run: npm run format:check
+
       - name: Compile extension
         id: webpack
         shell: bash
@@ -167,16 +174,13 @@ jobs:
         shell: bash
         run: npm run lint
 
-      - name: Check formatting
-        id: format
-        shell: bash
-        run: npm run format:check
-
       - name: Compile TypeScript
         id: test-compile
         shell: bash
         run: npm run test-compile
 
+      # `npx vscode-test` and not `npm test`, which would run the `pretest`
+      # script and repeat the compile and the lint of the steps above.
       - name: Run tests (Ubuntu)
         id: test-ubuntu
         if: runner.os == 'Linux'
@@ -184,13 +188,13 @@ jobs:
         run: |
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-          npm test
+          npx vscode-test
 
       - name: Run tests (Windows/macOS)
         id: test-other
         if: runner.os != 'Linux'
         shell: bash
-        run: npm test
+        run: npx vscode-test
 
       # The package holds no native dependency and no `--target`, so one
       # operating system produces the artefact that all three would.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,9 +499,9 @@ jobs:
         shell: bash
         run: |
           # This job has no checkout and no `node_modules`, so `npx` downloads
-          # the package. Naming it in full keeps the deprecated `vsce` package
-          # of the same name out of the call.
-          PUBLISHED=$(npx @vscode/vsce show mcanouil.quarto-wizard --json 2>/dev/null \
+          # the package, which is what `--yes` is for. Naming it in full keeps
+          # the deprecated `vsce` package of the same name out of the call.
+          PUBLISHED=$(npx --yes @vscode/vsce show mcanouil.quarto-wizard --json 2>/dev/null \
             | jq -r --arg v "${VERSION}" '.versions[]? | select(.version == $v) | .version' \
             | head -n 1) || PUBLISHED=""
           if [ -n "${PUBLISHED}" ]; then
@@ -513,7 +513,7 @@ jobs:
           if [ "${TYPE}" = "pre-release" ]; then
             PRERELEASE_FLAG="--pre-release"
           fi
-          npx @vscode/vsce publish ${PRERELEASE_FLAG} \
+          npx --yes @vscode/vsce publish ${PRERELEASE_FLAG} \
             --packagePath "quarto-wizard-${VERSION}.vsix" \
             --pat "${VS_MARKETPLACE_TOKEN}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,7 +501,11 @@ jobs:
           # This job has no checkout and no `node_modules`, so `npx` downloads
           # the package, which is what `--yes` is for. Naming it in full keeps
           # the deprecated `vsce` package of the same name out of the call.
-          PUBLISHED=$(npx --yes @vscode/vsce show mcanouil.quarto-wizard --json 2>/dev/null \
+          #
+          # The major version tracks the `@vscode/vsce` devDependency, so this
+          # job and the job that packaged the file run the same major. Move
+          # both together.
+          PUBLISHED=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json 2>/dev/null \
             | jq -r --arg v "${VERSION}" '.versions[]? | select(.version == $v) | .version' \
             | head -n 1) || PUBLISHED=""
           if [ -n "${PUBLISHED}" ]; then
@@ -513,7 +517,7 @@ jobs:
           if [ "${TYPE}" = "pre-release" ]; then
             PRERELEASE_FLAG="--pre-release"
           fi
-          npx --yes @vscode/vsce publish ${PRERELEASE_FLAG} \
+          npx --yes @vscode/vsce@3 publish ${PRERELEASE_FLAG} \
             --packagePath "quarto-wizard-${VERSION}.vsix" \
             --pat "${VS_MARKETPLACE_TOKEN}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,6 @@ jobs:
         shell: bash
         run: npm install
 
-      - name: Install Visual Studio Code Extension Manager
-        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
-        shell: bash
-        run: npm install -g @vscode/vsce
-
       - name: Bump Version / Commit / Push CHANGELOG.md
         id: bump-pull-request
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
@@ -139,7 +134,6 @@ jobs:
             DATE=${DATE}
           fi
 
-          # vsce package ${BUMP_VERSION} -m "${COMMIT}"
           npm version ${BUMP_VERSION} --no-git-tag-version
           npm run sync-metadata
 
@@ -304,10 +298,6 @@ jobs:
         shell: bash
         run: npm install
 
-      - name: Install Visual Studio Code Extension Manager
-        shell: bash
-        run: npm install -g @vscode/vsce
-
       - name: Set version
         id: set-version
         shell: bash
@@ -353,9 +343,9 @@ jobs:
         shell: bash
         run: |
           if [ "${TYPE}" = "pre-release" ]; then
-            vsce package --pre-release
+            npx @vscode/vsce package --pre-release
           else
-            vsce package
+            npx @vscode/vsce package
           fi
 
       - name: Package core library
@@ -497,10 +487,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
 
-      - name: Install Visual Studio Code Extension Manager
-        shell: bash
-        run: npm install -g @vscode/vsce
-
       - name: Download release bundle
         uses: actions/download-artifact@v8
         with:
@@ -512,7 +498,10 @@ jobs:
           TYPE: ${{ github.event.inputs.type }}
         shell: bash
         run: |
-          PUBLISHED=$(vsce show mcanouil.quarto-wizard --json 2>/dev/null \
+          # This job has no checkout and no `node_modules`, so `npx` downloads
+          # the package. Naming it in full keeps the deprecated `vsce` package
+          # of the same name out of the call.
+          PUBLISHED=$(npx @vscode/vsce show mcanouil.quarto-wizard --json 2>/dev/null \
             | jq -r --arg v "${VERSION}" '.versions[]? | select(.version == $v) | .version' \
             | head -n 1) || PUBLISHED=""
           if [ -n "${PUBLISHED}" ]; then
@@ -524,7 +513,7 @@ jobs:
           if [ "${TYPE}" = "pre-release" ]; then
             PRERELEASE_FLAG="--pre-release"
           fi
-          vsce publish ${PRERELEASE_FLAG} \
+          npx @vscode/vsce publish ${PRERELEASE_FLAG} \
             --packagePath "quarto-wizard-${VERSION}.vsix" \
             --pat "${VS_MARKETPLACE_TOKEN}"
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"test:watch": "npm run test-compile && vscode-test",
 		"test:manual": "node ./out/test/runTest.js",
 		"lint": "eslint --fix --cache --format unix \"src/**/*.{ts,tsx}\"",
+		"lint:check": "eslint --cache --format unix \"src/**/*.{ts,tsx}\"",
 		"format": "prettier --write \"src/**/*.{ts,tsx}\" \"packages/*/src/**/*.ts\" \"packages/*/tests/**/*.ts\"",
 		"format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"packages/*/src/**/*.ts\" \"packages/*/tests/**/*.ts\"",
 		"sync-metadata": "node scripts/sync-package-metadata.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
 		"clean": "rm -rf dist",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"lint": "eslint --fix --cache \"src/**/*.ts\""
+		"lint": "eslint --fix --cache \"src/**/*.ts\"",
+		"lint:check": "eslint --cache \"src/**/*.ts\""
 	},
 	"keywords": [
 		"quarto",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -15,7 +15,8 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:lua": "quarto pandoc lua -e \"assert(loadfile('src/validation/schema.lua'))\" && quarto pandoc lua tests/validation/lua/run.lua && quarto pandoc lua tests/validation/lua/conformance.lua ../../docs/_extensions ../../test-fixtures/_extensions",
-		"lint": "eslint --fix --cache \"src/**/*.ts\""
+		"lint": "eslint --fix --cache \"src/**/*.ts\"",
+		"lint:check": "eslint --cache \"src/**/*.ts\""
 	},
 	"keywords": [
 		"quarto",

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -244,7 +244,7 @@ const KEY_ALIASES: Record<string, string> = {
  * {@link KEY_ALIASES}, minus `replace-with` (deprecation-spec scope only).
  * Iterated when checking for camelCase/kebab-case collisions on one descriptor.
  */
-export const FIELD_ALIAS_PAIRS: ReadonlyArray<readonly [string, string]> = Object.entries(KEY_ALIASES)
+export const FIELD_ALIAS_PAIRS: readonly (readonly [string, string])[] = Object.entries(KEY_ALIASES)
 	.filter(([from]) => from !== "replace-with")
 	.map(([from, to]) => [to, from] as const);
 

--- a/packages/snippets/package.json
+++ b/packages/snippets/package.json
@@ -14,7 +14,8 @@
 		"clean": "rm -rf dist",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"lint": "eslint --fix --cache \"src/**/*.ts\""
+		"lint": "eslint --fix --cache \"src/**/*.ts\"",
+		"lint:check": "eslint --cache \"src/**/*.ts\""
 	},
 	"keywords": [
 		"quarto",


### PR DESCRIPTION
Three pieces of waste and one gate that could not fail.

`npm test` fires the `pretest` script, which runs `test-compile` and `lint` again after the steps above them have already run both. Counted per cell, the format pass and the three package builds ran four times on Linux and three times on the other two systems. The test steps call `npx vscode-test`, which is what the `test` script wraps.

The lint scripts pass `--fix`. ESLint repairs what it can and then exits zero, so no lint step could fail for an auto-fixable rule, and the repaired sources were what the job packaged. Each package gains a `lint:check` script beside its `lint` script, the pair that `format` and `format:check` already form, and every lint step calls the checking one. The gate caught one violation that had reached the default branch this way, a `ReadonlyArray<T>` annotation that `@typescript-eslint/array-type` forbids.

`Check formatting` moves above `Compile extension`, because `npm run webpack` begins with `prettier --write` over the files the check reads. This is a behaviour change: a commit whose source is not formatted now fails the build, where before the check could not fail.

Both job summaries read `job.status` instead of naming every step of the job. The old form meant a step that nobody added to the list reported success when it failed, and it needed an id on each step for that purpose alone. The Lua job had the same shape, where a failure of the checkout or of the Quarto setup left the expression empty and the table showed a row with no status.

The release workflow no longer installs `@vscode/vsce` globally three times. The `bump` job never called it at all, so that step and the commented-out call it served are gone. The `package` job resolves the declared copy. `publish-marketplace` has no checkout, so it downloads the tool, with the major pinned to track the devDependency and `--yes` to match the sibling job that publishes to Open VSX.

Verified locally: `actionlint` reports the same findings as `main` on both workflows and no new ones, `prettier --check` passes, every `lint:check` and `format:check` passes, and the suites are green at 1239 extension tests plus the three package suites.

Two things this deliberately leaves alone, both recorded as issues. The four scripts that begin with `npm run format` still rewrite the working tree and repeat each other, and undoing that changes the local loop rather than only CI. The Marketplace publish guard still reads every error from `vsce show` as "not published", which needs a real release to verify.

The formatting check was the one step that failed on Windows once it could fail, on all 214 files. A Windows
checkout converted every file to CRLF, and Prettier checks for LF. `.gitattributes` now checks the sources out
with LF on every platform, and the Typst fixture that records CRLF on purpose keeps its own rule.
