### PR TITLE
fix: stop the publish guards reading an error as an absence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,9 +513,19 @@ jobs:
           # and the job that packaged the file run the same major. Move both
           # together.
           #
-          # The step runs under `-e`, so a registry failure, a network failure
-          # or a failed download ends it here.
-          SHOWN=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json)
+          # The retries match the ones the Open VSX check makes, so a busy or a
+          # restarting registry does not end a release that had nothing wrong
+          # with it. A failure that outlasts them ends the step.
+          for attempt in 1 2 3; do
+            if SHOWN=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json); then
+              break
+            fi
+            if [ "${attempt}" = 3 ]; then
+              echo "::error::vsce show failed three times. The Marketplace could not be read."
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
 
           # Only two answers are understood, and anything else ends the step.
           # A guard that treats what it cannot read as an absence stops being a
@@ -529,9 +539,11 @@ jobs:
               'first(.versions[] | select(.version == $v) | .version) // ""' <<< "${SHOWN}")
           else
             # The whole answer goes to the log. A workflow command stops at the
-            # first newline, so the annotation carries one line of it.
+            # first newline, so the annotation carries one line of it. The
+            # runner reads a workflow command from any line of the log, so the
+            # answer of the registry is indented before it is printed.
             echo "vsce show returned:"
-            echo "${SHOWN}"
+            printf '%s\n' "${SHOWN}" | sed 's/^::/  ::/'
             echo "::error::vsce show returned an answer this check cannot read: $(head -c 200 <<< "${SHOWN}" | tr '\n' ' ')"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,11 +524,15 @@ jobs:
             # `vsce` reports an extension that was never published this way,
             # on standard output and with a zero exit status.
             PUBLISHED=""
-          elif jq -e 'type == "object" and has("versions")' > /dev/null 2>&1 <<< "${SHOWN}"; then
+          elif jq -e 'type == "object" and (.versions | type == "array")' > /dev/null 2>&1 <<< "${SHOWN}"; then
             PUBLISHED=$(jq -r --arg v "${VERSION}" \
               'first(.versions[] | select(.version == $v) | .version) // ""' <<< "${SHOWN}")
           else
-            echo "::error::vsce show returned an answer this check cannot read: ${SHOWN}"
+            # The whole answer goes to the log. A workflow command stops at the
+            # first newline, so the annotation carries one line of it.
+            echo "vsce show returned:"
+            echo "${SHOWN}"
+            echo "::error::vsce show returned an answer this check cannot read: $(head -c 200 <<< "${SHOWN}" | tr '\n' ' ')"
             exit 1
           fi
 
@@ -583,7 +587,7 @@ jobs:
           # otherwise end a release that had nothing wrong with it. Only a
           # persistent answer reaches the branches below, where anything but
           # the two expected codes is a failure and not an absence.
-          STATUS=$(curl -sL --retry 3 --retry-all-errors -o /dev/null -w '%{http_code}' \
+          STATUS=$(curl -sSL --retry 3 --retry-all-errors -o /dev/null -w '%{http_code}' \
             "https://open-vsx.org/api/mcanouil/quarto-wizard/${VERSION}")
           case "${STATUS}" in
             200)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,25 +498,38 @@ jobs:
           TYPE: ${{ github.event.inputs.type }}
         shell: bash
         run: |
+          # An empty version would ask the registry about the extension rather
+          # than about a release of it, and the answer would read as "already
+          # published" below.
+          if [ -z "${VERSION}" ]; then
+            echo "::error::The package job reported no version."
+            exit 1
+          fi
+
           # This job has no checkout and no `node_modules`, so `npx` downloads
           # the package, which is what `--yes` is for. Naming it in full keeps
-          # the deprecated `vsce` package of the same name out of the call.
+          # the deprecated `vsce` package of the same name out of the call. The
+          # major version tracks the `@vscode/vsce` devDependency, so this job
+          # and the job that packaged the file run the same major. Move both
+          # together.
           #
-          # The major version tracks the `@vscode/vsce` devDependency, so this
-          # job and the job that packaged the file run the same major. Move
-          # both together.
           # The step runs under `-e`, so a registry failure, a network failure
-          # or a failed download ends it here. This used to send every one of
-          # them down the branch that publishes.
+          # or a failed download ends it here.
           SHOWN=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json)
 
-          # An extension that was never published is not a failure. `vsce`
-          # exits 0 and prints the literal `undefined`, which is not JSON.
-          if jq -e . > /dev/null 2>&1 <<< "${SHOWN}"; then
-            PUBLISHED=$(jq -r --arg v "${VERSION}" \
-              'first(.versions[]? | select(.version == $v) | .version) // ""' <<< "${SHOWN}")
-          else
+          # Only two answers are understood, and anything else ends the step.
+          # A guard that treats what it cannot read as an absence stops being a
+          # guard on the day the output changes shape, and says nothing.
+          if [ "${SHOWN}" = "undefined" ]; then
+            # `vsce` reports an extension that was never published this way,
+            # on standard output and with a zero exit status.
             PUBLISHED=""
+          elif jq -e 'type == "object" and has("versions")' > /dev/null 2>&1 <<< "${SHOWN}"; then
+            PUBLISHED=$(jq -r --arg v "${VERSION}" \
+              'first(.versions[] | select(.version == $v) | .version) // ""' <<< "${SHOWN}")
+          else
+            echo "::error::vsce show returned an answer this check cannot read: ${SHOWN}"
+            exit 1
           fi
 
           if [ -n "${PUBLISHED}" ]; then
@@ -557,10 +570,20 @@ jobs:
           TYPE: ${{ github.event.inputs.type }}
         shell: bash
         run: |
-          # The step runs under `-e`, so a network failure ends it here. Only
-          # the answer of the registry is read below, where anything other
-          # than the two expected codes is a failure and not an absence.
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+          # An empty version would ask the registry about the extension rather
+          # than about a release of it, and 200 would then read as "already
+          # published" below.
+          if [ -z "${VERSION}" ]; then
+            echo "::error::The package job reported no version."
+            exit 1
+          fi
+
+          # The step runs under `-e`, so a network failure ends it here. The
+          # retries cover a busy or a restarting registry, which would
+          # otherwise end a release that had nothing wrong with it. Only a
+          # persistent answer reaches the branches below, where anything but
+          # the two expected codes is a failure and not an absence.
+          STATUS=$(curl -sL --retry 3 --retry-all-errors -o /dev/null -w '%{http_code}' \
             "https://open-vsx.org/api/mcanouil/quarto-wizard/${VERSION}")
           case "${STATUS}" in
             200)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,9 +513,9 @@ jobs:
           # and the job that packaged the file run the same major. Move both
           # together.
           #
-          # The retries match the ones the Open VSX check makes, so a busy or a
+          # The lookup retries, as the Open VSX check does, so a busy or a
           # restarting registry does not end a release that had nothing wrong
-          # with it. A failure that outlasts them ends the step.
+          # with it. A failure that outlasts the attempts ends the step.
           for attempt in 1 2 3; do
             if SHOWN=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json); then
               break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,9 +505,20 @@ jobs:
           # The major version tracks the `@vscode/vsce` devDependency, so this
           # job and the job that packaged the file run the same major. Move
           # both together.
-          PUBLISHED=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json 2>/dev/null \
-            | jq -r --arg v "${VERSION}" '.versions[]? | select(.version == $v) | .version' \
-            | head -n 1) || PUBLISHED=""
+          # The step runs under `-e`, so a registry failure, a network failure
+          # or a failed download ends it here. This used to send every one of
+          # them down the branch that publishes.
+          SHOWN=$(npx --yes @vscode/vsce@3 show mcanouil.quarto-wizard --json)
+
+          # An extension that was never published is not a failure. `vsce`
+          # exits 0 and prints the literal `undefined`, which is not JSON.
+          if jq -e . > /dev/null 2>&1 <<< "${SHOWN}"; then
+            PUBLISHED=$(jq -r --arg v "${VERSION}" \
+              'first(.versions[]? | select(.version == $v) | .version) // ""' <<< "${SHOWN}")
+          else
+            PUBLISHED=""
+          fi
+
           if [ -n "${PUBLISHED}" ]; then
             echo "::notice::mcanouil.quarto-wizard@${VERSION} already on Marketplace, skipping."
             exit 0
@@ -546,12 +557,22 @@ jobs:
           TYPE: ${{ github.event.inputs.type }}
         shell: bash
         run: |
+          # The step runs under `-e`, so a network failure ends it here. Only
+          # the answer of the registry is read below, where anything other
+          # than the two expected codes is a failure and not an absence.
           STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
             "https://open-vsx.org/api/mcanouil/quarto-wizard/${VERSION}")
-          if [ "${STATUS}" = "200" ]; then
-            echo "::notice::mcanouil/quarto-wizard@${VERSION} already on Open VSX, skipping."
-            exit 0
-          fi
+          case "${STATUS}" in
+            200)
+              echo "::notice::mcanouil/quarto-wizard@${VERSION} already on Open VSX, skipping."
+              exit 0
+              ;;
+            404) ;;
+            *)
+              echo "::error::Open VSX answered ${STATUS} for the version check."
+              exit 1
+              ;;
+          esac
 
           PRERELEASE_FLAG=""
           if [ "${TYPE}" = "pre-release" ]; then


### PR DESCRIPTION
Both publish jobs skip when the version is already on the registry, so a re-run does not try to publish it twice. Each guard turned a failure of the lookup into the answer "not published" and carried on to publish.

The Marketplace guard sent the lookup through `2>/dev/null` and `|| PUBLISHED=""`. A missing extension is not a failure there: `vsce show` exits 0 and prints the literal `undefined`. It is `jq` that fails on that value, and `-o pipefail` carried the failure out of the pipeline onto the same branch as a registry failure. The guard now understands two answers, that `undefined` and an object carrying a `versions` array, and ends the step on anything else. An error document is valid JSON and used to pass as an absence, which is the same defect one level up.

The Open VSX guard compared the status against 200 alone, so a 500, a 503 or a 429 read as an absence. It now treats 404 as the absence and any other answer as a failure.

Both lookups retry, so a busy or a restarting registry does not end a release that had nothing wrong with it. Both stop when the package job reports no version, because an empty version asks each registry about the extension rather than about a release of it, and both then answer as though the version were already published. The answer of the registry is indented before it reaches the log, since the runner reads a workflow command from any line.

Verified by two harnesses that run the shipped blocks under the same `bash -eo pipefail` the workflow uses. Fourteen payloads through the Marketplace decision: the two understood answers proceed, and an error document, a null, an empty string, a reshaped payload, a truncated document and a `versions` key holding null, a string or an object all end the step. Nine cases against the live registries: an existing version skips, an absent version and an absent extension publish, and an empty version, a 500 and an unreachable host each end the step. Under the same unreachable registry the old guard reaches the publish branch and the new one does not, which is the defect reproduced and closed.

What this does not prove is `vsce publish` and `ovsx publish` themselves, which only a release exercises. `dy2f` stays open until a release runs twice and the second run skips.
