### PR TITLE
fix: verify an existing release rather than rewrite it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,7 +423,7 @@ jobs:
         with:
           name: release-bundle
 
-      - name: Create or update GitHub release
+      - name: Create or verify the GitHub release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TYPE: ${{ github.event.inputs.type }}
@@ -439,22 +439,35 @@ jobs:
           )
 
           if gh release view "${VERSION}" >/dev/null 2>&1; then
-            # The tag of an existing release stays where it is. Refreshing it
-            # with assets built somewhere else would leave the tag and the
-            # assets naming different commits, which is what this release is
-            # careful not to do.
+            # The tag of an existing release stays where it is. Assets built
+            # somewhere else would leave the tag and the assets naming
+            # different commits, which is what this release is careful not
+            # to do.
             TAGGED=$(gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" --jq '.object.sha')
             if [ "${TAGGED}" != "${SHA}" ]; then
               echo "::error::Release ${VERSION} is tagged at ${TAGGED}, and this run built ${SHA}. Delete the release and its tag, or run the release from the tagged commit."
               exit 1
             fi
-            echo "::notice::Release ${VERSION} already exists; refreshing assets and notes."
-            FILES=()
+
+            # A published release is immutable, so its assets cannot be
+            # rewritten. The check above already proves that this release was
+            # built from this commit, so there is nothing here to refresh,
+            # only something to confirm. This branch carries a release that
+            # is dispatched a second time, which is how a release recovers
+            # from a publish that failed, so it has to reach the jobs that
+            # publish rather than end here.
+            PRESENT=$(gh release view "${VERSION}" --json assets --jq '.assets[].name')
+            MISSING=""
             for asset in "${ASSETS[@]}"; do
-              FILES+=("${asset%%#*}")
+              name=$(basename "${asset%%#*}")
+              grep -qxF "${name}" <<< "${PRESENT}" || MISSING="${MISSING} ${name}"
             done
-            gh release upload "${VERSION}" "${FILES[@]}" --clobber
-            gh release edit "${VERSION}" --notes-file "${CHANGELOG}"
+            if [ -n "${MISSING}" ]; then
+              echo "::error::Release ${VERSION} is missing:${MISSING}. A published release is immutable, so this run cannot add them. Delete the release and its tag, then run the release again."
+              exit 1
+            fi
+
+            echo "::notice::Release ${VERSION} already exists and carries every asset."
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,7 +438,13 @@ jobs:
             "./schema.lua#Quarto Wizard Schema Validator (lua)"
           )
 
-          if gh release view "${VERSION}" >/dev/null 2>&1; then
+          # One call, which both reports whether the release is there and
+          # lists what it carries. It reads the state of each asset and not
+          # the name alone, because an upload that died part way leaves the
+          # name on the release with a state that is not `uploaded`, and that
+          # is the very failure a second dispatch is here to recover from.
+          if PRESENT=$(gh release view "${VERSION}" --json assets \
+            --jq '.assets[] | select(.state == "uploaded") | .name' 2>/dev/null); then
             # The tag of an existing release stays where it is. Assets built
             # somewhere else would leave the tag and the assets naming
             # different commits, which is what this release is careful not
@@ -456,12 +462,6 @@ jobs:
             # is dispatched a second time, which is how a release recovers
             # from a publish that failed, so it has to reach the jobs that
             # publish rather than end here.
-            # `state` and not the name alone. An upload that died part way
-            # leaves the name on the release with a state that is not
-            # `uploaded`, and that is the very failure a second dispatch is
-            # here to recover from.
-            PRESENT=$(gh release view "${VERSION}" --json assets \
-              --jq '.assets[] | select(.state == "uploaded") | .name')
             MISSING=""
             for asset in "${ASSETS[@]}"; do
               name=$(basename "${asset%%#*}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,14 +456,19 @@ jobs:
             # is dispatched a second time, which is how a release recovers
             # from a publish that failed, so it has to reach the jobs that
             # publish rather than end here.
-            PRESENT=$(gh release view "${VERSION}" --json assets --jq '.assets[].name')
+            # `state` and not the name alone. An upload that died part way
+            # leaves the name on the release with a state that is not
+            # `uploaded`, and that is the very failure a second dispatch is
+            # here to recover from.
+            PRESENT=$(gh release view "${VERSION}" --json assets \
+              --jq '.assets[] | select(.state == "uploaded") | .name')
             MISSING=""
             for asset in "${ASSETS[@]}"; do
               name=$(basename "${asset%%#*}")
               grep -qxF "${name}" <<< "${PRESENT}" || MISSING="${MISSING} ${name}"
             done
             if [ -n "${MISSING}" ]; then
-              echo "::error::Release ${VERSION} is missing:${MISSING}. A published release is immutable, so this run cannot add them. Delete the release and its tag, then run the release again."
+              echo "::error::Release ${VERSION} is missing, or has not finished uploading:${MISSING}. A published release is immutable, so this run cannot replace them. Release the next patch version rather than repairing this one."
               exit 1
             fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,8 +443,23 @@ jobs:
           # the name alone, because an upload that died part way leaves the
           # name on the release with a state that is not `uploaded`, and that
           # is the very failure a second dispatch is here to recover from.
+          #
+          # `release not found` is the one failure that means the release is
+          # absent. Every other failure is a failure to read, and a guard that
+          # takes what it cannot read as an absence stops being a guard. This
+          # one would create a release that is already there.
+          VIEW_ERROR=$(mktemp)
           if PRESENT=$(gh release view "${VERSION}" --json assets \
-            --jq '.assets[] | select(.state == "uploaded") | .name' 2>/dev/null); then
+            --jq '.assets[] | select(.state == "uploaded") | .name' 2>"${VIEW_ERROR}"); then
+            FOUND=true
+          elif grep -qiF 'release not found' "${VIEW_ERROR}"; then
+            FOUND=false
+          else
+            echo "::error::Could not read release ${VERSION}: $(tr '\n' ' ' < "${VIEW_ERROR}")"
+            exit 1
+          fi
+
+          if [ "${FOUND}" = true ]; then
             # The tag of an existing release stays where it is. Assets built
             # somewhere else would leave the tag and the assets naming
             # different commits, which is what this release is careful not
@@ -468,7 +483,7 @@ jobs:
               grep -qxF "${name}" <<< "${PRESENT}" || MISSING="${MISSING} ${name}"
             done
             if [ -n "${MISSING}" ]; then
-              echo "::error::Release ${VERSION} is missing, or has not finished uploading:${MISSING}. A published release is immutable, so this run cannot replace them. Release the next patch version rather than repairing this one."
+              echo "::error::Release ${VERSION} exists, but these assets are missing or have not finished uploading:${MISSING}. A published release is immutable, so this run cannot replace them. Release the next patch version rather than repairing this one."
               exit 1
             fi
 


### PR DESCRIPTION
A release that already exists was refreshed by uploading its assets again with `--clobber`, which deletes each one first. A published release is immutable and refuses that delete, so the step ended there:

```text
HTTP 422: Validation Failed
Cannot delete asset from an immutable release
```

The jobs that publish depend on that job, so they never ran. That branch is the one a second dispatch takes, and a second dispatch is how a release recovers from a publish that failed, so the step that recovers a release could never be reached. Run 34596571184, a second dispatch of 3.6.0, failed exactly there.

The tag check above already proves the release was built from the commit this run built, so there is nothing to refresh. The step now confirms that every expected asset is on the release and succeeds, which lets the publish jobs run. An asset counts only when its state is `uploaded`, because an upload that died part way leaves the name in place with another state, and that is the failure a second dispatch exists to recover from. A missing asset ends the step, since an immutable release cannot be repaired by running the release again.

The probe that asks whether the release exists no longer reads every failure as an absence. A rate limit or an expired token used to send the run to the branch that creates a release, which then failed against the release that was there all along, and neither the tag check nor the asset check ran. `release not found` is the one failure that means absent. Anything else ends the step and reports what it read. This is the same pattern that #451 removed from the two publish guards, inherited from the probe this branch replaces.

The step is renamed, because it no longer updates anything.

Verified against the live 3.6.0 release, read-only, under the same `bash -eo pipefail` the runner uses. The existence probe in three cases: the release present, absent, and unreadable through an invalid token. The existing-release branch in five: the tag matching with every asset uploaded, one asset absent, the tag naming another commit, no assets at all, and an asset that has not finished uploading. In both cases the old form takes the wrong branch under conditions where the new form stops.

What this does not prove is the workflow itself, which needs a release dispatched twice. That is also what unblocks dy2f, whose second dispatch this failure prevented.

One related finding is recorded as a separate issue rather than fixed here. A recovery run builds the artefacts again and publishes those, while the release keeps what the first dispatch uploaded, so the bytes can differ although the source commit does not. Closing that means feeding the publish jobs from the release rather than from the build, which changes how artefacts flow between the jobs.
