### PR TITLE
ci: land the version bump on main without a pull request

### DIFF
--- a/.github/workflows/assets/askpass.sh
+++ b/.github/workflows/assets/askpass.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# @license MIT
+# @copyright 2026 Mickaël Canouil
+# @author Mickaël Canouil
+#
+# Answers the credential prompts of `git` for the release workflow.
+#
+# `git` reads the token from this script and not from the command line,
+# because a command line is readable from `/proc` by every process of the
+# same user. The jobs that push run the lifecycle scripts of every
+# dependency first, and any of those can leave a process behind.
+#
+# The caller exports `GH_TOKEN` and points `GIT_ASKPASS` at this file.
+
+case "$1" in
+Username*) echo "x-access-token" ;;
+*) echo "${GH_TOKEN}" ;;
+esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,11 +208,14 @@ jobs:
         shell: bash
         run: npx @vscode/vsce package --pre-release --out quarto-wizard.vsix
 
+      # `inputs.ref` first. Inside a called workflow the `github` context is
+      # the caller's, so `github.sha` there is the commit the release was
+      # dispatched from and not the commit these files were built from.
       - name: Upload VSIX as workflow artifact
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
-          name: quarto-wizard-${{ github.sha }}
+          name: quarto-wizard-${{ inputs.ref || github.sha }}
           path: quarto-wizard.vsix
           retention-days: 10
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,10 @@ permissions: read-all
 
 jobs:
   changes:
-    if: github.event.pull_request.draft == false
+    # A draft builds nothing. Any other event has no draft flag to read, and
+    # the first half of the condition answers for it, rather than leaving the
+    # decision to `null == false`.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Detect relevant changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -291,7 +294,7 @@ jobs:
     # selects the one whose API name is the literal `summary`. This job has no
     # `name` key, so its API name is this job id. A `name` key added here
     # would report every commit as not built.
-    if: always() && github.event.pull_request.draft == false
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs:
       - changes
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,15 @@ name: Build & Test Extension
 
 on:
   workflow_dispatch:
+  # The release workflow calls this one on the commit it is about to publish.
+  # The caller passes that commit here, because a called workflow otherwise
+  # checks out the commit the caller was dispatched from.
+  workflow_call:
+    inputs:
+      ref:
+        description: The commit to build instead of the one the caller runs on
+        type: string
+        required: false
   pull_request:
     types:
       - opened
@@ -49,7 +58,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # A manual run has no pull request to compare against, so it builds.
+          # A manual run, or a call from the release workflow, has no pull
+          # request to compare against, so it builds.
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
             echo "code=true" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -108,8 +118,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [25.x]
     steps:
+      # `ref` is empty on a pull request and on a manual run, and the action
+      # then checks out the commit of the event, as it does today.
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
@@ -229,6 +243,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Quarto CLI
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ on:
         default: "minor"
 
 jobs:
-  bump-version:
+  bump:
     runs-on: ubuntu-latest
 
+    # `GITHUB_TOKEN` writes nothing here. Every push carries the app token.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     env:
       BRANCH: ci/bump-version
@@ -41,14 +41,13 @@ jobs:
       BUMP_VERSION: ${{ inputs.version }}
 
     outputs:
-      sha: ${{ steps.merge-bump.outputs.sha }}
+      sha: ${{ steps.result.outputs.sha }}
+      bumped: ${{ steps.result.outputs.bumped }}
 
     steps:
-      # The bump pull request targets the branch the release was dispatched
-      # from. `build.yml` runs on pull requests against `main` alone, so a
-      # dispatch from anywhere else opens a pull request that no required check
-      # ever reports on, and the gate below would then time out for a reason it
-      # cannot name.
+      # The bump lands on `main` by a fast-forward push in the package job. A
+      # dispatch from any other branch would push a commit of that branch onto
+      # `main`, or be refused as not a fast-forward, and neither is a release.
       - name: Check the release runs from main
         shell: bash
         run: |
@@ -58,20 +57,25 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Quarto CLI
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: pre-release
-
       - name: Create GitHub App token
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
           client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_KEY }}
+
+      # The checkout keeps this token, so the push below runs as the app. The
+      # app is exempt from the ruleset, which is what lets the bump land on
+      # `main` without a pull request.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Quarto CLI
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: pre-release
 
       - name: Get GitHub App User ID
         id: get-user-id
@@ -101,9 +105,9 @@ jobs:
         shell: bash
         run: |
           if grep -q "Unreleased" CHANGELOG.md; then
-            echo "UNRELEASED_FOUND=true" >> ${GITHUB_OUTPUT}
+            echo "UNRELEASED_FOUND=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "UNRELEASED_FOUND=false" >> ${GITHUB_OUTPUT}
+            echo "UNRELEASED_FOUND=false" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up Node.js
@@ -115,160 +119,75 @@ jobs:
         shell: bash
         run: npm install
 
-      - name: Bump Version / Commit / Push CHANGELOG.md
-        id: bump-pull-request
+      - name: Bump the version and push it to the temporary branch
+        id: bump
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          COMMIT: "ci: bump version for release :rocket:"
           DATE: ${{ github.event.inputs.date }}
         shell: bash
         run: |
-          # `-B` and not `-b`. The checkout above fetches the triggering ref
-          # alone, so this branch is normally absent, but a re-run must not end
-          # here if it is present.
-          git checkout -B "${BRANCH}"
+          set -euo pipefail
           if [ "${DATE}" = "today" ]; then
             DATE=$(date +%Y-%m-%d)
-          else
-            DATE=${DATE}
           fi
 
-          npm version ${BUMP_VERSION} --no-git-tag-version
+          npm version "${BUMP_VERSION}" --no-git-tag-version
           npm run sync-metadata
 
           VERSION=$(jq -r .version package.json)
-          RELEASE_DATE="${VERSION} (${DATE})"
-          sed -i "s/Unreleased/${RELEASE_DATE}/" CHANGELOG.md
+          sed -i "s/Unreleased/${VERSION} (${DATE})/" CHANGELOG.md
           sed -i "s/^version:.*/version: ${VERSION}/" CITATION.cff
           sed -i "s/^date-released:.*/date-released: \"${DATE}\"/" CITATION.cff
-          git add CHANGELOG.md || echo "No changes to add"
-          git add CITATION.cff || echo "No changes to add"
-          git add packages/*/package.json || echo "No changes to add"
-          git add package.json || echo "No changes to add"
-          git add package-lock.json || echo "No changes to add"
 
           npm run docs:build
-          git add docs/ || echo "No changes to add"
 
-          git commit -m "${COMMIT}" || echo "No changes to commit"
-          git push --force origin ${BRANCH} || echo "No changes to push"
+          git add CHANGELOG.md CITATION.cff package.json package-lock.json packages/*/package.json docs/
+          git commit -m "${COMMIT}"
 
-          git status
+          # No pull request. The commit goes to a branch of its own, the
+          # verify job builds it there, and the package job fast-forwards
+          # `main` to it once the matrix has passed. `--force`, because a run
+          # that ended before the cleanup job, or a lost runner, can leave the
+          # branch behind, and this run must not stop on that.
+          git push --force origin "HEAD:refs/heads/${BRANCH}"
+          echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
-          sleep 5
-          # A release that stops at the check gate leaves this branch and its
-          # pull request open. The force push above updates that pull request,
-          # so reuse it. `gh pr create` refuses a second one and would end the
-          # re-run here, before the gate it exists to reach.
-          PR_NUMBER=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
-          if [ -z "${PR_NUMBER}" ]; then
-            PR_URL=$(gh pr create --fill-first --base "${GITHUB_REF_NAME}" --head "${BRANCH}" --label "Type: CI/CD :robot:" | tail -n 1)
-            PR_NUMBER="${PR_URL##*/}"
+      # The commit the rest of the release works on. A release with nothing to
+      # bump takes the commit the dispatch resolved, which is how a release
+      # whose publish failed is dispatched a second time.
+      - name: Report the commit to release
+        id: result
+        env:
+          BUMPED: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND }}
+          BUMP_SHA: ${{ steps.bump.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${BUMPED}" = "true" ]; then
+            echo "sha=${BUMP_SHA}" >> "${GITHUB_OUTPUT}"
+            echo "bumped=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "::notice::Reusing the open version bump pull request ${PR_NUMBER}."
+            echo "sha=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+            echo "bumped=false" >> "${GITHUB_OUTPUT}"
           fi
-          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Failed to open the version bump pull request. Read a pull request number from: ${PR_NUMBER}"
-            exit 1
-          fi
-          echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
-      # The token minted at the top of the job lasts an hour. The bump renders
-      # the documentation, and the gate below then waits for the matrix, so
-      # that hour can run out part way through the wait or before the merge.
-      # Both steps take a token minted here instead.
-      - name: Create GitHub App token for the gate
-        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
-        uses: actions/create-github-app-token@v3
-        id: gate-token
-        with:
-          client-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_KEY }}
-
-      # `gh pr merge --auto` does not hold the pull request here. The token that
-      # opens it can bypass the ruleset, so the automatic merge flag merges at
-      # once instead of queueing behind the required check. The release then
-      # packages a commit that nothing built. This step is the gate instead.
-      - name: Wait for the required checks to pass
-        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
-        timeout-minutes: 30
-        env:
-          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
-          PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
-          APPEARANCE_TIMEOUT_SECONDS: "300"
-          POLL_INTERVAL_SECONDS: "30"
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # `gh pr checks --watch` fails outright when no check has registered
-          # yet, and a pull request seconds old is exactly that state. Wait for
-          # a required context to appear before watching it.
-          deadline=$((SECONDS + APPEARANCE_TIMEOUT_SECONDS))
-          while true; do
-            # `gh pr checks` prints a count and still exits non-zero while the
-            # checks are pending, so read the count and judge it here rather
-            # than let the exit code stand for the answer.
-            count=$(gh pr checks "${PR_NUMBER}" --required --json state --jq 'length' 2>/dev/null || true)
-            count=${count##*$'\n'}
-            if [[ "${count}" =~ ^[1-9][0-9]*$ ]]; then
-              break
-            fi
-            if [ "${SECONDS}" -ge "${deadline}" ]; then
-              # The loop hides every failure, so a bad token looks the same as a
-              # check that has not started. Run once more without the muzzle, so
-              # the log carries the real reason next to the timeout.
-              echo "::error::No required check reported on pull request ${PR_NUMBER} after ${APPEARANCE_TIMEOUT_SECONDS} seconds. The last attempt reported:"
-              gh pr checks "${PR_NUMBER}" --required --json state || true
-              exit 1
-            fi
-            sleep "${POLL_INTERVAL_SECONDS}"
-          done
-
-          gh pr checks "${PR_NUMBER}" --required --watch --fail-fast --interval "${POLL_INTERVAL_SECONDS}"
-
-      - name: Merge the version bump pull request
-        id: merge-bump
-        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
-        env:
-          GH_TOKEN: ${{ steps.gate-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.bump-pull-request.outputs.number }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # The gate above proves that one commit was built. The merge response
-          # names the commit it creates, so take the SHA from the merge itself.
-          # Reading it back afterwards would race the write, which is the class
-          # of gap this whole gate exists to close.
-          # No retry. GitHub can refuse a merge it will accept a moment later,
-          # but it can also drop the response of a merge it performed, and a
-          # second attempt cannot tell those apart. Report and stop.
-          if ! SHA=$(gh api -X PUT "repos/${GH_REPO}/pulls/${PR_NUMBER}/merge" \
-            -f merge_method=squash --jq '.sha'); then
-            echo "::error::The merge of pull request ${PR_NUMBER} was refused. Read the error above, and inspect the default branch before running the release again, because a plain re-run bumps the version a second time."
-            exit 1
-          fi
-          if ! [[ "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Pull request ${PR_NUMBER} merged, but the response named no merge commit. Read: ${SHA}"
-            echo "::error::The merge itself succeeded. Inspect the default branch before running the release again, because a plain re-run bumps the version a second time."
-            exit 1
-          fi
-          echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"
-
-          # The merge is done and recorded. A branch left behind is untidy, not
-          # a reason to strand a release that has already landed its commit.
-          if ! gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${BRANCH}"; then
-            echo "::warning::Merged pull request ${PR_NUMBER}, but could not delete ${BRANCH}."
-          fi
+  # The full matrix and the Lua job, on the exact tree the release publishes.
+  # This is the gate that the bump pull request used to be. A called workflow
+  # runs inside this run, so `verdict.yml` never fires for it.
+  verify:
+    needs: bump
+    permissions: read-all
+    uses: ./.github/workflows/build.yml
+    with:
+      ref: ${{ needs.bump.outputs.sha }}
 
   package:
     runs-on: ubuntu-latest
 
-    needs: bump-version
+    needs: [bump, verify]
 
+    # `GITHUB_TOKEN` writes nothing here. The push to `main` carries the app
+    # token, and the attestation needs the two write scopes below.
     permissions:
       contents: read
       id-token: write
@@ -281,15 +200,36 @@ jobs:
       sha: ${{ steps.set-version.outputs.sha }}
 
     steps:
-      # The commit the gate cleared, not the tip of the default branch. Any
-      # commit landing between the merge and this checkout would otherwise be
-      # the one that gets packaged and published. A release that skipped the
-      # bump has no such commit, and takes the commit the dispatch resolved.
-      # Both are pinned; a branch name here would reopen the same race.
-      - name: Checkout the commit the gate cleared
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+
+      # The commit the matrix built, not the tip of the default branch. Any
+      # commit landing on `main` between the dispatch and this checkout would
+      # otherwise be the one that gets packaged and published.
+      - name: Checkout the commit the matrix built
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.bump-version.outputs.sha || github.sha }}
+          ref: ${{ needs.bump.outputs.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      # A fast-forward, so the commit on `main` is the commit the matrix built
+      # and the `non_fast_forward` rule is never in question. The app is exempt
+      # from the ruleset, which is what lets this push skip the pull request
+      # and the required check. A push that is refused means `main` moved
+      # since the dispatch, and the bump then belongs on the new tip.
+      - name: Land the bump on main
+        if: ${{ needs.bump.outputs.bumped == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git push origin HEAD:refs/heads/main; then
+            echo "::error::main moved since this release was dispatched, so the bump cannot land on it. Dispatch the release again."
+            exit 1
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,11 +105,14 @@ jobs:
           git config --global user.name "${USER_NAME}"
           git config --global user.email "${USER_EMAIL}"
 
-      - name: Check for "unreleased" in CHANGELOG.md
+      # The heading, and not the word. Entries are written as full sentences,
+      # so one of them can carry the word `Unreleased` in its prose, and a
+      # release must not read that as a section to bump.
+      - name: Check for the Unreleased heading in CHANGELOG.md
         id: check_unreleased
         shell: bash
         run: |
-          if grep -q "Unreleased" CHANGELOG.md; then
+          if grep -q "^## Unreleased$" CHANGELOG.md; then
             echo "UNRELEASED_FOUND=true" >> "${GITHUB_OUTPUT}"
           else
             echo "UNRELEASED_FOUND=false" >> "${GITHUB_OUTPUT}"
@@ -156,7 +159,14 @@ jobs:
           npm run sync-metadata
 
           VERSION=$(jq -r .version package.json)
-          sed -i "s/Unreleased/${VERSION} (${DATE})/" CHANGELOG.md
+          # The first heading alone, matched in full. A substitution on the
+          # word rewrites the first match on every line, so an entry whose
+          # prose carries it would be corrupted in the release notes.
+          awk -v heading="## ${VERSION} (${DATE})" '
+            !done && $0 == "## Unreleased" {print heading; done = 1; next}
+            {print}
+          ' CHANGELOG.md > CHANGELOG.md.new
+          mv CHANGELOG.md.new CHANGELOG.md
           sed -i "s/^version:.*/version: ${VERSION}/" CITATION.cff
           sed -i "s/^date-released:.*/date-released: \"${DATE}\"/" CITATION.cff
 
@@ -181,8 +191,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git push --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          # `git` reads the token through `GIT_ASKPASS` and not from the
+          # command line. A command line is readable from `/proc`, and the
+          # steps above have run the lifecycle scripts of every dependency,
+          # any of which can leave a process behind to read it.
+          ASKPASS="${RUNNER_TEMP}/askpass.sh"
+          cat > "${ASKPASS}" <<'ASKPASS_SCRIPT'
+          #!/bin/sh
+          case "$1" in
+            Username*) echo "x-access-token" ;;
+            *) echo "${GH_TOKEN}" ;;
+          esac
+          ASKPASS_SCRIPT
+          chmod 700 "${ASKPASS}"
+          trap 'rm -f "${ASKPASS}"' EXIT
+
+          GIT_ASKPASS="${ASKPASS}" git push --force \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/${BRANCH}"
 
   # The full matrix and the Lua job, on the exact tree the release publishes.
@@ -384,12 +409,39 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if ! git push \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            HEAD:refs/heads/main; then
-            echo "::error::main moved since this release was dispatched, so the bump cannot land on it. Dispatch the release again."
-            exit 1
+          # `git` reads the token through `GIT_ASKPASS` and not from the
+          # command line. A command line is readable from `/proc`, and the
+          # steps above have run the lifecycle scripts of every dependency,
+          # any of which can leave a process behind to read it.
+          ASKPASS="${RUNNER_TEMP}/askpass.sh"
+          cat > "${ASKPASS}" <<'ASKPASS_SCRIPT'
+          #!/bin/sh
+          case "$1" in
+            Username*) echo "x-access-token" ;;
+            *) echo "${GH_TOKEN}" ;;
+          esac
+          ASKPASS_SCRIPT
+          chmod 700 "${ASKPASS}"
+          trap 'rm -f "${ASKPASS}"' EXIT
+
+          # The error names what git reported. A refused fast-forward means
+          # `main` moved, and a re-dispatch is the answer. A revoked token, a
+          # ruleset that no longer exempts the app, and a network failure are
+          # different problems, and a message that names only the first one
+          # sends the operator through a whole rebuild for nothing.
+          PUSH_ERROR=$(mktemp)
+          if GIT_ASKPASS="${ASKPASS}" git push \
+            "https://github.com/${GITHUB_REPOSITORY}.git" \
+            HEAD:refs/heads/main 2>"${PUSH_ERROR}"; then
+            exit 0
           fi
+          cat "${PUSH_ERROR}"
+          if grep -qiE 'non-fast-forward|fetch first|behind its remote' "${PUSH_ERROR}"; then
+            echo "::error::main moved since this release was dispatched, so the bump cannot land on it. Dispatch the release again."
+          else
+            echo "::error::The push to main failed: $(tr '\n' ' ' < "${PUSH_ERROR}")"
+          fi
+          exit 1
 
   # The branch must not outlive the run, so this job runs after success, after
   # failure and after a cancel. It needs no ordering against the jobs that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,8 @@ jobs:
         run: |
           current_version=$(jq -r .version package.json)
           version_line=$(grep -n '"version"' package.json | cut -d: -f1)
-          echo "VERSION=${current_version}" >> ${GITHUB_ENV}
-          echo "version=${current_version}" >> ${GITHUB_OUTPUT}
+          echo "VERSION=${current_version}" >> "${GITHUB_ENV}"
+          echo "version=${current_version}" >> "${GITHUB_OUTPUT}"
           echo "::notice file=package.json,line=${version_line}::${current_version}"
 
           # Read from the tree that is checked out, and not by repeating the
@@ -323,7 +323,7 @@ jobs:
             /^## / && flag {flag=0}
             flag
           ' CHANGELOG.md >"CHANGELOG-${VERSION}.md"
-          echo "CHANGELOG=CHANGELOG-${VERSION}.md" >> ${GITHUB_ENV}
+          echo "CHANGELOG=CHANGELOG-${VERSION}.md" >> "${GITHUB_ENV}"
 
       - name: Append installation instructions to changelog
         env:
@@ -333,6 +333,9 @@ jobs:
           DOCS_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
         shell: bash
         run: |
+          # The single quotes are the point. `envsubst` reads the list of
+          # names to expand, and the shell must not expand them first.
+          # shellcheck disable=SC2016
           envsubst '${WIZARD_VERSION} ${REPO} ${DOCS_URL}' \
             < .github/workflows/assets/install-instructions.md \
             >> "${CHANGELOG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,50 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # The branch must not outlive the run. This job runs after success, after
+  # failure and after a cancel, and it sits after `package` so the branch is
+  # gone before the publish jobs start. The commit is on `main` by then, or
+  # the release is over and the next bump starts from scratch.
+  cleanup:
+    runs-on: ubuntu-latest
+
+    needs: [bump, verify, package]
+
+    if: always()
+
+    permissions: {}
+
+    env:
+      BRANCH: ci/bump-version
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+
+      # A branch that is already absent is the wanted state and not an error.
+      # A release with nothing to bump never creates it, and a run that failed
+      # in `bump` may have ended before the push.
+      - name: Delete the temporary branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          DELETE_ERROR=$(mktemp)
+          if gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${BRANCH}" 2>"${DELETE_ERROR}"; then
+            echo "Deleted ${BRANCH}."
+          elif grep -qiF 'reference does not exist' "${DELETE_ERROR}"; then
+            echo "${BRANCH} was already absent."
+          else
+            echo "::error::Could not delete ${BRANCH}: $(tr '\n' ' ' < "${DELETE_ERROR}")"
+            exit 1
+          fi
+
   release-github:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,38 @@ jobs:
         id: check_unreleased
         shell: bash
         run: |
+          set -euo pipefail
           if grep -q "^## Unreleased$" CHANGELOG.md; then
             echo "UNRELEASED_FOUND=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "UNRELEASED_FOUND=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "UNRELEASED_FOUND=false" >> "${GITHUB_OUTPUT}"
+
+          # Absent means one of two things, and only one of them is wanted.
+          # A release that recovers a failed publish has no heading, and a
+          # heading written in another shape has none either. The second case
+          # would otherwise repackage the version that is already released,
+          # find every registry satisfied, and end green having released
+          # nothing. The log names both readings, and shows any near miss.
+          echo "::notice::No '## Unreleased' heading, so this run republishes the current version. A bump was expected if that is not what you asked for."
+          grep -niF "unreleased" CHANGELOG.md || true
+
+      # The heading is absent, so this run republishes what is already on
+      # `main`. That is only correct while `main` is still the commit the
+      # failed release built. A commit landing after it would be packaged
+      # under the version of the release that is being recovered, and tagged
+      # with it, although no run ever built that pair.
+      - name: Check the recovery runs on the bump commit
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'false' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The prefix, because a bump that a pull request squashed onto
+          # `main` before this workflow changed carries a number after it.
+          SUBJECT=$(git log -1 --format=%s)
+          if [ "${SUBJECT#"${COMMIT}"}" = "${SUBJECT}" ]; then
+            echo "::error::main has moved past the bump commit, so this release cannot be recovered by republishing its tip. The tip is: ${SUBJECT}. Add an Unreleased section and release the next version instead."
+            exit 1
           fi
 
       # Quarto renders the documentation, and Node runs the bump itself. A
@@ -154,6 +182,14 @@ jobs:
           if [ "${DATE}" = "today" ]; then
             DATE=$(date +%Y-%m-%d)
           fi
+          # The input is free text. It reaches a `sed` expression that uses
+          # `/` as its delimiter, and the changelog heading, so a value such
+          # as `2026/09/11` ends the step with an error that names nothing
+          # the operator typed.
+          if ! [[ "${DATE}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "::error::The date input must be \"today\" or YYYY-MM-DD. Read: ${DATE}"
+            exit 1
+          fi
 
           npm version "${BUMP_VERSION}" --no-git-tag-version
           npm run sync-metadata
@@ -191,22 +227,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # `git` reads the token through `GIT_ASKPASS` and not from the
-          # command line. A command line is readable from `/proc`, and the
-          # steps above have run the lifecycle scripts of every dependency,
-          # any of which can leave a process behind to read it.
-          ASKPASS="${RUNNER_TEMP}/askpass.sh"
-          cat > "${ASKPASS}" <<'ASKPASS_SCRIPT'
-          #!/bin/sh
-          case "$1" in
-            Username*) echo "x-access-token" ;;
-            *) echo "${GH_TOKEN}" ;;
-          esac
-          ASKPASS_SCRIPT
-          chmod 700 "${ASKPASS}"
-          trap 'rm -f "${ASKPASS}"' EXIT
-
-          GIT_ASKPASS="${ASKPASS}" git push --force \
+          GIT_ASKPASS=.github/workflows/assets/askpass.sh git push --force \
             "https://github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:refs/heads/${BRANCH}"
 
@@ -214,10 +235,11 @@ jobs:
   # This is the gate that the bump pull request used to be. A called workflow
   # runs inside this run, so `verdict.yml` never fires for it.
   #
-  # A release with nothing to bump publishes a commit that is already on
-  # `main`, which reached `main` through a pull request and carries a green
-  # `verdict` for that reason. Building it again costs a three operating
-  # system matrix and answers a question that is already answered.
+  # A release with nothing to bump republishes a commit that is already on
+  # `main`. The bump job proves that commit is the bump of the release being
+  # recovered, and the run that created it only reached `main` by passing
+  # this same matrix. Building it again answers a question already answered,
+  # at the price of three operating systems.
   verify:
     needs: bump
     if: needs.bump.outputs.bumped == 'true'
@@ -409,28 +431,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # `git` reads the token through `GIT_ASKPASS` and not from the
-          # command line. A command line is readable from `/proc`, and the
-          # steps above have run the lifecycle scripts of every dependency,
-          # any of which can leave a process behind to read it.
-          ASKPASS="${RUNNER_TEMP}/askpass.sh"
-          cat > "${ASKPASS}" <<'ASKPASS_SCRIPT'
-          #!/bin/sh
-          case "$1" in
-            Username*) echo "x-access-token" ;;
-            *) echo "${GH_TOKEN}" ;;
-          esac
-          ASKPASS_SCRIPT
-          chmod 700 "${ASKPASS}"
-          trap 'rm -f "${ASKPASS}"' EXIT
-
           # The error names what git reported. A refused fast-forward means
           # `main` moved, and a re-dispatch is the answer. A revoked token, a
           # ruleset that no longer exempts the app, and a network failure are
           # different problems, and a message that names only the first one
           # sends the operator through a whole rebuild for nothing.
           PUSH_ERROR=$(mktemp)
-          if GIT_ASKPASS="${ASKPASS}" git push \
+          if GIT_ASKPASS=.github/workflows/assets/askpass.sh git push \
             "https://github.com/${GITHUB_REPOSITORY}.git" \
             HEAD:refs/heads/main 2>"${PUSH_ERROR}"; then
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ on:
         description: "Version"
         default: "minor"
 
+# The job that creates this branch and the job that deletes it must name the
+# same ref, so the name is written once here.
+env:
+  BRANCH: ci/bump-version
+
 jobs:
   bump:
     runs-on: ubuntu-latest
@@ -36,13 +41,15 @@ jobs:
       contents: read
 
     env:
-      BRANCH: ci/bump-version
       COMMIT: "ci: bump version for release :rocket:"
       BUMP_VERSION: ${{ inputs.version }}
 
     outputs:
-      sha: ${{ steps.result.outputs.sha }}
-      bumped: ${{ steps.result.outputs.bumped }}
+      # A skipped step reports an empty output, so a release with nothing to
+      # bump falls through to the commit the dispatch resolved. That is how a
+      # release whose publish failed is dispatched a second time.
+      sha: ${{ steps.bump.outputs.sha || github.sha }}
+      bumped: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND }}
 
     steps:
       # The bump lands on `main` by a fast-forward push in the package job. A
@@ -71,11 +78,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
-
-      - name: Set up Quarto CLI
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: pre-release
 
       - name: Get GitHub App User ID
         id: get-user-id
@@ -109,6 +111,15 @@ jobs:
           else
             echo "UNRELEASED_FOUND=false" >> "${GITHUB_OUTPUT}"
           fi
+
+      # Quarto renders the documentation, and Node runs the bump itself. A
+      # release with nothing to bump does neither, so both sit behind the
+      # check above rather than in front of it.
+      - name: Set up Quarto CLI
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: pre-release
 
       - name: Set up Node.js
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
@@ -151,25 +162,6 @@ jobs:
           # branch behind, and this run must not stop on that.
           git push --force origin "HEAD:refs/heads/${BRANCH}"
           echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-
-      # The commit the rest of the release works on. A release with nothing to
-      # bump takes the commit the dispatch resolved, which is how a release
-      # whose publish failed is dispatched a second time.
-      - name: Report the commit to release
-        id: result
-        env:
-          BUMPED: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND }}
-          BUMP_SHA: ${{ steps.bump.outputs.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${BUMPED}" = "true" ]; then
-            echo "sha=${BUMP_SHA}" >> "${GITHUB_OUTPUT}"
-            echo "bumped=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "sha=${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
-            echo "bumped=false" >> "${GITHUB_OUTPUT}"
-          fi
 
   # The full matrix and the Lua job, on the exact tree the release publishes.
   # This is the gate that the bump pull request used to be. A called workflow
@@ -215,21 +207,6 @@ jobs:
         with:
           ref: ${{ needs.bump.outputs.sha }}
           token: ${{ steps.app-token.outputs.token }}
-
-      # A fast-forward, so the commit on `main` is the commit the matrix built
-      # and the `non_fast_forward` rule is never in question. The app is exempt
-      # from the ruleset, which is what lets this push skip the pull request
-      # and the required check. A push that is refused means `main` moved
-      # since the dispatch, and the bump then belongs on the new tip.
-      - name: Land the bump on main
-        if: ${{ needs.bump.outputs.bumped == 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! git push origin HEAD:refs/heads/main; then
-            echo "::error::main moved since this release was dispatched, so the bump cannot land on it. Dispatch the release again."
-            exit 1
-          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -340,21 +317,43 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  # The branch must not outlive the run. This job runs after success, after
-  # failure and after a cancel, and it sits after `package` so the branch is
-  # gone before the publish jobs start. The commit is on `main` by then, or
-  # the release is over and the next bump starts from scratch.
+      # Last, and not first. `main` carrying a released version number with no
+      # release is the state this job can leave behind, so the window where it
+      # holds is the few seconds after this step rather than the length of the
+      # build above.
+      #
+      # A fast-forward, so the commit on `main` is the commit the matrix built
+      # and the `non_fast_forward` rule is never in question. The app is exempt
+      # from the ruleset, which is what lets this push skip the pull request
+      # and the required check. A push that is refused means `main` moved since
+      # the dispatch, and the bump then belongs on the new tip.
+      - name: Land the bump on main
+        if: ${{ needs.bump.outputs.bumped == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git push origin HEAD:refs/heads/main; then
+            echo "::error::main moved since this release was dispatched, so the bump cannot land on it. Dispatch the release again."
+            exit 1
+          fi
+
+  # The branch must not outlive the run, so this job runs after success, after
+  # failure and after a cancel. It needs no ordering against the jobs that
+  # publish: they read the release bundle and the tag, and neither reads this
+  # branch. The commit is on `main` by now, or the release is over and the next
+  # bump starts from scratch.
   cleanup:
     runs-on: ubuntu-latest
 
-    needs: [bump, verify, package]
+    # `package` already waits for `bump` and `verify`, so this one edge gives
+    # the same ordering.
+    needs: package
 
     if: always()
 
     permissions: {}
 
     env:
-      BRANCH: ci/bump-version
       GH_REPO: ${{ github.repository }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,14 @@ jobs:
   # The full matrix and the Lua job, on the exact tree the release publishes.
   # This is the gate that the bump pull request used to be. A called workflow
   # runs inside this run, so `verdict.yml` never fires for it.
+  #
+  # A release with nothing to bump publishes a commit that is already on
+  # `main`, which reached `main` through a pull request and carries a green
+  # `verdict` for that reason. Building it again costs a three operating
+  # system matrix and answers a question that is already answered.
   verify:
     needs: bump
+    if: needs.bump.outputs.bumped == 'true'
     permissions: read-all
     uses: ./.github/workflows/build.yml
     with:
@@ -177,6 +183,16 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [bump, verify]
+
+    # A skipped `verify` is the release that had nothing to bump, and it must
+    # reach the publish jobs, because that is how a release recovers from a
+    # publish that failed. A `verify` that ran and did not pass must not.
+    # `always()` is what lets this job read a skipped result at all.
+    if: >-
+      always()
+      && needs.bump.result == 'success'
+      && needs.verify.result != 'failure'
+      && needs.verify.result != 'cancelled'
 
     # `GITHUB_TOKEN` writes nothing here. The push to `main` carries the app
     # token, and the attestation needs the two write scopes below.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,16 @@ jobs:
           client-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_KEY }}
 
-      # The checkout keeps this token, so the push below runs as the app. The
-      # app is exempt from the ruleset, which is what lets the bump land on
-      # `main` without a pull request.
+      # `persist-credentials: false`, so no token is written to `.git/config`.
+      # This job runs `npm ci` and `npm run docs:build`, which run the
+      # lifecycle scripts of every dependency. A stored token is readable by
+      # all of them, and this one is exempt from the ruleset, so it can push
+      # to `main` unreviewed. The step that pushes takes the token in its own
+      # environment instead.
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Get GitHub App User ID
         id: get-user-id
@@ -125,12 +128,19 @@ jobs:
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         uses: actions/setup-node@v7
 
+      # `npm ci` and not `npm install`, so this job, the matrix that gates the
+      # release and the job that packages it all resolve the same dependency
+      # tree. `npm version` below updates the version in the lock file, which
+      # is the only change this job makes to it.
       - name: Install dependencies
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         shell: bash
-        run: npm install
+        run: npm ci
 
-      - name: Bump the version and push it to the temporary branch
+      # No token in this step. It runs the lifecycle scripts of every
+      # dependency through `npm`, and the push that follows holds the token
+      # for its own step alone.
+      - name: Bump the version and commit it
         id: bump
         if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
         env:
@@ -154,14 +164,26 @@ jobs:
 
           git add CHANGELOG.md CITATION.cff package.json package-lock.json packages/*/package.json docs/
           git commit -m "${COMMIT}"
-
-          # No pull request. The commit goes to a branch of its own, the
-          # verify job builds it there, and the package job fast-forwards
-          # `main` to it once the matrix has passed. `--force`, because a run
-          # that ended before the cleanup job, or a lost runner, can leave the
-          # branch behind, and this run must not stop on that.
-          git push --force origin "HEAD:refs/heads/${BRANCH}"
           echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      # No pull request. The commit goes to a branch of its own, the verify
+      # job builds it there, and the package job fast-forwards `main` to it
+      # once the matrix has passed.
+      #
+      # The remote is named in full, because the checkout stored no
+      # credentials. `--force`, because a run that ended before the cleanup
+      # job, or a lost runner, can leave the branch behind, and this run must
+      # not stop on that.
+      - name: Push the bump to the temporary branch
+        if: ${{ steps.check_unreleased.outputs.UNRELEASED_FOUND == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${BRANCH}"
 
   # The full matrix and the Lua job, on the exact tree the release publishes.
   # This is the gate that the bump pull request used to be. A called workflow
@@ -218,18 +240,25 @@ jobs:
       # The commit the matrix built, not the tip of the default branch. Any
       # commit landing on `main` between the dispatch and this checkout would
       # otherwise be the one that gets packaged and published.
+      #
+      # `persist-credentials: false`, so no token is written to `.git/config`.
+      # This job runs `npm ci`, `vsce package` and `npm pack`, which run the
+      # lifecycle scripts of every dependency. The step that pushes to `main`
+      # takes the token in its own environment instead.
       - name: Checkout the commit the matrix built
         uses: actions/checkout@v7
         with:
           ref: ${{ needs.bump.outputs.sha }}
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
 
+      # `npm ci` and not `npm install`, so the artefacts this job publishes
+      # come from the dependency tree the matrix tested.
       - name: Install dependencies
         shell: bash
-        run: npm install
+        run: npm ci
 
       - name: Set version
         id: set-version
@@ -333,22 +362,31 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-      # Last, and not first. `main` carrying a released version number with no
-      # release is the state this job can leave behind, so the window where it
-      # holds is the few seconds after this step rather than the length of the
-      # build above.
+      # Last, and not first. From this push until `release-github` creates the
+      # release, `main` carries a released version number that has no release.
+      # Running it here keeps that window to the length of `release-github`,
+      # rather than adding the whole build above to it. A release that fails
+      # inside that window is recovered by dispatching it again, which finds
+      # no `Unreleased`, skips the bump and publishes the tip of `main`.
       #
       # A fast-forward, so the commit on `main` is the commit the matrix built
       # and the `non_fast_forward` rule is never in question. The app is exempt
       # from the ruleset, which is what lets this push skip the pull request
       # and the required check. A push that is refused means `main` moved since
       # the dispatch, and the bump then belongs on the new tip.
+      #
+      # The remote is named in full, because the checkout stored no
+      # credentials.
       - name: Land the bump on main
         if: ${{ needs.bump.outputs.bumped == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
-          if ! git push origin HEAD:refs/heads/main; then
+          if ! git push \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            HEAD:refs/heads/main; then
             echo "::error::main moved since this release was dispatched, so the bump cannot land on it. Dispatch the release again."
             exit 1
           fi


### PR DESCRIPTION
The GitHub App that runs the release is exempt from the ruleset, so the version bump does not need a pull request to land on `main`. This removes the bump pull request and everything that existed to hold it open: the loop that waited for a required check to appear, the `gh pr checks --watch` gate, the second app token minted because the first expired during that wait, the merge through the API, and the reuse of an open pull request on a re-run.

The gate stays. The bump goes to `ci/bump-version`, `build.yml` runs on that exact commit as a reusable workflow, and `package` fast-forwards `main` to it once the matrix has passed. A `cleanup` job deletes the branch on every outcome, including a cancel.

- `build.yml` gains a `workflow_call` trigger with an optional `ref` input. Its two checkout steps pass that input, and the draft guards now state their rule instead of reading a null draft flag as false. Nothing else in it changes.
- The push to `main` is the last step of `package`, so a failure while the artefacts are built leaves `main` untouched.
- `verify` is skipped when there is nothing to bump, which is the dispatch that recovers a failed publish. The `bump` job first proves the tip of `main` is the bump commit, so that path cannot publish a commit no run built.
- Neither job stores a credential in `.git/config`, because both run dependency lifecycle scripts and the token is ruleset-exempt. Each push reads it through `.github/workflows/assets/askpass.sh`.
- `bump`, the matrix and `package` all install with `npm ci`, so the release publishes what the matrix tested.
- The changelog check and rewrite match the `## Unreleased` heading in full. Entries are written as full sentences, and the old substitution rewrote the first match on every line.
- The `date` input is validated before it reaches `sed`.

`verdict.yml` and the three publish jobs are untouched. The ruleset needs no change.

Verified locally with `actionlint` 1.7.12 on both workflow files and `shellcheck` on the new helper, plus `npm run lint:check`, `npm run format:check` and the test suite. The changelog rewrite, the recovery guard, the date check and the credential helper were each exercised directly. The pushes themselves can only run on a runner, so the next release exercises them.

After that release, `ci/bump-version` must be absent whatever the outcome, the tag must name the bump commit, and the tip of `main` must be that commit.
