### PR TITLE
fix: pin webpack so the production bundle loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- fix: Activate the extension again. Version 3.6.0 did not start, so no command worked and the extension found no project. (#457)
+
 ## 3.6.0 (2026-09-11)
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"typedoc-plugin-markdown": "^4.13.0",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.70.0",
-				"webpack": "^5.110.3",
+				"webpack": "5.109.2",
 				"webpack-cli": "^7.2.3"
 			},
 			"engines": {
@@ -9252,9 +9252,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.110.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
-			"integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
+			"version": "5.109.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+			"integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9268,10 +9268,11 @@
 				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^5.24.4",
 				"es-module-lexer": "^2.1.0",
+				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"graceful-fs": "^4.2.11",
 				"mime-db": "^1.54.0",
-				"minimizer-webpack-plugin": "^5.7.0",
+				"minimizer-webpack-plugin": "^5.6.1",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
@@ -9379,6 +9380,30 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webpack/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/webpack/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/webpack/node_modules/mime-db": {
@@ -9757,7 +9782,7 @@
 		},
 		"packages/core": {
 			"name": "@quarto-wizard/core",
-			"version": "3.5.0",
+			"version": "3.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"glob": "^13.0.6",
@@ -9792,7 +9817,7 @@
 		},
 		"packages/schema": {
 			"name": "@quarto-wizard/schema",
-			"version": "3.5.0",
+			"version": "3.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^5.4.1"
@@ -9808,7 +9833,7 @@
 		},
 		"packages/snippets": {
 			"name": "@quarto-wizard/snippets",
-			"version": "3.5.0",
+			"version": "3.6.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.5.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"build:schema": "npx tsc -p packages/schema && node packages/schema/scripts/copy-schemas.mjs",
 		"build:snippets": "npx tsc -p packages/snippets",
 		"build:core": "npx tsc -p packages/core",
-		"vscode:prepublish": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --mode production",
+		"vscode:prepublish": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --mode production && npm run check:bundle",
 		"webpack": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --mode development --stats-error-details",
 		"watch": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx webpack --watch --mode development --stats-error-details",
 		"test-compile": "npm run format && npm run build:schema && npm run build:snippets && npm run build:core && npx tsc -p ./",
@@ -75,6 +75,7 @@
 		"test": "vscode-test",
 		"test:watch": "npm run test-compile && vscode-test",
 		"test:manual": "node ./out/test/runTest.js",
+		"check:bundle": "node scripts/check-bundle.mjs",
 		"lint": "eslint --fix --cache --format unix \"src/**/*.{ts,tsx}\"",
 		"lint:check": "eslint --cache --format unix \"src/**/*.{ts,tsx}\"",
 		"format": "prettier --write \"src/**/*.{ts,tsx}\" \"packages/*/src/**/*.ts\" \"packages/*/tests/**/*.ts\"",
@@ -86,7 +87,7 @@
 		"docs:preview": "npm run docs:api && cd docs && quarto preview",
 		"docs:clean": "rm -rf docs/api docs/_site",
 		"docs:format": "prettier --write \"docs/**/*.{qmd,yml}\"",
-		"update:deps": "npx npm-check-updates -u --reject @types/vscode,typescript,mocha --workspaces --root && npm install"
+		"update:deps": "npx npm-check-updates -u --reject @types/vscode,typescript,mocha,webpack --workspaces --root && npm install"
 	},
 	"overrides": {
 		"diff": "^8.0.3",
@@ -120,7 +121,7 @@
 		"typedoc-plugin-markdown": "^4.13.0",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.70.0",
-		"webpack": "^5.110.3",
+		"webpack": "5.109.2",
 		"webpack-cli": "^7.2.3"
 	},
 	"capabilities": {

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -8,58 +8,59 @@
  * A fault that only the production build carries therefore reaches the
  * Marketplace while every check stays green.
  * Version 3.6.0 shipped that way.
- * The minifier joined three statements of a dependency into one call.
- * The bundle threw an error while it evaluated, so no command registered.
  *
  * The `vscode` module exists only inside the extension host.
  * A proxy stands in for it, and the proxy answers any property, call, or
  * construction.
  */
 
-import { createRequire } from "node:module";
+import Module, { createRequire } from "node:module";
 import { existsSync } from "node:fs";
-import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import Module from "node:module";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const bundlePath = join(__dirname, "..", "dist", "extension.js");
+const bundlePath = fileURLToPath(new URL("../dist/extension.js", import.meta.url));
 
-if (!existsSync(bundlePath)) {
-	console.error(`No bundle exists at ${bundlePath}.`);
-	console.error("Run `npx webpack --mode production`, then run this check again.");
+function fail(...lines) {
+	console.error(lines.join("\n"));
 	process.exit(1);
 }
 
+if (!existsSync(bundlePath)) {
+	fail(`No bundle exists at ${bundlePath}.`, "Run `npx webpack --mode production`, then run this check again.");
+}
+
 const stubHandler = {
-	get: (_target, property) => (property === "then" ? undefined : stub()),
-	apply: () => stub(),
-	construct: () => stub(),
+	// A stub that answers `then` looks like a promise, and an `await` on it never settles.
+	get: (_target, property) => (property === "then" ? undefined : stub),
+	apply: () => stub,
+	construct: () => stub,
 };
 
-function stub() {
-	return new Proxy(function () {}, stubHandler);
-}
+const stub = new Proxy(function () {}, stubHandler);
 
 const load = Module._load;
 Module._load = function (request, parent, isMain) {
-	return request === "vscode" ? stub() : load.call(this, request, parent, isMain);
+	return request === "vscode" ? stub : load.call(this, request, parent, isMain);
 };
 
 let bundle;
 try {
 	bundle = createRequire(import.meta.url)(bundlePath);
 } catch (error) {
-	console.error(`The production bundle threw an error while it loaded: ${error.message}`);
-	console.error(error.stack);
-	console.error("The bundle is broken and the extension cannot activate. Do not publish it.");
-	process.exit(1);
+	fail(
+		`The production bundle threw an error while it loaded: ${error.message}`,
+		error.stack,
+		"The bundle is broken and the extension cannot activate. Do not publish it.",
+	);
 }
 
-if (typeof bundle.activate !== "function") {
-	console.error("The production bundle loaded, but it exports no `activate` function.");
-	console.error("The extension cannot activate. Do not publish it.");
-	process.exit(1);
+for (const name of ["activate", "deactivate"]) {
+	if (typeof bundle[name] !== "function") {
+		fail(`The production bundle loaded, but it exports no \`${name}\` function.`, "Do not publish it.");
+	}
 }
 
-console.log("The production bundle loads and exports `activate`.");
+console.log("The production bundle loads and exports `activate` and `deactivate`.");
+
+// The bundle can register a handle as it loads, and an open handle would hold the job open.
+process.exit(0);

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Loads the production bundle and makes sure that it exports `activate`.
+ *
+ * The production bundle is the artefact that ships, and nothing else loads it.
+ * `vscode-test` runs the TypeScript output in `out/`.
+ * The Extension Development Host runs the development bundle.
+ * A fault that only the production build carries therefore reaches the
+ * Marketplace while every check stays green.
+ * Version 3.6.0 shipped that way.
+ * The minifier joined three statements of a dependency into one call.
+ * The bundle threw an error while it evaluated, so no command registered.
+ *
+ * The `vscode` module exists only inside the extension host.
+ * A proxy stands in for it, and the proxy answers any property, call, or
+ * construction.
+ */
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import Module from "node:module";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bundlePath = join(__dirname, "..", "dist", "extension.js");
+
+if (!existsSync(bundlePath)) {
+	console.error(`No bundle exists at ${bundlePath}.`);
+	console.error("Run `npx webpack --mode production`, then run this check again.");
+	process.exit(1);
+}
+
+const stubHandler = {
+	get: (_target, property) => (property === "then" ? undefined : stub()),
+	apply: () => stub(),
+	construct: () => stub(),
+};
+
+function stub() {
+	return new Proxy(function () {}, stubHandler);
+}
+
+const load = Module._load;
+Module._load = function (request, parent, isMain) {
+	return request === "vscode" ? stub() : load.call(this, request, parent, isMain);
+};
+
+let bundle;
+try {
+	bundle = createRequire(import.meta.url)(bundlePath);
+} catch (error) {
+	console.error(`The production bundle threw an error while it loaded: ${error.message}`);
+	console.error(error.stack);
+	console.error("The bundle is broken and the extension cannot activate. Do not publish it.");
+	process.exit(1);
+}
+
+if (typeof bundle.activate !== "function") {
+	console.error("The production bundle loaded, but it exports no `activate` function.");
+	console.error("The extension cannot activate. Do not publish it.");
+	process.exit(1);
+}
+
+console.log("The production bundle loads and exports `activate`.");


### PR DESCRIPTION
Version 3.6.0 shipped a production bundle that could not load, so the extension never activated.
No command worked, and no project was found.

`webpack` 5.110 removes unused CommonJS exports in production mode.
It applies this to `undici/index.js`, drops the three `module.exports.X =` assignment targets, and joins the expressions that are left into one call.
The call reaches `WebSocket.ping`, which reads a private field from a module object and throws a `TypeError` while the bundle evaluates.

Bisection puts the change in 5.110.0.
The production bundle loads on 5.109.2, and it throws on 5.110.0 and on 5.110.3.
The development bundle is correct at every version, which is why the Extension Development Host never showed the fault.

This pins `webpack` to 5.109.2 with no range, and adds it to the reject list of `update:deps`.

`scripts/check-bundle.mjs` loads the production bundle with a stub for `vscode`, and makes sure that it exports `activate` and `deactivate`.
`vscode:prepublish` runs the check, so `vsce package` and `vsce publish` both stop when the bundle cannot load.
Nothing else in the repository loads that bundle.
The test suite runs the TypeScript output in `out/`, so every check stayed green while 3.6.0 shipped.

Closes #457
